### PR TITLE
fix: sign the pool announcement with the pool key it advertises

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -30,7 +30,6 @@ import java.util.logging.Logger;
 public class NostrPublisher implements AutoCloseable {
 
     private static final Logger logger = Logger.getLogger(NostrPublisher.class.getName());
-    private static final Identity SENDER = Identity.generateRandomIdentity();
 
     private String poolPrivateKey = "";
 
@@ -67,55 +66,26 @@ public class NostrPublisher implements AutoCloseable {
             }
                 TorUtils.logTorIp();
 
-            logger.info("Public key: " + SENDER.getPublicKey().toString());
-
             poolIdentity = Identity.generateRandomIdentity();
             poolPrivateKey = poolIdentity.getPrivateKey().toString();
 
             long timeout = Instant.now().getEpochSecond() + 3600;
 
-            List<BaseTag> tags = new ArrayList<>();
             String poolId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
             String relayUrl = RELAYS.values().iterator().next();
             String network = com.sparrowwallet.drongo.Network.get().getName();
-            String content = String.format(
-                    "{\n" +
-                            "  \"versions\": [\"1\"],\n" +
-                            "  \"type\": \"new_pool\",\n" +
-                            "  \"id\": \"%s\",\n" +
-                            "  \"network\": \"%s\",\n" +
-                            "  \"public_key\": \"%s\",\n" +
-                            "  \"denomination\": %s,\n" +
-                            "  \"peers\": %s,\n" +
-                            "  \"timeout\": %d,\n" +
-                            "  \"relays\": [\"%s\"],\n" +
-                            "  \"relay\": \"%s\",\n" +
-                            "  \"fee_rate\": 1,\n" +
-                            "  \"transport\": { \"tor\": { \"enable\": true }, \"vpn\": { \"enable\": false, \"vpn_gateway\": null } }\n" +
-                            "}",
-                    poolId,
-                    network,
-                    poolIdentity.getPublicKey().toString(),
-                    denomination,
-                    peers,
-                    timeout,
-                    relayUrl,
+
+            NIP01 nip01 = new NIP01(poolIdentity);
+
+            GenericEvent event = buildPoolEvent(poolIdentity, poolId, network, denomination, peers, timeout,
                     relayUrl);
-
-            NIP01 nip01 = new NIP01(SENDER);
-
-            GenericEvent event = new GenericEvent(
-                    SENDER.getPublicKey(),
-                    Kind.CONJOIN_POOL.getValue(),
-                    tags,
-                    content);
 
             nip01.setEvent(event);
             nip01.sign();
 
             if (AppServices.isTorRunning()) {
                 DefaultRequestContext context = new DefaultRequestContext();
-                context.setPrivateKey(SENDER.getPrivateKey().getRawData());
+                context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
                 context.setRelays(RELAYS);
                 Client.getInstance().connect(context);
             }
@@ -132,6 +102,46 @@ public class NostrPublisher implements AutoCloseable {
             e.printStackTrace();
             return null;
         }
+    }
+
+    /**
+     * Build the kind 2022 announcement. The event is authored by the pool key it advertises, which
+     * is what other joinstr clients check before accepting the pool.
+     */
+    static GenericEvent buildPoolEvent(Identity poolIdentity, String poolId, String network, String denomination,
+            String peers, long timeout, String relayUrl) {
+
+        String content = String.format(
+                "{\n" +
+                        "  \"versions\": [\"1\"],\n" +
+                        "  \"type\": \"new_pool\",\n" +
+                        "  \"id\": \"%s\",\n" +
+                        "  \"network\": \"%s\",\n" +
+                        "  \"public_key\": \"%s\",\n" +
+                        "  \"denomination\": %s,\n" +
+                        "  \"peers\": %s,\n" +
+                        "  \"timeout\": %d,\n" +
+                        "  \"relays\": [\"%s\"],\n" +
+                        "  \"relay\": \"%s\",\n" +
+                        "  \"fee_rate\": 1,\n" +
+                        "  \"transport\": { \"tor\": { \"enable\": true }, \"vpn\": { \"enable\": false, \"vpn_gateway\": null } }\n" +
+                        "}",
+                poolId,
+                network,
+                poolIdentity.getPublicKey().toString(),
+                denomination,
+                peers,
+                timeout,
+                relayUrl,
+                relayUrl);
+
+        List<BaseTag> tags = new ArrayList<>();
+
+        return new GenericEvent(
+                poolIdentity.getPublicKey(),
+                Kind.CONJOIN_POOL.getValue(),
+                tags,
+                content);
     }
 
     @Override

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/NostrPublisherTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/NostrPublisherTest.java
@@ -1,0 +1,61 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NostrPublisherTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private GenericEvent event(Identity poolIdentity) {
+        return NostrPublisher.buildPoolEvent(poolIdentity, "0123456789abcdef", "regtest", "0.001", "3",
+                1750000000L, "wss://nos.lol");
+    }
+
+    @Test
+    public void announcementIsAuthoredByThePoolKeyItAdvertises() throws Exception {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        GenericEvent event = event(poolIdentity);
+
+        JsonNode content = MAPPER.readTree(event.getContent());
+
+        // other joinstr clients drop a pool event whose author is not the pool key in its content
+        assertEquals(event.getPubKey().toString(), content.get("public_key").asText());
+        assertEquals(poolIdentity.getPublicKey().toString(), content.get("public_key").asText());
+    }
+
+    @Test
+    public void announcementUsesTheCoinjoinPoolKind() {
+        assertEquals(2022, event(Identity.generateRandomIdentity()).getKind());
+    }
+
+    @Test
+    public void eachPoolGetsItsOwnAnnouncerKey() throws Exception {
+        // a shared announcer key would publicly link every pool created in one session
+        JsonNode first = MAPPER.readTree(event(Identity.generateRandomIdentity()).getContent());
+        JsonNode second = MAPPER.readTree(event(Identity.generateRandomIdentity()).getContent());
+
+        assertNotEquals(first.get("public_key").asText(), second.get("public_key").asText());
+    }
+
+    @Test
+    public void announcementCarriesTheFieldsOtherClientsRequire() throws Exception {
+        JsonNode content = MAPPER.readTree(event(Identity.generateRandomIdentity()).getContent());
+
+        for(String field : new String[] {"id", "public_key", "denomination", "peers", "timeout", "relay"}) {
+            assertTrue(content.has(field), "missing required field: " + field);
+        }
+        assertEquals("0123456789abcdef", content.get("id").asText());
+        assertEquals("regtest", content.get("network").asText());
+        assertEquals(1750000000L, content.get("timeout").asLong());
+        assertEquals("wss://nos.lol", content.get("relay").asText());
+        assertEquals("wss://nos.lol", content.get("relays").get(0).asText());
+    }
+}


### PR DESCRIPTION
Closes #49.

The kind 2022 pool announcement was signed by a process-wide static `SENDER` identity while the `public_key` in its content was a different, per-pool identity. The Electrum joinstr plugin drops any announcement whose author is not the pool key it names (`plugin/joinstr.py:1093-1098`), so no Electrum peer could see a pool created here.

The static also meant every pool created in one Sparrow session was published under the same announcer pubkey and was therefore publicly linkable, which NIP.md rules out ("All events are published with a new pubkey").

## Changes

`fix: sign the pool announcement with the pool key it advertises`

- Remove the `SENDER` static and sign the announcement, and the Tor request context, with the per-pool `poolIdentity`.
- Extract the announcement body into `buildPoolEvent`, so the signing key and the advertised key can be asserted together in a test without touching a relay.
- Drop the `logger.info("Public key: ...")` line, which logged the announcer key on every pool creation.

`test: cover the pool announcement author and required fields`

Four cases in a new `NostrPublisherTest`:

- the event author equals the `public_key` in the content, which is the invariant the Electrum plugin checks
- the kind is 2022
- two pools do not share an announcer key
- the content carries `id`, `public_key`, `denomination`, `peers`, `timeout` and `relay`, the fields the plugin requires before it will parse a pool at all (`plugin/joinstr.py:1088-1092`)

## Verification

`./gradlew :test --tests '*NostrPublisherTest*'` passes, 4 tests. Reverting the fix so the event is authored by a different key makes `announcementIsAuthoredByThePoolKeyItAdvertises` fail, so the test does hold the behaviour down.

Full suite `./gradlew test` is green on Temurin 22.

This is one of four independent interop blockers. On its own it makes Sparrow pools visible to Electrum peers, but joining still fails until #50 and #51 are fixed.
