### PR TITLE
fix: estimate the coinjoin fee at the same vsize per peer as other clients

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -20,8 +20,13 @@ public final class CoinjoinMath {
     public static final long MAX_UTXO_MARGIN = 5000;
     /** Inputs are signed with SIGHASH_ALL | SIGHASH_ANYONECANPAY (0x81) per the joinstr NIP. */
     public static final SigHash INPUT_SIGHASH = SigHash.ANYONECANPAY_ALL;
-    /** Rough vsize charged per peer (one input + one output) when estimating the fee. */
-    private static final long ESTIMATED_VSIZE_PER_PEER = 150L;
+    /**
+     * Vsize charged per peer (one input plus one output) when estimating the fee. Every client in a
+     * pool must use the same figure or they derive different output amounts and reject each other's
+     * registration PSBTs. This matches the reference implementation, which estimates the whole
+     * transaction at 100 vB per output.
+     */
+    private static final long ESTIMATED_VSIZE_PER_PEER = 100L;
 
     private CoinjoinMath() {
     }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMathTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMathTest.java
@@ -60,11 +60,36 @@ public class CoinjoinMathTest {
     @Test
     public void outputAmountSubtractsFee() {
         long pool = 100_000L;
-        // feeRate 1 sat/vB, 150 vB per peer -> 150 sats fee per output regardless of peer count
-        assertEquals(150L, CoinjoinMath.feePerOutput(1, 3));
-        assertEquals(150L, CoinjoinMath.feePerOutput(1, 5));
-        assertEquals(pool - 150L, CoinjoinMath.outputAmount(pool, 1, 3));
-        assertEquals(pool - 1500L, CoinjoinMath.outputAmount(pool, 10, 3));
+        // feeRate 1 sat/vB, 100 vB per peer, so 100 sats per output regardless of peer count
+        assertEquals(100L, CoinjoinMath.feePerOutput(1, 3));
+        assertEquals(100L, CoinjoinMath.feePerOutput(1, 5));
+        assertEquals(pool - 100L, CoinjoinMath.outputAmount(pool, 1, 3));
+        assertEquals(pool - 1000L, CoinjoinMath.outputAmount(pool, 10, 3));
+    }
+
+    /**
+     * The per-output fee has to match what other joinstr clients derive, or the output amounts
+     * differ and every registration PSBT is rejected on both sides. The reference implementation
+     * computes int(fee_rate * 100 * output_ct) // output_ct.
+     */
+    @Test
+    public void feePerOutputMatchesTheReferenceEstimate() {
+        for(int peers = 2; peers <= 10; peers++) {
+            for(long rate : new long[] {1, 2, 5, 13, 100}) {
+                long reference = (rate * 100L * peers) / peers;
+                assertEquals(reference, CoinjoinMath.feePerOutput(rate, peers),
+                        "rate=" + rate + " peers=" + peers);
+            }
+        }
+    }
+
+    @Test
+    public void outputAmountIsIndependentOfPeerCount() {
+        long pool = 250_000L;
+        long expected = CoinjoinMath.outputAmount(pool, 4, 2);
+        for(int peers = 2; peers <= 8; peers++) {
+            assertEquals(expected, CoinjoinMath.outputAmount(pool, 4, peers));
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #52.

`CoinjoinMath.ESTIMATED_VSIZE_PER_PEER` was 150. The Electrum joinstr plugin estimates the transaction at 100 vB per output (`plugin/joinstr.py:1553-1557`):

```python
estimated_vbyte_size = 100 * output_ct
estimated_fee = int(session.pool_fee_rate * estimated_vbyte_size)
per_output_fee = estimated_fee // output_ct
session.output_amount = pool_amount_sats - per_output_fee
```

For the same pool the two clients therefore derived output amounts differing by `50 * fee_rate` sats per output, and each side's output validation rejected every registration PSBT the other published.

## Changes

`fix: estimate the coinjoin fee at the same vsize per peer as other clients`

One constant, 150 to 100, with a comment saying why it is not a free parameter.

`test: pin the per-output fee to the reference estimate`

- Updated the existing `outputAmountSubtractsFee` expectations.
- Added `feePerOutputMatchesTheReferenceEstimate`, which checks the value against `int(rate * 100 * peers) // peers` across peer counts 2 to 10 and rates 1, 2, 5, 13 and 100, so a future change to the constant or the rounding fails here rather than in a live pool.
- Added `outputAmountIsIndependentOfPeerCount`, which records the property the current formula has.

## Verification

`./gradlew :test` green, `CoinjoinMathTest` now 14 tests.
