### PR TITLE
Use new tor circuit for each nostr event

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/AppServices.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppServices.java
@@ -516,6 +516,12 @@ public class AppServices {
         return Tor.getDefault() != null;
     }
 
+    public void startTor() {
+        if (!isTorRunning() && torService != null && !torService.isRunning()) {
+            torService.start();
+        }
+    }
+
     public static boolean isUsingProxy() {
         return isTorRunning() || Config.get().isUseProxy();
     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -110,6 +110,7 @@ public class CoinjoinHandler {
                 if (AppServices.isTorRunning()) {
                     Client.getInstance().disconnect();
                     TorUtils.changeIdentity(AppServices.getTorProxy());
+                    TorUtils.logTorIp();
                 }
 
                 JoinstrMessage message = new JoinstrMessage();
@@ -443,6 +444,7 @@ public class CoinjoinHandler {
             if (AppServices.isTorRunning()) {
                 Client.getInstance().disconnect();
                 TorUtils.changeIdentity(AppServices.getTorProxy());
+                TorUtils.logTorIp();
             }
 
             JoinstrMessage message = new JoinstrMessage();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -19,11 +19,14 @@ import com.sparrowwallet.sparrow.net.ElectrumServer;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import nostr.api.NIP04;
+import nostr.client.Client;
+import nostr.context.impl.DefaultRequestContext;
 import nostr.event.BaseTag;
 import nostr.event.Kind;
 import nostr.event.impl.GenericEvent;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
+import com.sparrowwallet.sparrow.net.TorUtils;
 import org.bouncycastle.util.encoders.Base64;
 
 import java.math.BigDecimal;
@@ -104,6 +107,11 @@ public class CoinjoinHandler {
     private void sendOutputToPool(String address) {
         executorService.submit(() -> {
             try {
+                if (AppServices.isTorRunning()) {
+                    Client.getInstance().disconnect();
+                    TorUtils.changeIdentity(AppServices.getTorProxy());
+                }
+
                 JoinstrMessage message = new JoinstrMessage();
                 message.setType("output");
                 message.setAddress(address);
@@ -123,6 +131,14 @@ public class CoinjoinHandler {
 
                 nip04.setEvent(outputEvent);
                 nip04.sign();
+
+                if (AppServices.isTorRunning()) {
+                    DefaultRequestContext context = new DefaultRequestContext();
+                    context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
+                    context.setRelays(Map.of("default", relay));
+                    Client.getInstance().connect(context);
+                }
+
                 nip04.send(Map.of("default", relay));
 
                 logger.info("Output registered: " + address);
@@ -424,6 +440,11 @@ public class CoinjoinHandler {
 
     private void sendInputToPool(String psbtBase64) {
         try {
+            if (AppServices.isTorRunning()) {
+                Client.getInstance().disconnect();
+                TorUtils.changeIdentity(AppServices.getTorProxy());
+            }
+
             JoinstrMessage message = new JoinstrMessage();
             message.setType("input");
             message.setPsbt(psbtBase64);
@@ -443,6 +464,14 @@ public class CoinjoinHandler {
 
             nip04.setEvent(inputEvent);
             nip04.sign();
+
+            if (AppServices.isTorRunning()) {
+                DefaultRequestContext context = new DefaultRequestContext();
+                context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
+                context.setRelays(Map.of("default", relay));
+                Client.getInstance().connect(context);
+            }
+
             nip04.send(Map.of("default", relay));
 
             logger.info("Signed input sent to pool");
@@ -460,7 +489,7 @@ public class CoinjoinHandler {
                 PSBT psbt = new PSBT(Base64.decode(psbtBase64), false);
 
                 for (PSBTInput input : psbt.getPsbtInputs()) {
-                    String outpoint = input.getOutpoint().toString();
+                    String outpoint = input.getInput().getOutpoint().toString();
                     if (allInputs.contains(outpoint)) {
                         logger.warning("Rejecting duplicate input: " + outpoint);
                         return;
@@ -494,7 +523,7 @@ public class CoinjoinHandler {
 
                 inputPSBTs.add(psbtBase64);
                 for (PSBTInput input : psbt.getPsbtInputs()) {
-                    allInputs.add(input.getOutpoint().toString());
+                    allInputs.add(input.getInput().getOutpoint().toString());
                 }
 
                 logger.info("Received valid input " + inputPSBTs.size() + "/" + numPeers);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -108,10 +108,14 @@ public class CoinjoinHandler {
         executorService.submit(() -> {
             try {
                 if (AppServices.isTorRunning()) {
-                    Client.getInstance().disconnect();
+                    try {
+                        Client.getInstance().disconnect();
+                    } catch (Exception e) {
+                        // Not yet connected, safe to ignore
+                    }
                     TorUtils.changeIdentity(AppServices.getTorProxy());
-                    TorUtils.logTorIp();
                 }
+                    TorUtils.logTorIp();
 
                 JoinstrMessage message = new JoinstrMessage();
                 message.setType("output");
@@ -442,10 +446,14 @@ public class CoinjoinHandler {
     private void sendInputToPool(String psbtBase64) {
         try {
             if (AppServices.isTorRunning()) {
-                Client.getInstance().disconnect();
+                try {
+                    Client.getInstance().disconnect();
+                } catch (Exception e) {
+                    // Not yet connected, safe to ignore
+                }
                 TorUtils.changeIdentity(AppServices.getTorProxy());
-                TorUtils.logTorIp();
             }
+                TorUtils.logTorIp();
 
             JoinstrMessage message = new JoinstrMessage();
             message.setType("input");

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
@@ -61,6 +61,9 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
     public JoinstrController() { }
 
     public void initializeView() {
+        // Ensure Tor is running for Joinstr circuit isolation
+        AppServices.get().startTor();
+
         joinstrMenu.selectedToggleProperty().addListener((observable, oldValue, selectedToggle) -> {
             if(selectedToggle == null) {
                 if(oldValue != null)

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
@@ -2,6 +2,8 @@ package com.sparrowwallet.sparrow.joinstr;
 import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.Theme;
 import com.sparrowwallet.sparrow.io.Config;
+import com.google.common.net.HostAndPort;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
@@ -25,6 +27,7 @@ import javafx.stage.Stage;
 public class JoinstrController extends JoinstrFormController implements IThreadExecutor {
 
     private static final Logger logger = Logger.getLogger(JoinstrController.class.getName());
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(JoinstrController.class);
 
     private Stage stage;
 
@@ -63,6 +66,8 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
     public void initializeView() {
         // Ensure Tor is running for Joinstr circuit isolation
         AppServices.get().startTor();
+        // Route nostr-java WebSocket connections through Tor SOCKS proxy
+        applyTorSocksProxy();
 
         joinstrMenu.selectedToggleProperty().addListener((observable, oldValue, selectedToggle) -> {
             if(selectedToggle == null) {
@@ -183,6 +188,36 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
         this.stage = stage;
     }
 
+    /**
+     * Sets JVM-wide SOCKS proxy properties so nostr-java WebSocket connections
+     * are routed through Tor. Polls until Tor is ready (up to 90s).
+     */
+    private void applyTorSocksProxy() {
+        Thread t = new Thread(() -> {
+            try {
+                int waited = 0;
+                while (!AppServices.isTorRunning() && waited < 90) {
+                    Thread.sleep(2000);
+                    waited += 2;
+                }
+                if (AppServices.isTorRunning()) {
+                    HostAndPort proxy = AppServices.getTorProxy();
+                    System.setProperty("socksProxyHost", proxy.getHost());
+                    System.setProperty("socksProxyPort", String.valueOf(proxy.getPort()));
+                    log.info("[Joinstr] Nostr connections routed through Tor SOCKS proxy {}:{}",
+                            proxy.getHost(), proxy.getPort());
+                } else {
+                    log.warn("[Joinstr] Tor not ready after 90s — nostr connections may not be over Tor");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        t.setDaemon(true);
+        t.setName("TorProxyApplier");
+        t.start();
+    }
+
     @Override
     public void close() {
         try {
@@ -191,6 +226,10 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
                 formController.close();
             }
             controllerCache.clear();
+
+            // Clear the JVM SOCKS proxy so normal Sparrow traffic is unaffected
+            System.clearProperty("socksProxyHost");
+            System.clearProperty("socksProxyPort");
 
             shutdownThreads();
             stage.close();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -151,6 +151,7 @@ public class NostrListener implements AutoCloseable {
             if (AppServices.isTorRunning()) {
                 Client.getInstance().disconnect();
                 TorUtils.changeIdentity(AppServices.getTorProxy());
+                TorUtils.logTorIp();
             }
 
             credentialsMap.put("relay", poolCredentials.get("relay"));
@@ -189,6 +190,7 @@ public class NostrListener implements AutoCloseable {
             if (AppServices.isTorRunning()) {
                 Client.getInstance().disconnect();
                 TorUtils.changeIdentity(AppServices.getTorProxy());
+                TorUtils.logTorIp();
             }
 
             client = Client.getInstance();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -14,6 +14,8 @@ import nostr.event.impl.GenericEvent;
 import nostr.event.message.ReqMessage;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.net.TorUtils;
 
 import java.util.*;
 import java.util.concurrent.TimeoutException;
@@ -145,6 +147,12 @@ public class NostrListener implements AutoCloseable {
             credentialsMap.put("denomination", poolCredentials.get("denomination"));
             credentialsMap.put("peers", poolCredentials.get("peers"));
             credentialsMap.put("timeout", poolCredentials.get("timeout"));
+
+            if (AppServices.isTorRunning()) {
+                Client.getInstance().disconnect();
+                TorUtils.changeIdentity(AppServices.getTorProxy());
+            }
+
             credentialsMap.put("relay", poolCredentials.get("relay"));
             credentialsMap.put("private_key", poolCredentials.get("private_key"));
             credentialsMap.put("fee_rate", poolCredentials.get("fee_rate"));
@@ -178,6 +186,11 @@ public class NostrListener implements AutoCloseable {
 
     private void connectAndSubscribe() {
         try {
+            if (AppServices.isTorRunning()) {
+                Client.getInstance().disconnect();
+                TorUtils.changeIdentity(AppServices.getTorProxy());
+            }
+
             client = Client.getInstance();
             DefaultRequestContext context = new DefaultRequestContext();
             context.setPrivateKey(identity.getPrivateKey().getRawData());

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -149,10 +149,14 @@ public class NostrListener implements AutoCloseable {
             credentialsMap.put("timeout", poolCredentials.get("timeout"));
 
             if (AppServices.isTorRunning()) {
-                Client.getInstance().disconnect();
+                try {
+                    Client.getInstance().disconnect();
+                } catch (Exception e) {
+                    // Not yet connected, safe to ignore
+                }
                 TorUtils.changeIdentity(AppServices.getTorProxy());
-                TorUtils.logTorIp();
             }
+                TorUtils.logTorIp();
 
             credentialsMap.put("relay", poolCredentials.get("relay"));
             credentialsMap.put("private_key", poolCredentials.get("private_key"));
@@ -188,10 +192,14 @@ public class NostrListener implements AutoCloseable {
     private void connectAndSubscribe() {
         try {
             if (AppServices.isTorRunning()) {
-                Client.getInstance().disconnect();
+                try {
+                    Client.getInstance().disconnect();
+                } catch (Exception e) {
+                    // Not yet connected, safe to ignore
+                }
                 TorUtils.changeIdentity(AppServices.getTorProxy());
-                TorUtils.logTorIp();
             }
+                TorUtils.logTorIp();
 
             client = Client.getInstance();
             DefaultRequestContext context = new DefaultRequestContext();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -60,6 +60,7 @@ public class NostrPublisher implements AutoCloseable {
             if (AppServices.isTorRunning()) {
                 Client.getInstance().disconnect();
                 TorUtils.changeIdentity(AppServices.getTorProxy());
+                TorUtils.logTorIp();
             }
 
             logger.info("Public key: " + SENDER.getPublicKey().toString());

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -58,10 +58,14 @@ public class NostrPublisher implements AutoCloseable {
         Identity poolIdentity;
         try {
             if (AppServices.isTorRunning()) {
-                Client.getInstance().disconnect();
+                try {
+                    Client.getInstance().disconnect();
+                } catch (Exception e) {
+                    // Not yet connected, safe to ignore
+                }
                 TorUtils.changeIdentity(AppServices.getTorProxy());
-                TorUtils.logTorIp();
             }
+                TorUtils.logTorIp();
 
             logger.info("Public key: " + SENDER.getPublicKey().toString());
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -14,6 +14,10 @@ import com.sparrowwallet.sparrow.wallet.WalletForm;
 import com.sparrowwallet.sparrow.io.Storage;
 import com.sparrowwallet.sparrow.wallet.NodeEntry;
 import com.sparrowwallet.sparrow.EventManager;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.net.TorUtils;
+import nostr.client.Client;
+import nostr.context.impl.DefaultRequestContext;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -52,8 +56,12 @@ public class NostrPublisher implements AutoCloseable {
         }
 
         Identity poolIdentity;
-
         try {
+            if (AppServices.isTorRunning()) {
+                Client.getInstance().disconnect();
+                TorUtils.changeIdentity(AppServices.getTorProxy());
+            }
+
             logger.info("Public key: " + SENDER.getPublicKey().toString());
 
             poolIdentity = Identity.generateRandomIdentity();
@@ -93,6 +101,13 @@ public class NostrPublisher implements AutoCloseable {
 
             nip01.setEvent(event);
             nip01.sign();
+
+            if (AppServices.isTorRunning()) {
+                DefaultRequestContext context = new DefaultRequestContext();
+                context.setPrivateKey(SENDER.getPrivateKey().getRawData());
+                context.setRelays(RELAYS);
+                Client.getInstance().connect(context);
+            }
 
             nip01.send(RELAYS);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -208,6 +208,7 @@ public class OtherPoolsController extends JoinstrFormController {
                     if (AppServices.isTorRunning()) {
                         Client.getInstance().disconnect();
                         TorUtils.changeIdentity(AppServices.getTorProxy());
+                        TorUtils.logTorIp();
                     }
 
                     client.connect(context);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -206,10 +206,14 @@ public class OtherPoolsController extends JoinstrFormController {
 
                 try {
                     if (AppServices.isTorRunning()) {
-                        Client.getInstance().disconnect();
+                        try {
+                            Client.getInstance().disconnect();
+                        } catch (Exception e) {
+                            // Not yet connected, safe to ignore
+                        }
                         TorUtils.changeIdentity(AppServices.getTorProxy());
-                        TorUtils.logTorIp();
                     }
+                        TorUtils.logTorIp();
 
                     client.connect(context);
                     client.send(reqMessage);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -3,6 +3,8 @@ package com.sparrowwallet.sparrow.joinstr;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparrowwallet.sparrow.io.Config;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.net.TorUtils;
 import com.sparrowwallet.sparrow.joinstr.control.JoinstrInfoPane;
 import com.sparrowwallet.sparrow.joinstr.control.JoinstrPoolList;
 import javafx.application.Platform;
@@ -203,6 +205,11 @@ public class OtherPoolsController extends JoinstrFormController {
                 context.setRelays(Map.of("default", DEFAULT_RELAY));
 
                 try {
+                    if (AppServices.isTorRunning()) {
+                        Client.getInstance().disconnect();
+                        TorUtils.changeIdentity(AppServices.getTorProxy());
+                    }
+
                     client.connect(context);
                     client.send(reqMessage);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -4,6 +4,10 @@ import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
 import com.sparrowwallet.sparrow.control.QRDisplayDialog;
 
 import javafx.beans.property.SimpleStringProperty;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.net.TorUtils;
+import nostr.client.Client;
+import nostr.context.impl.DefaultRequestContext;
 import nostr.event.Kind;
 import nostr.id.Identity;
 import nostr.event.BaseTag;
@@ -182,45 +186,69 @@ public class JoinstrPoolList extends VBox {
                             QRDisplayDialog qrDialog = new QRDisplayDialog(pubkey);
                             qrDialog.showAndWait();
 
-                            PublicKey poolPubKey = new PublicKey(pool.getPubkey());
-                            String requestContent = "{\"type\": \"join_pool\"}";
-                            List<BaseTag> tags = new ArrayList<>();
-                            tags.add(new PubKeyTag(poolPubKey)); // Send to pool creator's pubkey
-
-                            NIP04 nip04 = new NIP04(identity, poolPubKey); // Use pool's pubkey
-                            String encryptedContent = nip04.encrypt(identity, requestContent, poolPubKey);
-
-                            GenericEvent encrypted_event = new GenericEvent(
-                                    identity.getPublicKey(),
-                                    Kind.ENCRYPTED_DIRECT_MESSAGE.getValue(),
-                                    tags,
-                                    encryptedContent);
-
-                            nip04.setEvent(encrypted_event);
-                            nip04.sign();
-                            nip04.send(Map.of("default", pool.getRelay()));
-
-                            Logger.getLogger(JoinstrPoolList.class.getName())
-                                    .info("Join request sent. Event ID:: " + encrypted_event.getId());
-                            joinButton.setDisable(true);
-
-                            java.util.ArrayList<JoinstrPool> pools = com.sparrowwallet.sparrow.io.Config.get()
-                                    .getPoolStore();
-                            if (pools.stream().noneMatch(p -> p.getPubkey().equals(pool.getPubkey()))) {
-                                pools.add(pool);
-                                com.sparrowwallet.sparrow.io.Config.get().setPoolStore(pools);
+                            new Thread(() -> {
                                 try {
-                                    JoinstrPool.savePoolsFile(
-                                            com.sparrowwallet.sparrow.io.Storage.getJoinstrPoolsFile().getPath());
-                                } catch (Exception e) {
+                                    if(AppServices.isTorRunning()) {
+                                        Client.getInstance().disconnect();
+                                        TorUtils.changeIdentity(AppServices.getTorProxy());
+                                        TorUtils.logTorIp();
+                                    }
+
+                                    PublicKey poolPubKey = new PublicKey(pool.getPubkey());
+                                    String requestContent = "{\"type\": \"join_pool\"}";
+                                    List<BaseTag> tags = new ArrayList<>();
+                                    tags.add(new PubKeyTag(poolPubKey)); // Send to pool creator's pubkey
+
+                                    NIP04 nip04 = new NIP04(identity, poolPubKey); // Use pool's pubkey
+                                    String encryptedContent = nip04.encrypt(identity, requestContent, poolPubKey);
+
+                                    GenericEvent encrypted_event = new GenericEvent(
+                                            identity.getPublicKey(),
+                                            Kind.ENCRYPTED_DIRECT_MESSAGE.getValue(),
+                                            tags,
+                                            encryptedContent);
+
+                                    nip04.setEvent(encrypted_event);
+                                    nip04.sign();
+
+                                    if(AppServices.isTorRunning()) {
+                                        DefaultRequestContext context = new DefaultRequestContext();
+                                        context.setPrivateKey(identity.getPrivateKey().getRawData());
+                                        context.setRelays(Map.of("default", pool.getRelay()));
+                                        Client.getInstance().connect(context);
+                                    }
+
+                                    nip04.send(Map.of("default", pool.getRelay()));
+
+                                    Logger.getLogger(JoinstrPoolList.class.getName())
+                                            .info("Join request sent. Event ID:: " + encrypted_event.getId());
+
+                                    javafx.application.Platform.runLater(() -> {
+                                        joinButton.setDisable(true);
+
+                                        java.util.ArrayList<JoinstrPool> pools = com.sparrowwallet.sparrow.io.Config.get()
+                                                .getPoolStore();
+                                        if(pools.stream().noneMatch(p -> p.getPubkey().equals(pool.getPubkey()))) {
+                                            pools.add(pool);
+                                            com.sparrowwallet.sparrow.io.Config.get().setPoolStore(pools);
+                                            try {
+                                                JoinstrPool.savePoolsFile(
+                                                        com.sparrowwallet.sparrow.io.Storage.getJoinstrPoolsFile().getPath());
+                                            } catch(Exception e) {
+                                                // Ignore
+                                            }
+                                        }
+
+                                        if(onJoinCallback != null) {
+                                            onJoinCallback.run();
+                                        }
+
+                                        pool.startListeningForCredentials(identity);
+                                    });
+                                } catch(Exception e) {
+                                    Logger.getLogger(JoinstrPoolList.class.getName()).severe("Error joining pool: " + e.getMessage());
                                 }
-                            }
-
-                            if (onJoinCallback != null) {
-                                javafx.application.Platform.runLater(onJoinCallback);
-                            }
-
-                            pool.startListeningForCredentials(identity);
+                            }).start();
 
                         });
                     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -189,10 +189,14 @@ public class JoinstrPoolList extends VBox {
                             new Thread(() -> {
                                 try {
                                     if(AppServices.isTorRunning()) {
-                                        Client.getInstance().disconnect();
+                                        try {
+                                            Client.getInstance().disconnect();
+                                        } catch (Exception e) {
+                                            // Not yet connected, safe to ignore
+                                        }
                                         TorUtils.changeIdentity(AppServices.getTorProxy());
-                                        TorUtils.logTorIp();
                                     }
+                                        TorUtils.logTorIp();
 
                                     PublicKey poolPubKey = new PublicKey(pool.getPubkey());
                                     String requestContent = "{\"type\": \"join_pool\"}";

--- a/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/Tor.java
@@ -113,11 +113,19 @@ public class Tor implements Closeable {
 
     public void changeIdentity() {
         if(instance != null) {
+            java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
             instance.enqueue(TorCmd.Signal.NewNym.INSTANCE, throwable -> {
                 log.warn("Failed to signal newnym", throwable);
+                latch.countDown();
             }, _ -> {
                 log.info("Signalled newnym for new Tor circuit");
+                latch.countDown();
             });
+            try {
+                latch.await(3, java.util.concurrent.TimeUnit.SECONDS);
+            } catch(InterruptedException e) {
+                // Ignore
+            }
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
@@ -33,8 +33,9 @@ public class TorUtils {
                     Thread.sleep(3000);
                     HttpClientService httpClientService = AppServices.getHttpClientService();
                     Map<String, String> response = httpClientService.requestJson(CHECK_TOR_IP_URL, Map.class, null);
-                    if (response != null && response.containsKey("ip")) {
-                        julLog.info("Tor IP: " + response.get("ip"));
+                    String ip = response != null ? response.getOrDefault("IP", response.get("ip")) : null;
+                    if (ip != null) {
+                        julLog.info("Tor IP: " + ip);
                     } else {
                         julLog.warning("Tor IP check returned empty response");
                     }

--- a/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
@@ -81,6 +81,13 @@ public class TorUtils {
     private static void writeNewNym(Socket socket) throws IOException {
         log.debug("Sending NEWNYM to " + socket);
         socket.getOutputStream().write("SIGNAL NEWNYM\r\n".getBytes());
+        BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+        String line = reader.readLine();
+        if(line == null || !TOR_OK.matcher(line).matches()) {
+            log.warn("NEWNYM failed: " + line);
+        } else {
+            log.info("NEWNYM acknowledged by Tor control port");
+        }
     }
 
     private static class TorAuthenticationException extends Exception {

--- a/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
@@ -23,30 +23,49 @@ public class TorUtils {
             .compile("^2\\d{2}[ -]AUTH METHODS=(\\S+)\\s?(COOKIEFILE=\"?(.+?)\"?)?$");
     private static final String CHECK_TOR_IP_URL = "https://check.torproject.org/api/ip";
 
+    private static volatile long lastIpCheckMs = 0;
     private static final java.util.concurrent.atomic.AtomicInteger IP_CHECK_COUNTER = new java.util.concurrent.atomic.AtomicInteger(0);
 
     public static void logTorIp() {
-        if (AppServices.isTorRunning()) {
-            java.util.logging.Logger julLog = java.util.logging.Logger.getLogger("nostr.TorUtils");
-            Thread ipThread = new Thread(() -> {
-                try {
-                    Thread.sleep(3000);
-                    HttpClientService httpClientService = AppServices.getHttpClientService();
-                    Map<String, String> response = httpClientService.requestJson(CHECK_TOR_IP_URL, Map.class, null);
-                    String ip = response != null ? response.getOrDefault("IP", response.get("ip")) : null;
-                    if (ip != null) {
-                        julLog.info("Tor IP: " + ip);
-                    } else {
-                        julLog.warning("Tor IP check returned empty response");
-                    }
-                } catch (Exception e) {
-                    julLog.warning("Tor IP check failed: " + e.getMessage());
-                }
-            });
-            ipThread.setDaemon(true);
-            ipThread.setName("IPChecker-" + IP_CHECK_COUNTER.incrementAndGet());
-            ipThread.start();
+        long now = System.currentTimeMillis();
+        if (now - lastIpCheckMs < 30_000) {
+            return; // debounce: skip if checked within last 30s
         }
+        lastIpCheckMs = now;
+
+        log.info("[TorUtils] Tor circuit rotated, isTorRunning={}", AppServices.isTorRunning());
+        Thread ipThread = new Thread(() -> {
+            try {
+                // Wait up to 60s for Tor to finish bootstrapping
+                int waited = 0;
+                while (!AppServices.isTorRunning() && waited < 60) {
+                    Thread.sleep(2000);
+                    waited += 2;
+                }
+                if (!AppServices.isTorRunning()) {
+                    log.warn("[TorUtils] Tor not ready after 60s, IP check aborted");
+                    return;
+                }
+                Thread.sleep(5000);
+                HttpClientService httpClientService = AppServices.getHttpClientService();
+                if (httpClientService == null) {
+                    log.warn("[TorUtils] Tor IP check skipped: HTTP client not available");
+                    return;
+                }
+                Map<String, String> response = httpClientService.requestJson(CHECK_TOR_IP_URL, Map.class, null);
+                String ip = response != null ? response.getOrDefault("IP", response.get("ip")) : null;
+                if (ip != null) {
+                    log.info("[TorUtils] Tor exit IP: {}", ip);
+                } else {
+                    log.warn("[TorUtils] Tor IP check returned empty response");
+                }
+            } catch (Exception e) {
+                log.warn("[TorUtils] Tor IP check failed: {}", e.toString());
+            }
+        });
+        ipThread.setDaemon(true);
+        ipThread.setName("IPChecker-" + IP_CHECK_COUNTER.incrementAndGet());
+        ipThread.start();
     }
 
     public static void changeIdentity(HostAndPort proxy) {

--- a/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
@@ -26,17 +26,20 @@ public class TorUtils {
     private static final java.util.concurrent.atomic.AtomicInteger IP_CHECK_COUNTER = new java.util.concurrent.atomic.AtomicInteger(0);
 
     public static void logTorIp() {
-        if (AppServices.isTorRunning() && AppServices.isConnected()) {
+        if (AppServices.isTorRunning()) {
+            java.util.logging.Logger julLog = java.util.logging.Logger.getLogger("nostr.TorUtils");
             Thread ipThread = new Thread(() -> {
                 try {
                     Thread.sleep(3000);
                     HttpClientService httpClientService = AppServices.getHttpClientService();
                     Map<String, String> response = httpClientService.requestJson(CHECK_TOR_IP_URL, Map.class, null);
                     if (response != null && response.containsKey("ip")) {
-                        log.info("IP: " + response.get("ip"));
+                        julLog.info("Tor IP: " + response.get("ip"));
+                    } else {
+                        julLog.warning("Tor IP check returned empty response");
                     }
                 } catch (Exception e) {
-                    log.warn("Error checking IP: " + e.getMessage());
+                    julLog.warning("Tor IP check failed: " + e.getMessage());
                 }
             });
             ipThread.setDaemon(true);

--- a/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
+++ b/src/main/java/com/sparrowwallet/sparrow/net/TorUtils.java
@@ -12,33 +12,58 @@ import java.net.SocketTimeoutException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TorUtils {
     private static final Logger log = LoggerFactory.getLogger(TorUtils.class);
     private static final Pattern TOR_OK = Pattern.compile("^2\\d{2}[ -]OK$");
-    private static final Pattern TOR_AUTH_METHODS = Pattern.compile("^2\\d{2}[ -]AUTH METHODS=(\\S+)\\s?(COOKIEFILE=\"?(.+?)\"?)?$");
+    private static final Pattern TOR_AUTH_METHODS = Pattern
+            .compile("^2\\d{2}[ -]AUTH METHODS=(\\S+)\\s?(COOKIEFILE=\"?(.+?)\"?)?$");
+    private static final String CHECK_TOR_IP_URL = "https://check.torproject.org/api/ip";
+
+    private static final java.util.concurrent.atomic.AtomicInteger IP_CHECK_COUNTER = new java.util.concurrent.atomic.AtomicInteger(0);
+
+    public static void logTorIp() {
+        if (AppServices.isTorRunning() && AppServices.isConnected()) {
+            Thread ipThread = new Thread(() -> {
+                try {
+                    Thread.sleep(3000);
+                    HttpClientService httpClientService = AppServices.getHttpClientService();
+                    Map<String, String> response = httpClientService.requestJson(CHECK_TOR_IP_URL, Map.class, null);
+                    if (response != null && response.containsKey("ip")) {
+                        log.info("IP: " + response.get("ip"));
+                    }
+                } catch (Exception e) {
+                    log.warn("Error checking IP: " + e.getMessage());
+                }
+            });
+            ipThread.setDaemon(true);
+            ipThread.setName("IPChecker-" + IP_CHECK_COUNTER.incrementAndGet());
+            ipThread.start();
+        }
+    }
 
     public static void changeIdentity(HostAndPort proxy) {
-        if(AppServices.isTorRunning()) {
+        if (AppServices.isTorRunning()) {
             Tor.getDefault().changeIdentity();
         } else {
             HostAndPort control = HostAndPort.fromParts(proxy.getHost(), proxy.getPort() + 1);
-            try(Socket socket = new Socket(control.getHost(), control.getPort())) {
+            try (Socket socket = new Socket(control.getHost(), control.getPort())) {
                 socket.setSoTimeout(1500);
-                if(authenticate(socket)) {
+                if (authenticate(socket)) {
                     writeNewNym(socket);
                 }
-            } catch(TorAuthenticationException e) {
+            } catch (TorAuthenticationException e) {
                 log.warn("Error authenticating to Tor at " + control + ", server returned " + e.getMessage());
-            } catch(SocketTimeoutException e) {
+            } catch (SocketTimeoutException e) {
                 log.warn("Timeout reading from " + control + ", is this a Tor ControlPort?");
-            } catch(AccessDeniedException e) {
+            } catch (AccessDeniedException e) {
                 log.warn("Permission denied reading Tor cookie file at " + e.getFile());
-            } catch(FileSystemException e) {
+            } catch (FileSystemException e) {
                 log.warn("Error reading Tor cookie file at " + e.getFile());
-            } catch(Exception e) {
+            } catch (Exception e) {
                 log.warn("Error connecting to " + control + ", no Tor ControlPort configured?");
             }
         }
@@ -49,20 +74,20 @@ public class TorUtils {
         BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
         String line;
         File cookieFile = null;
-        while((line = reader.readLine()) != null) {
+        while ((line = reader.readLine()) != null) {
             Matcher authMatcher = TOR_AUTH_METHODS.matcher(line);
-            if(authMatcher.matches()) {
+            if (authMatcher.matches()) {
                 String methods = authMatcher.group(1);
-                if(methods.contains("COOKIE") && !authMatcher.group(3).isEmpty()) {
+                if (methods.contains("COOKIE") && !authMatcher.group(3).isEmpty()) {
                     cookieFile = new File(authMatcher.group(3));
                 }
             }
-            if(TOR_OK.matcher(line).matches()) {
+            if (TOR_OK.matcher(line).matches()) {
                 break;
             }
         }
 
-        if(cookieFile != null && cookieFile.exists()) {
+        if (cookieFile != null && cookieFile.exists()) {
             byte[] cookieBytes = Files.readAllBytes(cookieFile.toPath());
             String authentication = "AUTHENTICATE " + Utils.bytesToHex(cookieBytes) + "\r\n";
             socket.getOutputStream().write(authentication.getBytes());
@@ -71,7 +96,7 @@ public class TorUtils {
         }
 
         line = reader.readLine();
-        if(TOR_OK.matcher(line).matches()) {
+        if (TOR_OK.matcher(line).matches()) {
             return true;
         } else {
             throw new TorAuthenticationException(line);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -38,6 +38,10 @@
     <logger name="org.springframework.web.socket.sockjs.client.DefaultTransportRequest" level="OFF" />
     <logger name="org.xbill.DNS.dnssec.DnsSecVerifier" level="ERROR" />
 
+    <!-- Joinstr Tor circuit isolation logs -->
+    <logger name="com.sparrowwallet.sparrow.net.TorUtils" level="INFO"/>
+    <logger name="com.sparrowwallet.sparrow.net.Tor" level="INFO"/>
+
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
     <define name="appDir" class="com.sparrowwallet.drongo.PropertyDefiner">


### PR DESCRIPTION
Closes https://github.com/QcMrHyde/sparrow-joinstr/issues/33

Uses `TorUtils.changeIdentity(HostAndPort proxy)` before every connection with a nostr relay. This method sends the NEWNYM signal to the Tor control port, instructing Tor to use a new circuit for the next stream.