### PR TITLE
Fix multiple bugs

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -61,7 +61,12 @@ public class CoinjoinHandler {
     private NostrListener messageListener;
     private Runnable onReadyForInputCallback;
 
+    private final Object stateLock = new Object();
+    private final java.util.concurrent.atomic.AtomicBoolean finalizing = new java.util.concurrent.atomic.AtomicBoolean(false);
+    private volatile boolean completed = false;
+
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final java.util.concurrent.ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
 
     public CoinjoinHandler(Identity poolIdentity, JoinstrPool pool, Wallet wallet, Storage storage,
             Consumer<String> statusCallback) {
@@ -101,9 +106,35 @@ public class CoinjoinHandler {
 
         updateStatus("Output registered");
 
+        scheduleTimeout();
+
         sendOutputToPool(myOutputAddress);
 
         startListeningForMessages();
+    }
+
+    /**
+     * Abort the coinjoin if it has not completed by the pool timeout, so a stalled pool does not
+     * hang forever with the selected UTXO locked.
+     */
+    private void scheduleTimeout() {
+        long delaySeconds;
+        try {
+            delaySeconds = Long.parseLong(pool.getTimeout().trim()) - Instant.now().getEpochSecond();
+        } catch (Exception e) {
+            delaySeconds = 3600;
+        }
+        if (delaySeconds <= 0) {
+            delaySeconds = 3600;
+        }
+
+        timeoutExecutor.schedule(() -> {
+            if (!completed) {
+                logger.warning("Coinjoin timed out before completion");
+                updateStatus("Timed out");
+                stopListening();
+            }
+        }, delaySeconds, java.util.concurrent.TimeUnit.SECONDS);
     }
 
     private void sendOutputToPool(String address) {
@@ -179,12 +210,19 @@ public class CoinjoinHandler {
     private void handleOutputReceived(JoinstrMessage message) {
         try {
             String addressStr = message.getAddress();
+            if (addressStr == null) {
+                return;
+            }
 
-            if (addressStr != null && !outputAddresses.contains(addressStr)) {
-                try {
-                    Address.fromString(addressStr);
-                } catch (Exception e) {
-                    logger.warning("Received invalid output address: " + addressStr);
+            try {
+                Address.fromString(addressStr);
+            } catch (Exception e) {
+                logger.warning("Received invalid output address: " + addressStr);
+                return;
+            }
+
+            synchronized (stateLock) {
+                if (outputAddresses.contains(addressStr) || outputAddresses.size() >= numPeers) {
                     return;
                 }
 
@@ -306,7 +344,7 @@ public class CoinjoinHandler {
 
             long estimatedTxSize = 150L * numPeers;
             long totalFee = feeRate * estimatedTxSize;
-            long feePerOutput = totalFee / numPeers;
+            long feePerOutput = (numPeers > 0) ? totalFee / numPeers : 0;
             long outputAmount = poolAmountSats - feePerOutput;
 
             logger.info("Creating PSBT: pool=" + poolAmountSats + " sats, fee/output=" + feePerOutput + ", output="
@@ -496,8 +534,15 @@ public class CoinjoinHandler {
     private void handleInputReceived(JoinstrMessage message) {
         try {
             String psbtBase64 = message.getPsbt();
+            if (psbtBase64 == null) {
+                return;
+            }
 
-            if (psbtBase64 != null && !inputPSBTs.contains(psbtBase64)) {
+            synchronized (stateLock) {
+                if (inputPSBTs.contains(psbtBase64) || inputPSBTs.size() >= numPeers) {
+                    return;
+                }
+
                 PSBT psbt = new PSBT(Base64.decode(psbtBase64), false);
 
                 for (PSBTInput input : psbt.getPsbtInputs()) {
@@ -540,7 +585,7 @@ public class CoinjoinHandler {
 
                 logger.info("Received valid input " + inputPSBTs.size() + "/" + numPeers);
 
-                if (inputPSBTs.size() == numPeers) {
+                if (inputPSBTs.size() == numPeers && finalizing.compareAndSet(false, true)) {
                     logger.info("All inputs registered, finalizing coinjoin");
 
                     // Run finalization in background
@@ -732,6 +777,7 @@ public class CoinjoinHandler {
                 } catch (Exception e) {
                     logger.warning("Failed to save history: " + e.getMessage());
                 }
+                completed = true;
                 updateStatus("Complete");
                 pool.setStatus("Complete");
 
@@ -757,6 +803,7 @@ public class CoinjoinHandler {
             if (messageListener != null) {
                 messageListener.close();
             }
+            timeoutExecutor.shutdownNow();
             executorService.shutdown();
         } catch (Exception e) {
             logger.warning("Error stopping listener: " + e.getMessage());

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -120,10 +120,14 @@ public class JoinPoolHandler {
             if (openWallets.isEmpty()) {
                 throw new IllegalStateException("No wallet found");
             }
-            Map.Entry<com.sparrowwallet.drongo.wallet.Wallet, Storage> firstWallet = openWallets.entrySet().iterator()
-                    .next();
-            com.sparrowwallet.drongo.wallet.Wallet wallet = firstWallet.getKey();
-            Storage storage = firstWallet.getValue();
+            Map.Entry<com.sparrowwallet.drongo.wallet.Wallet, Storage> selectedWallet = selectWallet(openWallets);
+            if (selectedWallet == null) {
+                logger.warning("No wallet selected for coinjoin");
+                Platform.runLater(() -> statusCallback.accept("Error: No wallet selected"));
+                return;
+            }
+            com.sparrowwallet.drongo.wallet.Wallet wallet = selectedWallet.getKey();
+            Storage storage = selectedWallet.getValue();
 
             WalletForm walletForm = new WalletForm(storage, wallet);
             NodeEntry freshEntry = walletForm.getFreshNodeEntry(KeyPurpose.RECEIVE, null);
@@ -145,6 +149,33 @@ public class JoinPoolHandler {
             e.printStackTrace();
             Platform.runLater(() -> statusCallback.accept("Error: " + e.getMessage()));
         }
+    }
+
+    /**
+     * Choose which open wallet to use for the coinjoin. With a single wallet it is used directly;
+     * with several, the user is prompted so the output address and input UTXO come from the same
+     * wallet they intend, rather than an arbitrary first entry.
+     */
+    private Map.Entry<com.sparrowwallet.drongo.wallet.Wallet, Storage> selectWallet(
+            Map<com.sparrowwallet.drongo.wallet.Wallet, Storage> openWallets) throws Exception {
+        if (openWallets.size() == 1) {
+            return openWallets.entrySet().iterator().next();
+        }
+
+        java.util.concurrent.FutureTask<Map.Entry<com.sparrowwallet.drongo.wallet.Wallet, Storage>> task = new java.util.concurrent.FutureTask<>(
+                () -> {
+                    com.sparrowwallet.sparrow.joinstr.control.WalletSelectionDialog dialog = new com.sparrowwallet.sparrow.joinstr.control.WalletSelectionDialog(
+                            openWallets);
+                    dialog.showAndWait();
+                    return dialog.getSelectedWallet();
+                });
+
+        if (Platform.isFxApplicationThread()) {
+            task.run();
+        } else {
+            Platform.runLater(task);
+        }
+        return task.get();
     }
 
     /**

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -132,7 +132,7 @@ public class JoinstrPool {
     }
 
     public int getParsedPeers() {
-        if (peers == null || peers.get().trim().isEmpty()) {
+        if (peers == null || peers.get() == null || peers.get().trim().isEmpty()) {
             return 0;
         }
         try {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -76,25 +76,31 @@ public class NostrPublisher implements AutoCloseable {
 
             List<BaseTag> tags = new ArrayList<>();
             String poolId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+            String relayUrl = RELAYS.values().iterator().next();
+            String network = com.sparrowwallet.drongo.Network.get().getName();
             String content = String.format(
                     "{\n" +
+                            "  \"versions\": [\"1\"],\n" +
                             "  \"type\": \"new_pool\",\n" +
                             "  \"id\": \"%s\",\n" +
+                            "  \"network\": \"%s\",\n" +
                             "  \"public_key\": \"%s\",\n" +
                             "  \"denomination\": %s,\n" +
                             "  \"peers\": %s,\n" +
                             "  \"timeout\": %d,\n" +
+                            "  \"relays\": [\"%s\"],\n" +
                             "  \"relay\": \"%s\",\n" +
                             "  \"fee_rate\": 1,\n" +
-                            "  \"transport\": \"tor\",\n" +
-                            "  \"vpn_gateway\": null\n" +
+                            "  \"transport\": { \"tor\": { \"enable\": true }, \"vpn\": { \"enable\": false, \"vpn_gateway\": null } }\n" +
                             "}",
                     poolId,
+                    network,
                     poolIdentity.getPublicKey().toString(),
                     denomination,
                     peers,
                     timeout,
-                    RELAYS.values().iterator().next());
+                    relayUrl,
+                    relayUrl);
 
             NIP01 nip01 = new NIP01(SENDER);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -175,15 +175,17 @@ public class OtherPoolsController extends JoinstrFormController {
                                             String relayUrl = extractRelay(poolData);
                                             if (relayUrl == null || relayUrl.isEmpty()
                                                     || !networkMatches(poolData)
-                                                    || !poolData.has("public_key")) {
+                                                    || !poolData.has("public_key")
+                                                    || !poolData.has("denomination")
+                                                    || !poolData.has("peers")) {
                                                 return;
                                             }
 
                                             JoinstrPool pool = new JoinstrPool(
                                                     relayUrl,
                                                     poolData.get("public_key").asText(),
-                                                    poolData.has("denomination") ? poolData.get("denomination").asText() : "",
-                                                    poolData.has("peers") ? poolData.get("peers").asText() : "",
+                                                    poolData.get("denomination").asText(),
+                                                    poolData.get("peers").asText(),
                                                     String.valueOf(timeout));
 
                                             if (pools.stream().noneMatch(

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -50,6 +50,28 @@ public class OtherPoolsController extends JoinstrFormController {
     private java.util.logging.Handler currentEventHandler;
     private final AtomicBoolean isFetching = new AtomicBoolean(false);
 
+    /**
+     * Read the relay from a pool event, preferring the NIP "relays" array and falling back to the
+     * legacy single "relay" field, so pools from other joinstr clients are not silently dropped.
+     */
+    static String extractRelay(JsonNode poolData) {
+        if (poolData.has("relays") && poolData.get("relays").isArray() && poolData.get("relays").size() > 0) {
+            return poolData.get("relays").get(0).asText();
+        }
+        if (poolData.has("relay")) {
+            return poolData.get("relay").asText();
+        }
+        return null;
+    }
+
+    /** Legacy pools omit "network"; those are accepted. Otherwise the network must match ours. */
+    static boolean networkMatches(JsonNode poolData) {
+        if (!poolData.has("network")) {
+            return true;
+        }
+        return poolData.get("network").asText().equalsIgnoreCase(com.sparrowwallet.drongo.Network.get().getName());
+    }
+
     @Override
     public void initializeView() {
         try {
@@ -150,11 +172,18 @@ public class OtherPoolsController extends JoinstrFormController {
                                                 return;
                                             }
 
+                                            String relayUrl = extractRelay(poolData);
+                                            if (relayUrl == null || relayUrl.isEmpty()
+                                                    || !networkMatches(poolData)
+                                                    || !poolData.has("public_key")) {
+                                                return;
+                                            }
+
                                             JoinstrPool pool = new JoinstrPool(
-                                                    poolData.get("relay").asText(),
+                                                    relayUrl,
                                                     poolData.get("public_key").asText(),
-                                                    poolData.get("denomination").asText(),
-                                                    poolData.get("peers").asText(),
+                                                    poolData.has("denomination") ? poolData.get("denomination").asText() : "",
+                                                    poolData.has("peers") ? poolData.get("peers").asText() : "",
                                                     String.valueOf(timeout));
 
                                             if (pools.stream().noneMatch(

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrRobustnessTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrRobustnessTest.java
@@ -1,0 +1,70 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JoinstrRobustnessTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonNode json(String s) throws Exception {
+        return mapper.readTree(s);
+    }
+
+    // --- B9: getParsedPeers must not NPE on a null peers value ---
+
+    @Test
+    public void parsedPeersHandlesNullValue() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", null, "0");
+        assertEquals(0, pool.getParsedPeers());
+    }
+
+    @Test
+    public void parsedPeersHandlesUsualForms() {
+        assertEquals(3, new JoinstrPool("r", "p", "0.01", "3", "0").getParsedPeers());
+        assertEquals(4, new JoinstrPool("r", "p", "0.01", "1/4", "0").getParsedPeers());
+        assertEquals(0, new JoinstrPool("r", "p", "0.01", "abc", "0").getParsedPeers());
+    }
+
+    // --- B5: relay extraction prefers the NIP "relays" array, falls back to legacy "relay" ---
+
+    @Test
+    public void extractRelayPrefersRelaysArray() throws Exception {
+        JsonNode node = json("{\"relays\":[\"wss://a\",\"wss://b\"],\"relay\":\"wss://legacy\"}");
+        assertEquals("wss://a", OtherPoolsController.extractRelay(node));
+    }
+
+    @Test
+    public void extractRelayFallsBackToLegacyRelay() throws Exception {
+        JsonNode node = json("{\"relay\":\"wss://legacy\"}");
+        assertEquals("wss://legacy", OtherPoolsController.extractRelay(node));
+    }
+
+    @Test
+    public void extractRelayFallsBackWhenRelaysEmpty() throws Exception {
+        JsonNode node = json("{\"relays\":[],\"relay\":\"wss://legacy\"}");
+        assertEquals("wss://legacy", OtherPoolsController.extractRelay(node));
+    }
+
+    @Test
+    public void extractRelayReturnsNullWhenAbsent() throws Exception {
+        assertNull(OtherPoolsController.extractRelay(json("{\"denomination\":\"0.01\"}")));
+    }
+
+    // --- B5: network filtering ---
+
+    @Test
+    public void networkMatchesWhenFieldAbsent() throws Exception {
+        assertTrue(OtherPoolsController.networkMatches(json("{\"relay\":\"wss://a\"}")));
+    }
+
+    @Test
+    public void networkMatchesCurrentNetworkAndRejectsOthers() throws Exception {
+        String current = com.sparrowwallet.drongo.Network.get().getName();
+        assertTrue(OtherPoolsController.networkMatches(json("{\"network\":\"" + current + "\"}")));
+        assertFalse(OtherPoolsController.networkMatches(json("{\"network\":\"" + current + "x\"}")));
+    }
+}


### PR DESCRIPTION

`NostrPublisher` emits non-standard fields: a single "relay" string and "transport":"tor" string, and hardcodes nos.lol + fee_rate:1. The NIP mandates a "relays" array, structured transport, plus network and versions. Discovery then reads poolData.get("relay") (OtherPoolsController:151), so a standards-compliant pool (which has relays) throws NPE and is silently skipped. 

Timeout is only used to filter expired pools at discovery (OtherPoolsController:149). Nothing aborts a coinjoin that stalls mid-flow, so a disappearing peer hangs the pool forever with a UTXO effectively locked.

`handleInputReceived`/`handleOutputReceived` run on the logging-handler thread; the contains()-then-add() and size() == numPeers checks aren't atomic, so two near-simultaneous messages can finalize twice or overshoot numPeers.

`JoinstrPool.getParsedPeers` null-checks the property object but then dereferences peers.get().trim() — a null string value NPEs. And createCoinjoinPSBT divides totalFee / numPeers (line 309) with no numPeers > 0 guard, unlike the guarded path at line 513.

`startCoinjoinFlow` always grabs the first open wallet for the output address, which may differ from the wallet whose UTXO funds the input.