### PR TITLE
fix: accept a fractional pool fee rate

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -45,7 +45,7 @@ public class CoinjoinHandler {
     private final String relay;
     private final int numPeers;
     private final long poolAmountSats;
-    private long feeRate;
+    private double feeRate;
     private final Consumer<String> statusCallback;
 
     private final List<String> outputAddresses = new CopyOnWriteArrayList<>();
@@ -80,7 +80,7 @@ public class CoinjoinHandler {
         this.poolAmountSats = CoinjoinMath.denominationToSats(pool.getDenomination());
     }
 
-    public void setFeeRate(long feeRate) {
+    public void setFeeRate(double feeRate) {
         this.feeRate = feeRate;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -48,14 +48,26 @@ public final class CoinjoinMath {
         return value >= minInputSats(poolAmountSats) && value <= maxInputSats(poolAmountSats);
     }
 
-    public static long feePerOutput(long feeRate, int numPeers) {
+    public static long feePerOutput(double feeRate, int numPeers) {
+        if (numPeers <= 0) {
+            return 0;
+        }
         long estimatedTxSize = ESTIMATED_VSIZE_PER_PEER * numPeers;
-        long totalFee = feeRate * estimatedTxSize;
-        return numPeers > 0 ? totalFee / numPeers : 0;
+        long totalFee = (long) (feeRate * estimatedTxSize);
+        return totalFee / numPeers;
     }
 
-    public static long outputAmount(long poolAmountSats, long feeRate, int numPeers) {
+    public static long outputAmount(long poolAmountSats, double feeRate, int numPeers) {
         return poolAmountSats - feePerOutput(feeRate, numPeers);
+    }
+
+    /** Render a fee rate without a trailing ".0" when it is a whole number of sat/vB. */
+    public static String formatFeeRate(double feeRate) {
+        if (feeRate == Math.rint(feeRate) && Double.isFinite(feeRate)) {
+            return String.valueOf((long) feeRate);
+        }
+        return new java.math.BigDecimal(feeRate).setScale(2, java.math.RoundingMode.HALF_UP)
+                .stripTrailingZeros().toPlainString();
     }
 
     /** An output reduced to the two fields coinjoin validation cares about. */

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -22,8 +22,8 @@ public class JoinPoolHandler {
     private static final Logger logger = Logger.getLogger(JoinPoolHandler.class.getName());
 
     /** Absolute bounds on an accepted pool fee rate (sat/vB). */
-    static final long MIN_FEE_RATE = 1;
-    static final long MAX_FEE_RATE = 100;
+    static final double MIN_FEE_RATE = 1;
+    static final double MAX_FEE_RATE = 100;
 
     private Identity joinIdentity;
     private JoinstrPool pool;
@@ -31,7 +31,7 @@ public class JoinPoolHandler {
     private NostrListener credentialsListener;
     private Identity poolIdentity;
     private int numPeers;
-    private long feeRate = 1;
+    private double feeRate = 1;
     private Consumer<String> statusCallback;
     private CoinjoinHandler coinjoinHandler;
 
@@ -39,9 +39,12 @@ public class JoinPoolHandler {
      * Accept a fee rate that stays within a tolerance band of the advertised rate (it may drift
      * between pool creation and the coinjoin) and within the absolute [MIN_FEE_RATE, MAX_FEE_RATE] range.
      */
-    static boolean isFeeRateAcceptable(long feeRate, long advertisedFeeRate) {
-        long lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
-        long hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
+    static boolean isFeeRateAcceptable(double feeRate, double advertisedFeeRate) {
+        if (!Double.isFinite(feeRate) || !Double.isFinite(advertisedFeeRate)) {
+            return false;
+        }
+        double lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
+        double hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
         return feeRate >= lo && feeRate <= hi;
     }
 
@@ -113,8 +116,8 @@ public class JoinPoolHandler {
 
             Platform.runLater(() -> statusCallback.accept("Credentials received"));
 
-            long advertisedFeeRate = pool.getParsedFeeRate();
-            long credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
+            double advertisedFeeRate = pool.getParsedFeeRate();
+            double credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
 
             if (!isFeeRateAcceptable(credentialsFeeRate, advertisedFeeRate)) {
                 logger.severe("Rejecting pool: fee rate " + credentialsFeeRate
@@ -140,7 +143,7 @@ public class JoinPoolHandler {
     /**
      * Start the coinjoin flow using CoinjoinHandler
      */
-    private void startCoinjoinFlow(long feeRate) {
+    private void startCoinjoinFlow(double feeRate) {
         try {
             Map<com.sparrowwallet.drongo.wallet.Wallet, Storage> openWallets = AppServices.get().getOpenWallets();
             if (openWallets.isEmpty()) {
@@ -251,15 +254,15 @@ public class JoinPoolHandler {
                 logger.info("Selected UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() + " value="
                         + selectedUtxo.getValue());
 
-                long feePerOutput = feeRate * 150;
-                long outputAmount = poolAmountSats - feePerOutput;
+                long outputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate,
+                        coinjoinHandler.getNumPeers());
                 long myFee = selectedUtxo.getValue() - outputAmount;
 
                 java.util.Optional<ButtonType> confirm = AppServices.showAlertDialog(
                         "Confirm Coinjoin Input",
                         "Input: " + selectedUtxo.getValue() + " sats\n" +
                                 "Output: " + outputAmount + " sats\n" +
-                                "Fee: " + myFee + " sats (" + feeRate + " sat/vB)\n\n" +
+                                "Fee: " + myFee + " sats (" + CoinjoinMath.formatFeeRate(feeRate) + " sat/vB)\n\n" +
                                 "Proceed with signing?",
                         Alert.AlertType.CONFIRMATION, ButtonType.CANCEL, ButtonType.OK);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -8,7 +8,7 @@ public class JoinstrMessage {
     private String psbt;
     private String id;
     private String private_key;
-    private Long fee_rate;
+    private Double fee_rate;
 
     public String getType() {
         return type;
@@ -50,11 +50,11 @@ public class JoinstrMessage {
         this.private_key = private_key;
     }
 
-    public Long getFeeRate() {
+    public Double getFeeRate() {
         return fee_rate;
     }
 
-    public void setFeeRate(Long fee_rate) {
+    public void setFeeRate(Double fee_rate) {
         this.fee_rate = fee_rate;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -90,12 +90,20 @@ public class JoinstrPool {
         this.feeRate = feeRate;
     }
 
-    public long getParsedFeeRate() {
+    /**
+      * The advertised fee rate in sat/vB. Pools publish it as a JSON number, which other joinstr
+      * clients derive from their own estimator and so is usually fractional.
+      */
+    public double getParsedFeeRate() {
         try {
             if (feeRate == null || feeRate.trim().isEmpty()) {
                 return 1;
             }
-            return Long.parseLong(feeRate.trim());
+            double parsed = Double.parseDouble(feeRate.trim());
+            if (!Double.isFinite(parsed) || parsed <= 0) {
+                return 1;
+            }
+            return parsed;
         } catch (Exception e) {
             return 1;
         }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -87,7 +87,7 @@ public class JoinstrInfoPane extends VBox {
             relayValueLabel.setText(pool.getRelay());
             pubkeyValueLabel.setText(pool.getPubkey());
             denominationValueLabel.setText(pool.getDenomination());
-            feeRateValueLabel.setText(pool.getParsedFeeRate() + " sat/vB");
+            feeRateValueLabel.setText(com.sparrowwallet.sparrow.joinstr.CoinjoinMath.formatFeeRate(pool.getParsedFeeRate()) + " sat/vB");
             statusValueLabel.textProperty().bind(pool.statusProperty());
         } else {
             clearPoolInfo();

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
@@ -49,6 +49,31 @@ public class FeeRateValidationTest {
     }
 
     @Test
+    public void poolParsesFractionalAdvertisedFeeRate() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
+        pool.setFeeRate("2.5");
+        assertEquals(2.5, pool.getParsedFeeRate());
+        // a whole rate written as a decimal is what the electrum plugin usually publishes
+        pool.setFeeRate("3.0");
+        assertEquals(3.0, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void fractionalRatesAreComparedAgainstTheAdvertisedBand() {
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(3.0, 2.5));
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(2.5, 2.5));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(5.1, 2.5));
+        // the advertised rate no longer collapses to 1, so a normal pool is not refused
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(3.0, 3.0));
+    }
+
+    @Test
+    public void nonFiniteRatesAreRefused() {
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(Double.NaN, 4));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(4, Double.POSITIVE_INFINITY));
+    }
+
+    @Test
     public void poolFeeRateDefaultsOnMalformedValue() {
         JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
         pool.setFeeRate("abc");
@@ -57,5 +82,15 @@ public class FeeRateValidationTest {
         assertEquals(1, pool.getParsedFeeRate());
         pool.setFeeRate(null);
         assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("0");
+        assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("-4");
+        assertEquals(1, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void feeRateIsRenderedWithoutATrailingZero() {
+        assertEquals("3", CoinjoinMath.formatFeeRate(3.0));
+        assertEquals("2.5", CoinjoinMath.formatFeeRate(2.5));
     }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
@@ -41,7 +41,7 @@ public class JoinstrMessageTest {
         JoinstrMessage message = new JoinstrMessage();
         message.setType("credentials");
         message.setPrivateKey("deadbeef");
-        message.setFeeRate(5L);
+        message.setFeeRate(5.0);
 
         String json = message.toJson();
 
@@ -59,7 +59,29 @@ public class JoinstrMessageTest {
 
         assertEquals("credentials", parsed.getType());
         assertEquals("deadbeef", parsed.getPrivateKey());
-        assertEquals(7L, parsed.getFeeRate());
+        assertEquals(7.0, parsed.getFeeRate());
+    }
+
+    /**
+     * The electrum plugin derives fee_rate from its own estimator (fee_per_kb / 1000), so the
+     * value on the wire is usually fractional. Parsing it must not throw.
+     */
+    @Test
+    public void parsesFractionalFeeRate() {
+        String json = "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":2.5}";
+
+        JoinstrMessage parsed = JoinstrMessage.fromJson(json);
+
+        assertEquals(2.5, parsed.getFeeRate());
+        assertEquals("deadbeef", parsed.getPrivateKey());
+    }
+
+    @Test
+    public void parsesWholeFeeRateWrittenAsDecimal() {
+        JoinstrMessage parsed = JoinstrMessage.fromJson(
+                "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":3.0}");
+
+        assertEquals(3.0, parsed.getFeeRate());
     }
 
     @Test


### PR DESCRIPTION
Closes #51.

`JoinstrMessage.fee_rate` was a `Long`, but the Electrum joinstr plugin derives `fee_rate` from its own estimator (`fee_per_kb / 1000` in `fetch_hour_fee`, `plugin/joinstr.py:1263-1273`) and publishes it as a JSON float. Gson throws on a fractional value for a `Long` field, the exception was swallowed by the catch in `NostrListener.java:128-130`, and the credentials were dropped with only a FINE log line.

Confirmed against the bundled Gson:

```
Long field THREW: JsonSyntaxException: java.lang.NumberFormatException: Expected a long but was 2.5
Double field parsed: 2.5
```

The same problem existed on the announcement side. `JoinstrPool.getParsedFeeRate` used `Long.parseLong`, so an advertised rate of `3.0` threw and silently became `1`. `isFeeRateAcceptable(3, 1)` then computed `hi = min(100, 2)` and refused the pool with "Fee rate out of range", so a normal Electrum pool was rejected twice over.

## Changes

`fix: accept a fractional pool fee rate`

- `JoinstrMessage.fee_rate` is now a `Double`.
- `JoinstrPool.getParsedFeeRate` returns `double`, parses with `Double.parseDouble`, and falls back to 1 for a value that is unparseable, non-finite or not positive. Previously a zero or negative advertised rate parsed fine and was carried into the fee maths.
- `CoinjoinMath.feePerOutput` and `outputAmount` take a `double` rate. The total fee is truncated before the per-output division, matching `int(fee_rate * vsize) // output_ct` in the plugin (`plugin/joinstr.py:1553-1557`).
- `JoinPoolHandler` keeps the `[1, 100]` absolute band and the half to double drift band, now computed in decimal, and refuses a non-finite rate outright.
- `JoinPoolHandler` no longer recomputes the fee inline as `feeRate * 150` for the confirmation dialog. It calls `CoinjoinMath.outputAmount`, so the number shown to the user and the number signed into the PSBT come from one place. Behaviour is unchanged at the current constant.
- Added `CoinjoinMath.formatFeeRate` so the info pane and the confirmation dialog show "3 sat/vB" rather than "3.0 sat/vB".

`test: cover fractional pool fee rates`

- `JoinstrMessageTest`: parsing `"fee_rate": 2.5` and `"fee_rate": 3.0` from a foreign credentials payload. Both threw before.
- `FeeRateValidationTest`: fractional advertised rates, the band comparison at fractional values, a regression case that a 3.0 pool advertising 3.0 is accepted (it was refused before, because the advertised side collapsed to 1), non-finite rates refused, zero and negative advertised rates falling back to 1, and the display formatting.

## Verification

`./gradlew :test` is green: 45 tests across the six joinstr test classes, no failures.

The `Expected a long but was 2.5` behaviour above was reproduced directly against gson before the change.

This is one of four independent interop blockers, and the one that stops this client joining an Electrum pool. #49 covers the other direction. #50 and #52 are still needed for a mixed pool to complete.
