### PR TITLE
build: bump version to 0.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,10 @@ if(System.getProperty("os.arch") == "aarch64") {
 def headless = "true".equals(System.getProperty("java.awt.headless"))
 
 group = 'com.sparrowwallet'
-version = '2.3.2-joinstr.0.1.0'
+version = '2.3.2-joinstr.0.1.1'
 // jpackage requires a numeric-only version (X.Y.Z) on Windows and macOS.
 // This is the version embedded into the installer/package metadata.
-def jpackageVersion = '0.1.0'
+def jpackageVersion = '0.1.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
+++ b/src/main/java/com/sparrowwallet/sparrow/SparrowWallet.java
@@ -18,7 +18,7 @@ import java.util.*;
 public class SparrowWallet {
     public static final String APP_ID = "sparrow";
     public static final String APP_NAME = "Sparrow";
-    public static final String APP_VERSION = "2.3.2-joinstr.0.1.0";
+    public static final String APP_VERSION = "2.3.2-joinstr.0.1.1";
     public static final String APP_VERSION_SUFFIX = "";
     public static final String APP_HOME_PROPERTY = "sparrow.home";
     public static final String NETWORK_ENV_PROPERTY = "SPARROW_NETWORK";


### PR DESCRIPTION
Bumps the version to `0.1.1` ahead of the release:

- `build.gradle`: `version` → `2.3.2-joinstr.0.1.1`, `jpackageVersion` → `0.1.1`
- `SparrowWallet.APP_VERSION` → `2.3.2-joinstr.0.1.1`

Release notes are prepared separately for review.