### PR TITLE
Parse, display and validate pool fee rate

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -9,6 +9,8 @@ import com.sparrowwallet.sparrow.io.Storage;
 import com.sparrowwallet.sparrow.wallet.NodeEntry;
 import com.sparrowwallet.sparrow.wallet.WalletForm;
 import javafx.application.Platform;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
 import nostr.id.Identity;
 
 import java.util.*;
@@ -19,14 +21,29 @@ import java.util.logging.Logger;
 public class JoinPoolHandler {
     private static final Logger logger = Logger.getLogger(JoinPoolHandler.class.getName());
 
+    /** Absolute bounds on an accepted pool fee rate (sat/vB). */
+    static final long MIN_FEE_RATE = 1;
+    static final long MAX_FEE_RATE = 100;
+
     private Identity joinIdentity;
     private JoinstrPool pool;
     private String relay;
     private NostrListener credentialsListener;
     private Identity poolIdentity;
     private int numPeers;
+    private long feeRate = 1;
     private Consumer<String> statusCallback;
     private CoinjoinHandler coinjoinHandler;
+
+    /**
+     * Accept a fee rate that stays within a tolerance band of the advertised rate (it may drift
+     * between pool creation and the coinjoin) and within the absolute [MIN_FEE_RATE, MAX_FEE_RATE] range.
+     */
+    static boolean isFeeRateAcceptable(long feeRate, long advertisedFeeRate) {
+        long lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
+        long hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
+        return feeRate >= lo && feeRate <= hi;
+    }
 
     public JoinPoolHandler(Identity joinIdentity, JoinstrPool pool, Consumer<String> statusCallback) {
         this.joinIdentity = joinIdentity;
@@ -96,13 +113,22 @@ public class JoinPoolHandler {
 
             Platform.runLater(() -> statusCallback.accept("Credentials received"));
 
-            long feeRate = 1;
-            if (message.getFeeRate() != null) {
-                feeRate = message.getFeeRate();
+            long advertisedFeeRate = pool.getParsedFeeRate();
+            long credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
+
+            if (!isFeeRateAcceptable(credentialsFeeRate, advertisedFeeRate)) {
+                logger.severe("Rejecting pool: fee rate " + credentialsFeeRate
+                        + " sat/vB is outside the accepted range for advertised " + advertisedFeeRate
+                        + " sat/vB (absolute max " + MAX_FEE_RATE + ")");
+                Platform.runLater(() -> statusCallback.accept("Error: Fee rate out of range"));
+                stop();
+                return;
             }
 
+            this.feeRate = credentialsFeeRate;
+
             // Use CoinjoinHandler for the rest of the flow
-            startCoinjoinFlow(feeRate);
+            startCoinjoinFlow(credentialsFeeRate);
 
         } catch (Exception e) {
             logger.severe("Error processing credentials: " + e.getMessage());
@@ -193,6 +219,24 @@ public class JoinPoolHandler {
 
                 logger.info("Selected UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() + " value="
                         + selectedUtxo.getValue());
+
+                long feePerOutput = feeRate * 150;
+                long outputAmount = poolAmountSats - feePerOutput;
+                long myFee = selectedUtxo.getValue() - outputAmount;
+
+                java.util.Optional<ButtonType> confirm = AppServices.showAlertDialog(
+                        "Confirm Coinjoin Input",
+                        "Input: " + selectedUtxo.getValue() + " sats\n" +
+                                "Output: " + outputAmount + " sats\n" +
+                                "Fee: " + myFee + " sats (" + feeRate + " sat/vB)\n\n" +
+                                "Proceed with signing?",
+                        Alert.AlertType.CONFIRMATION, ButtonType.CANCEL, ButtonType.OK);
+
+                if (confirm.isEmpty() || confirm.get() != ButtonType.OK) {
+                    logger.info("User cancelled coinjoin input confirmation");
+                    Platform.runLater(() -> statusCallback.accept("Input registration cancelled"));
+                    return;
+                }
 
                 coinjoinHandler.startInputPhase(selectedUtxo, utxoNode);
             } else {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -27,6 +27,7 @@ public class JoinstrPool {
     private final SimpleStringProperty status;
     private final javafx.beans.property.SimpleIntegerProperty connectedPeers;
     private String privateKey;
+    private String feeRate = "1";
     private JoinPoolHandler handler;
 
     public JoinstrPool(String relay, String pubkey, String denomination,
@@ -79,6 +80,25 @@ public class JoinstrPool {
 
     public void setPrivateKey(String privateKey) {
         this.privateKey = privateKey;
+    }
+
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public long getParsedFeeRate() {
+        try {
+            if (feeRate == null || feeRate.trim().isEmpty()) {
+                return 1;
+            }
+            return Long.parseLong(feeRate.trim());
+        } catch (Exception e) {
+            return 1;
+        }
     }
 
     public String getDenomination() {
@@ -252,6 +272,7 @@ public class JoinstrPool {
         private final String timeout;
         private final String status;
         private final String privateKey;
+        private final String feeRate;
 
         public JoinstrPoolData(JoinstrPool joinstrPool) {
             this.relay = joinstrPool.getRelay();
@@ -261,10 +282,15 @@ public class JoinstrPool {
             this.timeout = joinstrPool.getTimeout();
             this.status = joinstrPool.getStatus();
             this.privateKey = joinstrPool.getPrivateKey();
+            this.feeRate = joinstrPool.getFeeRate();
         }
 
         public JoinstrPool getPoolObject() {
-            return new JoinstrPool(relay, pubkey, denomination, peers, timeout, privateKey, status);
+            JoinstrPool pool = new JoinstrPool(relay, pubkey, denomination, peers, timeout, privateKey, status);
+            if (feeRate != null) {
+                pool.setFeeRate(feeRate);
+            }
+            return pool;
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -157,6 +157,10 @@ public class OtherPoolsController extends JoinstrFormController {
                                                     poolData.get("peers").asText(),
                                                     String.valueOf(timeout));
 
+                                            if (poolData.has("fee_rate")) {
+                                                pool.setFeeRate(poolData.get("fee_rate").asText());
+                                            }
+
                                             if (pools.stream().noneMatch(
                                                     (p) -> Objects.equals(p.getPubkey(), pool.getPubkey())) &&
                                                     myPools.stream().noneMatch(

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -14,6 +14,7 @@ public class JoinstrInfoPane extends VBox {
     private Label relayValueLabel;
     private Label pubkeyValueLabel;
     private Label denominationValueLabel;
+    private Label feeRateValueLabel;
     private Label statusValueLabel;
 
     public JoinstrInfoPane() {
@@ -50,7 +51,11 @@ public class JoinstrInfoPane extends VBox {
         Label denominationLabel = new Label("Denomination:");
         denominationLabel.getStyleClass().add("text-grey");
         denominationValueLabel = new Label();
- 
+
+        Label feeRateLabel = new Label("Fee rate:");
+        feeRateLabel.getStyleClass().add("text-grey");
+        feeRateValueLabel = new Label();
+
         Label statusLabel = new Label("Status:");
         statusLabel.getStyleClass().add("text-grey");
         statusValueLabel = new Label();
@@ -59,6 +64,7 @@ public class JoinstrInfoPane extends VBox {
             relayValueLabel.setStyle("-fx-text-fill: white;");
             pubkeyValueLabel.setStyle("-fx-text-fill: white;");
             denominationValueLabel.setStyle("-fx-text-fill: white;");
+            feeRateValueLabel.setStyle("-fx-text-fill: white;");
             statusValueLabel.setStyle("-fx-text-fill: white;");
         }
 
@@ -68,8 +74,10 @@ public class JoinstrInfoPane extends VBox {
         detailsGrid.add(pubkeyValueLabel, 1, 1);
         detailsGrid.add(denominationLabel, 0, 2);
         detailsGrid.add(denominationValueLabel, 1, 2);
-        detailsGrid.add(statusLabel, 0, 3);
-        detailsGrid.add(statusValueLabel, 1, 3);
+        detailsGrid.add(feeRateLabel, 0, 3);
+        detailsGrid.add(feeRateValueLabel, 1, 3);
+        detailsGrid.add(statusLabel, 0, 4);
+        detailsGrid.add(statusValueLabel, 1, 4);
 
         getChildren().add(detailsGrid);
     }
@@ -79,6 +87,7 @@ public class JoinstrInfoPane extends VBox {
             relayValueLabel.setText(pool.getRelay());
             pubkeyValueLabel.setText(pool.getPubkey());
             denominationValueLabel.setText(pool.getDenomination());
+            feeRateValueLabel.setText(pool.getParsedFeeRate() + " sat/vB");
             statusValueLabel.textProperty().bind(pool.statusProperty());
         } else {
             clearPoolInfo();
@@ -89,6 +98,7 @@ public class JoinstrInfoPane extends VBox {
         relayValueLabel.setText("");
         pubkeyValueLabel.setText("");
         denominationValueLabel.setText("");
+        feeRateValueLabel.setText("");
         statusValueLabel.textProperty().unbind();
         statusValueLabel.setText("");
     }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
@@ -1,0 +1,61 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FeeRateValidationTest {
+
+    @Test
+    public void acceptsFeeRateWithinToleranceOfAdvertised() {
+        // advertised 4 -> band [2, 8]
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(4, 4));
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(2, 4));
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(8, 4));
+    }
+
+    @Test
+    public void rejectsFeeRateOutsideToleranceOfAdvertised() {
+        // advertised 4 -> band [2, 8]
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(1, 4));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(9, 4));
+    }
+
+    @Test
+    public void defaultPoolFeeRateBandIsOneToTwo() {
+        // advertised 1 -> band [max(1,0), min(100,2)] = [1, 2]
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(1, 1));
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(2, 1));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(3, 1));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(0, 1));
+    }
+
+    @Test
+    public void absoluteCapAppliesRegardlessOfAdvertised() {
+        // advertised 60 -> hi clamped to 100, not 120
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(100, 60));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(101, 60));
+        // an absurd advertised rate leaves an empty band -> everything rejected
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(100, 300));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(300, 300));
+    }
+
+    @Test
+    public void poolParsesAdvertisedFeeRate() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
+        assertEquals(1, pool.getParsedFeeRate()); // default when unset
+        pool.setFeeRate("7");
+        assertEquals(7, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void poolFeeRateDefaultsOnMalformedValue() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
+        pool.setFeeRate("abc");
+        assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("");
+        assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate(null);
+        assertEquals(1, pool.getParsedFeeRate());
+    }
+}


### PR DESCRIPTION
Previously `fee_rate` from the `kind:2022` pool event was never parsed or shown and the value actually used arrived in the private credentials message after joining, unchecked. A joiner had no way to see it and no guard against a bad one.

Changes:
- Parse `fee_rate` from the pool event into a new `JoinstrPool` field (persisted with the pool).
- Show it as a "Fee rate: N sat/vB" row in the pool info pane, so it is known before joining.
- On credentials receipt, reject the pool if the fee rate falls outside a tolerance band of the advertised value (advertised × [0.5, 2], clamped to [1, 100] sat/vB).
- Confirm input / output / fee in a dialog after UTXO selection; cancel aborts registration.

Tests: `FeeRateValidationTest` covers the range check and fee-rate parsing (default + malformed).