### PR TITLE
[qa] add basic unit tests and CI for joinstr

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+      - name: Set up JDK 22.0.2
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '22.0.2'
+      - name: Show Build Versions
+        run: ./gradlew -v
+      - name: Run tests
+        run: ./gradlew -Djava.awt.headless=true test
+      - name: Upload test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test/
+          if-no-files-found: ignore

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -3,7 +3,6 @@ package com.sparrowwallet.sparrow.joinstr;
 import com.google.gson.Gson;
 import com.sparrowwallet.drongo.address.Address;
 import com.sparrowwallet.drongo.protocol.Script;
-import com.sparrowwallet.drongo.protocol.SigHash;
 import com.sparrowwallet.drongo.protocol.Transaction;
 import com.sparrowwallet.drongo.protocol.TransactionInput;
 import com.sparrowwallet.drongo.protocol.TransactionOutput;
@@ -30,7 +29,6 @@ import nostr.id.Identity;
 import com.sparrowwallet.sparrow.net.TorUtils;
 import org.bouncycastle.util.encoders.Base64;
 
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -74,9 +72,7 @@ public class CoinjoinHandler {
 
         this.numPeers = pool.getParsedPeers();
 
-        String denomStr = pool.getDenomination().replace(" BTC", "").replace("BTC", "").trim();
-        BigDecimal denom = new BigDecimal(denomStr);
-        this.poolAmountSats = denom.movePointRight(8).longValueExact();
+        this.poolAmountSats = CoinjoinMath.denominationToSats(pool.getDenomination());
     }
 
     public void setFeeRate(long feeRate) {
@@ -213,9 +209,9 @@ public class CoinjoinHandler {
                 ", value=" + selectedUtxo.getValue() + " sats");
 
         long value = selectedUtxo.getValue();
-        long minAllowed = poolAmountSats + 500;
-        long maxAllowed = poolAmountSats + 5000;
-        if (value < minAllowed || value > maxAllowed) {
+        long minAllowed = CoinjoinMath.minInputSats(poolAmountSats);
+        long maxAllowed = CoinjoinMath.maxInputSats(poolAmountSats);
+        if (!CoinjoinMath.isInputValueInRange(value, poolAmountSats)) {
             Platform.runLater(() -> {
                 com.sparrowwallet.sparrow.AppServices.showErrorDialog("Invalid UTXO",
                         "The selected UTXO has a value of " + value + " sats, which is outside the allowed range of "
@@ -304,10 +300,8 @@ public class CoinjoinHandler {
 
             tx.addInput(utxo.getHash(), (int) utxo.getIndex(), new Script(new byte[0]));
 
-            long estimatedTxSize = 150L * numPeers;
-            long totalFee = feeRate * estimatedTxSize;
-            long feePerOutput = totalFee / numPeers;
-            long outputAmount = poolAmountSats - feePerOutput;
+            long feePerOutput = CoinjoinMath.feePerOutput(feeRate, numPeers);
+            long outputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers);
 
             logger.info("Creating PSBT: pool=" + poolAmountSats + " sats, fee/output=" + feePerOutput + ", output="
                     + outputAmount);
@@ -324,7 +318,7 @@ public class CoinjoinHandler {
             PSBT psbt = new PSBT(tx);
 
             PSBTInput psbtInput = psbt.getPsbtInputs().get(0);
-            psbtInput.setSigHash(SigHash.ANYONECANPAY_ALL);
+            psbtInput.setSigHash(CoinjoinMath.INPUT_SIGHASH);
 
             if (wallet != null) {
                 Transaction utxoTx = wallet.getTransactions().get(utxo.getHash()).getTransaction();
@@ -347,41 +341,23 @@ public class CoinjoinHandler {
     }
 
     private boolean validateOutputs(Transaction tx, List<String> expectedAddresses) {
-        long estimatedTxSize = 150L * numPeers;
-        long totalFee = feeRate * estimatedTxSize;
-        long feePerOutput = totalFee / numPeers;
-        long expectedOutputAmount = poolAmountSats - feePerOutput;
+        long expectedOutputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers);
 
-        Set<String> foundAddresses = new HashSet<>();
-
+        List<CoinjoinMath.OutputView> views = new ArrayList<>();
         for (TransactionOutput output : tx.getOutputs()) {
             try {
-                Address outputAddr = output.getScript().getToAddress();
-                String addrStr = outputAddr.toString();
-                if (expectedAddresses.contains(addrStr)) {
-                    if (output.getValue() != expectedOutputAmount) {
-                        logger.severe(
-                                "Output " + addrStr + " has incorrect amount: " + output.getValue() + " vs expected "
-                                        + expectedOutputAmount);
-                        return false;
-                    }
-                    foundAddresses.add(addrStr);
-                } else {
-                    logger.warning("Unrecognized output address in transaction: " + addrStr);
-                    return false;
-                }
+                String addrStr = output.getScript().getToAddress().toString();
+                views.add(new CoinjoinMath.OutputView(addrStr, output.getValue()));
             } catch (Exception e) {
                 logger.warning("Could not parse output address: " + e.getMessage());
             }
         }
 
-        if (foundAddresses.size() != expectedAddresses.size()) {
-            logger.severe("Missing output addresses. Found " + foundAddresses.size() + " vs expected "
-                    + expectedAddresses.size());
-            return false;
+        boolean valid = CoinjoinMath.validateOutputs(views, expectedAddresses, expectedOutputAmount);
+        if (!valid) {
+            logger.severe("Output validation failed against expected amount " + expectedOutputAmount);
         }
-
-        return true;
+        return valid;
     }
 
     private void signPSBT(PSBT psbt, BlockTransactionHashIndex utxo, WalletNode utxoNode, Wallet signingWallet) {
@@ -508,10 +484,7 @@ public class CoinjoinHandler {
                     }
                 }
 
-                long estimatedTxSize = 150L * numPeers;
-                long totalFee = feeRate * estimatedTxSize;
-                long feePerOutput = (numPeers > 0) ? totalFee / numPeers : 0;
-                long expectedOutputAmount = poolAmountSats - feePerOutput;
+                long expectedOutputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers);
 
                 Transaction tx = psbt.getTransaction();
                 for (TransactionOutput output : tx.getOutputs()) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -1,0 +1,86 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.protocol.SigHash;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Pure coinjoin arithmetic and output validation, extracted from CoinjoinHandler so it can be
+ * unit tested without a wallet, identity or relay connection.
+ */
+public final class CoinjoinMath {
+
+    /** A joined UTXO must be worth at least the denomination plus this margin (fee + change buffer). */
+    public static final long MIN_UTXO_MARGIN = 500;
+    /** A joined UTXO must be worth at most the denomination plus this margin. */
+    public static final long MAX_UTXO_MARGIN = 5000;
+    /** Inputs are signed with SIGHASH_ALL | SIGHASH_ANYONECANPAY (0x81) per the joinstr NIP. */
+    public static final SigHash INPUT_SIGHASH = SigHash.ANYONECANPAY_ALL;
+    /** Rough vsize charged per peer (one input + one output) when estimating the fee. */
+    private static final long ESTIMATED_VSIZE_PER_PEER = 150L;
+
+    private CoinjoinMath() {
+    }
+
+    /**
+     * Convert a denomination string (e.g. "0.001", "0.01 BTC") to satoshis.
+     * Throws if the denomination is not a valid number or is not a whole number of satoshis.
+     */
+    public static long denominationToSats(String denomination) {
+        String denomStr = denomination.replace(" BTC", "").replace("BTC", "").trim();
+        BigDecimal denom = new BigDecimal(denomStr);
+        return denom.movePointRight(8).longValueExact();
+    }
+
+    public static long minInputSats(long poolAmountSats) {
+        return poolAmountSats + MIN_UTXO_MARGIN;
+    }
+
+    public static long maxInputSats(long poolAmountSats) {
+        return poolAmountSats + MAX_UTXO_MARGIN;
+    }
+
+    public static boolean isInputValueInRange(long value, long poolAmountSats) {
+        return value >= minInputSats(poolAmountSats) && value <= maxInputSats(poolAmountSats);
+    }
+
+    public static long feePerOutput(long feeRate, int numPeers) {
+        long estimatedTxSize = ESTIMATED_VSIZE_PER_PEER * numPeers;
+        long totalFee = feeRate * estimatedTxSize;
+        return numPeers > 0 ? totalFee / numPeers : 0;
+    }
+
+    public static long outputAmount(long poolAmountSats, long feeRate, int numPeers) {
+        return poolAmountSats - feePerOutput(feeRate, numPeers);
+    }
+
+    /** An output reduced to the two fields coinjoin validation cares about. */
+    public record OutputView(String address, long value) {
+    }
+
+    /**
+     * Every output must pay one of the expected addresses exactly {@code expectedAmount} sats, and
+     * all expected addresses must be present exactly once. Mirrors the equal-value coinjoin rule.
+     */
+    public static boolean validateOutputs(List<OutputView> outputs, Collection<String> expectedAddresses,
+            long expectedAmount) {
+        Set<String> expected = new HashSet<>(expectedAddresses);
+        Set<String> found = new HashSet<>();
+
+        for (OutputView output : outputs) {
+            if (!expected.contains(output.address())) {
+                return false;
+            }
+            if (output.value() != expectedAmount) {
+                return false;
+            }
+            found.add(output.address());
+        }
+
+        return found.size() == expected.size();
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandlerTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandlerTest.java
@@ -1,0 +1,42 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies CoinjoinHandler still derives the pool amount and peer count correctly after the
+ * arithmetic was moved into CoinjoinMath. The constructor touches neither wallet nor identity,
+ * so nulls are safe here.
+ */
+public class CoinjoinHandlerTest {
+
+    private CoinjoinHandler handlerFor(String denomination, String peers) {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pubkey", denomination, peers, "0");
+        return new CoinjoinHandler(null, pool, null, null, null);
+    }
+
+    @Test
+    public void derivesPoolAmountFromDenomination() {
+        CoinjoinHandler handler = handlerFor("0.01", "3");
+        try {
+            assertEquals(1_000_000L, handler.getPoolAmountSats());
+            assertEquals(3, handler.getNumPeers());
+            assertFalse(handler.isReadyForInputPhase());
+            assertTrue(handler.getOutputAddresses().isEmpty());
+        } finally {
+            handler.stopListening();
+        }
+    }
+
+    @Test
+    public void parsesPeerCountFromConnectedOverTotalForm() {
+        CoinjoinHandler handler = handlerFor("0.001", "1/4");
+        try {
+            assertEquals(100_000L, handler.getPoolAmountSats());
+            assertEquals(4, handler.getNumPeers());
+        } finally {
+            handler.stopListening();
+        }
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMathTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMathTest.java
@@ -1,0 +1,113 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CoinjoinMathTest {
+
+    private static final String OUR_ADDR = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    private static final String PEER_ADDR = "bc1q2480xax2lt0u5a5s3x44aa323c9l44kk2v86mq";
+    private static final String WRONG_ADDR = "bc1q6280xax2lt0u5a5s3x44aa323c9l44kk4v08oq";
+
+    // --- denomination -> sats (mirrors py-joinstr test_utxo::TestDenominationRange) ---
+
+    @Test
+    public void denominationToSats() {
+        assertEquals(100_000L, CoinjoinMath.denominationToSats("0.001"));
+        assertEquals(1_000_000L, CoinjoinMath.denominationToSats("0.01"));
+        assertEquals(100_000_000L, CoinjoinMath.denominationToSats("1"));
+        assertEquals(29_000_000L, CoinjoinMath.denominationToSats("0.29"));
+    }
+
+    @Test
+    public void denominationToleratesBtcSuffixAndWhitespace() {
+        assertEquals(100_000L, CoinjoinMath.denominationToSats(" 0.001 BTC "));
+        assertEquals(1_000_000L, CoinjoinMath.denominationToSats("0.01BTC"));
+    }
+
+    @Test
+    public void denominationRejectsNonNumeric() {
+        assertThrows(NumberFormatException.class, () -> CoinjoinMath.denominationToSats("abc"));
+        assertThrows(NumberFormatException.class, () -> CoinjoinMath.denominationToSats(""));
+    }
+
+    @Test
+    public void denominationRejectsSubSatoshiPrecision() {
+        // 0.000000001 BTC is a fraction of a satoshi and must not be silently truncated.
+        assertThrows(ArithmeticException.class, () -> CoinjoinMath.denominationToSats("0.000000001"));
+    }
+
+    // --- UTXO value range (mirrors py-joinstr test_utxo::TestCheckUtxoAvailability boundaries) ---
+
+    @Test
+    public void utxoRangeBoundaries() {
+        long pool = 100_000L;
+        assertEquals(100_500L, CoinjoinMath.minInputSats(pool));
+        assertEquals(105_000L, CoinjoinMath.maxInputSats(pool));
+
+        assertTrue(CoinjoinMath.isInputValueInRange(100_500L, pool));  // at min
+        assertTrue(CoinjoinMath.isInputValueInRange(105_000L, pool));  // at max
+        assertFalse(CoinjoinMath.isInputValueInRange(100_499L, pool)); // too small
+        assertFalse(CoinjoinMath.isInputValueInRange(105_001L, pool)); // too large
+        assertFalse(CoinjoinMath.isInputValueInRange(pool, pool));     // exactly denomination: no fee margin
+    }
+
+    // --- fee / output amount ---
+
+    @Test
+    public void outputAmountSubtractsFee() {
+        long pool = 100_000L;
+        // feeRate 1 sat/vB, 150 vB per peer -> 150 sats fee per output regardless of peer count
+        assertEquals(150L, CoinjoinMath.feePerOutput(1, 3));
+        assertEquals(150L, CoinjoinMath.feePerOutput(1, 5));
+        assertEquals(pool - 150L, CoinjoinMath.outputAmount(pool, 1, 3));
+        assertEquals(pool - 1500L, CoinjoinMath.outputAmount(pool, 10, 3));
+    }
+
+    @Test
+    public void feePerOutputHandlesZeroPeers() {
+        // Must not divide by zero.
+        assertEquals(0L, CoinjoinMath.feePerOutput(5, 0));
+    }
+
+    // --- sighash flag (mirrors py-joinstr test_sighash) ---
+
+    @Test
+    public void inputSighashIsAllAnyonecanpay() {
+        assertEquals(0x81, CoinjoinMath.INPUT_SIGHASH.intValue());
+    }
+
+    // --- output validation (mirrors py-joinstr test_outputs / test_validation) ---
+
+    private CoinjoinMath.OutputView out(String address, long value) {
+        return new CoinjoinMath.OutputView(address, value);
+    }
+
+    @Test
+    public void validOutputsAccepted() {
+        List<CoinjoinMath.OutputView> outputs = List.of(out(OUR_ADDR, 100_000), out(PEER_ADDR, 100_000));
+        assertTrue(CoinjoinMath.validateOutputs(outputs, List.of(OUR_ADDR, PEER_ADDR), 100_000));
+    }
+
+    @Test
+    public void unexpectedAddressRejected() {
+        List<CoinjoinMath.OutputView> outputs = List.of(out(WRONG_ADDR, 100_000), out(PEER_ADDR, 100_000));
+        assertFalse(CoinjoinMath.validateOutputs(outputs, List.of(OUR_ADDR, PEER_ADDR), 100_000));
+    }
+
+    @Test
+    public void wrongAmountRejected() {
+        List<CoinjoinMath.OutputView> outputs = List.of(out(OUR_ADDR, 99_999), out(PEER_ADDR, 100_000));
+        assertFalse(CoinjoinMath.validateOutputs(outputs, List.of(OUR_ADDR, PEER_ADDR), 100_000));
+    }
+
+    @Test
+    public void missingExpectedOutputRejected() {
+        // Only one of the two expected addresses is present.
+        List<CoinjoinMath.OutputView> outputs = List.of(out(OUR_ADDR, 100_000));
+        assertFalse(CoinjoinMath.validateOutputs(outputs, List.of(OUR_ADDR, PEER_ADDR), 100_000));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
@@ -1,0 +1,75 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JoinstrMessageTest {
+
+    @Test
+    public void outputMessageRoundTrips() {
+        JoinstrMessage message = new JoinstrMessage();
+        message.setType("output");
+        message.setAddress("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq");
+
+        JoinstrMessage parsed = JoinstrMessage.fromJson(message.toJson());
+
+        assertEquals("output", parsed.getType());
+        assertEquals("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", parsed.getAddress());
+        assertNull(parsed.getPsbt());
+    }
+
+    @Test
+    public void inputMessageRoundTrips() {
+        JoinstrMessage message = new JoinstrMessage();
+        message.setType("input");
+        message.setPsbt("cHNidP8BAAAAAA==");
+
+        JoinstrMessage parsed = JoinstrMessage.fromJson(message.toJson());
+
+        assertEquals("input", parsed.getType());
+        assertEquals("cHNidP8BAAAAAA==", parsed.getPsbt());
+    }
+
+    /**
+     * The wire format uses snake_case keys (private_key, fee_rate) so that pools are
+     * interoperable with other joinstr clients. Guard against an accidental rename to
+     * camelCase which would silently break credential exchange.
+     */
+    @Test
+    public void credentialsUseSnakeCaseWireKeys() {
+        JoinstrMessage message = new JoinstrMessage();
+        message.setType("credentials");
+        message.setPrivateKey("deadbeef");
+        message.setFeeRate(5L);
+
+        String json = message.toJson();
+
+        assertTrue(json.contains("\"private_key\""), "expected snake_case private_key in: " + json);
+        assertTrue(json.contains("\"fee_rate\""), "expected snake_case fee_rate in: " + json);
+        assertFalse(json.contains("privateKey"), "wire format must not use camelCase privateKey");
+        assertFalse(json.contains("feeRate"), "wire format must not use camelCase feeRate");
+    }
+
+    @Test
+    public void parsesForeignCredentialsJson() {
+        String json = "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":7}";
+
+        JoinstrMessage parsed = JoinstrMessage.fromJson(json);
+
+        assertEquals("credentials", parsed.getType());
+        assertEquals("deadbeef", parsed.getPrivateKey());
+        assertEquals(7L, parsed.getFeeRate());
+    }
+
+    @Test
+    public void unsetOptionalFieldsAreNull() {
+        JoinstrMessage parsed = JoinstrMessage.fromJson("{\"type\":\"output\"}");
+
+        assertEquals("output", parsed.getType());
+        assertNull(parsed.getAddress());
+        assertNull(parsed.getPsbt());
+        assertNull(parsed.getPrivateKey());
+        assertNull(parsed.getFeeRate());
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrPoolTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrPoolTest.java
@@ -1,0 +1,57 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JoinstrPoolTest {
+
+    private JoinstrPool poolWithPeers(String peers) {
+        return new JoinstrPool("wss://nos.lol", "pubkey", "0.01", peers, "0");
+    }
+
+    @Test
+    public void parsesPlainPeerCount() {
+        assertEquals(3, poolWithPeers("3").getParsedPeers());
+        assertEquals(5, poolWithPeers(" 5 ").getParsedPeers());
+    }
+
+    @Test
+    public void parsesConnectedOverTotalForm() {
+        // "connected/total" - the total (right side) is the pool size
+        assertEquals(3, poolWithPeers("1/3").getParsedPeers());
+        assertEquals(5, poolWithPeers("0/5").getParsedPeers());
+    }
+
+    @Test
+    public void malformedPeerStringsReturnZero() {
+        assertEquals(0, poolWithPeers("").getParsedPeers());
+        assertEquals(0, poolWithPeers("   ").getParsedPeers());
+        assertEquals(0, poolWithPeers("abc").getParsedPeers());
+        assertEquals(0, poolWithPeers("5/").getParsedPeers());
+    }
+
+    @Test
+    public void peersStatusReflectsConnectedAndTotal() {
+        JoinstrPool pool = poolWithPeers("3");
+        assertEquals(0, pool.getConnectedPeers());
+        assertEquals("0/3", pool.getPeersStatus());
+    }
+
+    @Test
+    public void gettersReturnConstructorValues() {
+        JoinstrPool pool = new JoinstrPool("wss://relay.example", "npub123", "0.05", "4", "1700000000");
+        assertEquals("wss://relay.example", pool.getRelay());
+        assertEquals("npub123", pool.getPubkey());
+        assertEquals("0.05", pool.getDenomination());
+        assertEquals("4", pool.getPeers());
+        assertEquals("1700000000", pool.getTimeout());
+    }
+
+    @Test
+    public void emptyPrivateKeyYieldsNoIdentity() {
+        // No private key set and no handler attached: must return null rather than throw.
+        JoinstrPool pool = poolWithPeers("3");
+        assertNull(pool.getJoinstrIdentity());
+    }
+}


### PR DESCRIPTION
Adds the first tests for joinstrand a CI workflow to run them.

- `JoinstrMessageTest` — JSON round-trips for output/input/credentials messages; guards the snake_case wire keys (`private_key`, `fee_rate`) used for cross-client compatibility.
- `JoinstrPoolTest` — `getParsedPeers` edge cases (`"3"`, `"1/3"`, `""`, `"abc"`, `"5/"`), peers-status, getters, empty-key identity.
- `.github/workflows/test.yaml` — runs `./gradlew test` on every PR and push to `main`.
