### PR TITLE
fix: send complete pool credentials with the announced types

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -45,7 +45,7 @@ public class CoinjoinHandler {
     private final String relay;
     private final int numPeers;
     private final long poolAmountSats;
-    private long feeRate;
+    private double feeRate;
     private final Consumer<String> statusCallback;
 
     private final List<String> outputAddresses = new CopyOnWriteArrayList<>();
@@ -80,7 +80,7 @@ public class CoinjoinHandler {
         this.poolAmountSats = CoinjoinMath.denominationToSats(pool.getDenomination());
     }
 
-    public void setFeeRate(long feeRate) {
+    public void setFeeRate(double feeRate) {
         this.feeRate = feeRate;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -48,14 +48,26 @@ public final class CoinjoinMath {
         return value >= minInputSats(poolAmountSats) && value <= maxInputSats(poolAmountSats);
     }
 
-    public static long feePerOutput(long feeRate, int numPeers) {
+    public static long feePerOutput(double feeRate, int numPeers) {
+        if (numPeers <= 0) {
+            return 0;
+        }
         long estimatedTxSize = ESTIMATED_VSIZE_PER_PEER * numPeers;
-        long totalFee = feeRate * estimatedTxSize;
-        return numPeers > 0 ? totalFee / numPeers : 0;
+        long totalFee = (long) (feeRate * estimatedTxSize);
+        return totalFee / numPeers;
     }
 
-    public static long outputAmount(long poolAmountSats, long feeRate, int numPeers) {
+    public static long outputAmount(long poolAmountSats, double feeRate, int numPeers) {
         return poolAmountSats - feePerOutput(feeRate, numPeers);
+    }
+
+    /** Render a fee rate without a trailing ".0" when it is a whole number of sat/vB. */
+    public static String formatFeeRate(double feeRate) {
+        if (feeRate == Math.rint(feeRate) && Double.isFinite(feeRate)) {
+            return String.valueOf((long) feeRate);
+        }
+        return new java.math.BigDecimal(feeRate).setScale(2, java.math.RoundingMode.HALF_UP)
+                .stripTrailingZeros().toPlainString();
     }
 
     /** An output reduced to the two fields coinjoin validation cares about. */

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -22,8 +22,8 @@ public class JoinPoolHandler {
     private static final Logger logger = Logger.getLogger(JoinPoolHandler.class.getName());
 
     /** Absolute bounds on an accepted pool fee rate (sat/vB). */
-    static final long MIN_FEE_RATE = 1;
-    static final long MAX_FEE_RATE = 100;
+    static final double MIN_FEE_RATE = 1;
+    static final double MAX_FEE_RATE = 100;
 
     private Identity joinIdentity;
     private JoinstrPool pool;
@@ -31,7 +31,7 @@ public class JoinPoolHandler {
     private NostrListener credentialsListener;
     private Identity poolIdentity;
     private int numPeers;
-    private long feeRate = 1;
+    private double feeRate = 1;
     private Consumer<String> statusCallback;
     private CoinjoinHandler coinjoinHandler;
 
@@ -39,9 +39,12 @@ public class JoinPoolHandler {
      * Accept a fee rate that stays within a tolerance band of the advertised rate (it may drift
      * between pool creation and the coinjoin) and within the absolute [MIN_FEE_RATE, MAX_FEE_RATE] range.
      */
-    static boolean isFeeRateAcceptable(long feeRate, long advertisedFeeRate) {
-        long lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
-        long hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
+    static boolean isFeeRateAcceptable(double feeRate, double advertisedFeeRate) {
+        if (!Double.isFinite(feeRate) || !Double.isFinite(advertisedFeeRate)) {
+            return false;
+        }
+        double lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
+        double hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
         return feeRate >= lo && feeRate <= hi;
     }
 
@@ -113,8 +116,8 @@ public class JoinPoolHandler {
 
             Platform.runLater(() -> statusCallback.accept("Credentials received"));
 
-            long advertisedFeeRate = pool.getParsedFeeRate();
-            long credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
+            double advertisedFeeRate = pool.getParsedFeeRate();
+            double credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
 
             if (!isFeeRateAcceptable(credentialsFeeRate, advertisedFeeRate)) {
                 logger.severe("Rejecting pool: fee rate " + credentialsFeeRate
@@ -140,7 +143,7 @@ public class JoinPoolHandler {
     /**
      * Start the coinjoin flow using CoinjoinHandler
      */
-    private void startCoinjoinFlow(long feeRate) {
+    private void startCoinjoinFlow(double feeRate) {
         try {
             Map<com.sparrowwallet.drongo.wallet.Wallet, Storage> openWallets = AppServices.get().getOpenWallets();
             if (openWallets.isEmpty()) {
@@ -251,15 +254,15 @@ public class JoinPoolHandler {
                 logger.info("Selected UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() + " value="
                         + selectedUtxo.getValue());
 
-                long feePerOutput = feeRate * 150;
-                long outputAmount = poolAmountSats - feePerOutput;
+                long outputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate,
+                        coinjoinHandler.getNumPeers());
                 long myFee = selectedUtxo.getValue() - outputAmount;
 
                 java.util.Optional<ButtonType> confirm = AppServices.showAlertDialog(
                         "Confirm Coinjoin Input",
                         "Input: " + selectedUtxo.getValue() + " sats\n" +
                                 "Output: " + outputAmount + " sats\n" +
-                                "Fee: " + myFee + " sats (" + feeRate + " sat/vB)\n\n" +
+                                "Fee: " + myFee + " sats (" + CoinjoinMath.formatFeeRate(feeRate) + " sat/vB)\n\n" +
                                 "Proceed with signing?",
                         Alert.AlertType.CONFIRMATION, ButtonType.CANCEL, ButtonType.OK);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -8,7 +8,7 @@ public class JoinstrMessage {
     private String psbt;
     private String id;
     private String private_key;
-    private Long fee_rate;
+    private Double fee_rate;
 
     public String getType() {
         return type;
@@ -50,11 +50,11 @@ public class JoinstrMessage {
         this.private_key = private_key;
     }
 
-    public Long getFeeRate() {
+    public Double getFeeRate() {
         return fee_rate;
     }
 
-    public void setFeeRate(Long fee_rate) {
+    public void setFeeRate(Double fee_rate) {
         this.fee_rate = fee_rate;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -27,6 +27,7 @@ public class JoinstrPool {
     private final SimpleStringProperty status;
     private final javafx.beans.property.SimpleIntegerProperty connectedPeers;
     private String privateKey;
+    private String poolId = "";
     private String feeRate = "1";
     private JoinPoolHandler handler;
 
@@ -76,6 +77,50 @@ public class JoinstrPool {
 
     public String getPrivateKey() {
         return privateKey;
+    }
+
+    /** The pool id from the announcement, which peers echo back in the credentials. */
+    public String getPoolId() {
+        return poolId;
+    }
+
+    public void setPoolId(String poolId) {
+        this.poolId = poolId == null ? "" : poolId;
+    }
+
+    /**
+     * The credentials a joiner is sent. Every field the pool announced is repeated here with the
+     * same type, because a joiner checks the credentials against the announcement it chose before
+     * trusting the private key inside them.
+     */
+    public Map<String, Object> toCredentials() {
+        Map<String, Object> credentials = new LinkedHashMap<>();
+        credentials.put("id", poolId);
+        credentials.put("public_key", getPubkey());
+        credentials.put("denomination", asNumber(getDenomination(), 0d));
+        credentials.put("peers", getParsedPeers());
+        credentials.put("timeout", asLong(getTimeout()));
+        credentials.put("relay", getRelay());
+        credentials.put("fee_rate", getParsedFeeRate());
+        credentials.put("private_key", privateKey);
+        return credentials;
+    }
+
+    private static double asNumber(String value, double fallback) {
+        try {
+            double parsed = Double.parseDouble(value.trim());
+            return Double.isFinite(parsed) ? parsed : fallback;
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+
+    private static long asLong(String value) {
+        try {
+            return Long.parseLong(value.trim());
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
     public void setPrivateKey(String privateKey) {
@@ -280,6 +325,7 @@ public class JoinstrPool {
         private final String timeout;
         private final String status;
         private final String privateKey;
+        private final String poolId;
         private final String feeRate;
 
         public JoinstrPoolData(JoinstrPool joinstrPool) {
@@ -290,6 +336,7 @@ public class JoinstrPool {
             this.timeout = joinstrPool.getTimeout();
             this.status = joinstrPool.getStatus();
             this.privateKey = joinstrPool.getPrivateKey();
+            this.poolId = joinstrPool.getPoolId();
             this.feeRate = joinstrPool.getFeeRate();
         }
 
@@ -298,6 +345,7 @@ public class JoinstrPool {
             if (feeRate != null) {
                 pool.setFeeRate(feeRate);
             }
+            pool.setPoolId(poolId);
             return pool;
         }
     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -90,12 +90,20 @@ public class JoinstrPool {
         this.feeRate = feeRate;
     }
 
-    public long getParsedFeeRate() {
+    /**
+      * The advertised fee rate in sat/vB. Pools publish it as a JSON number, which other joinstr
+      * clients derive from their own estimator and so is usually fractional.
+      */
+    public double getParsedFeeRate() {
         try {
             if (feeRate == null || feeRate.trim().isEmpty()) {
                 return 1;
             }
-            return Long.parseLong(feeRate.trim());
+            double parsed = Double.parseDouble(feeRate.trim());
+            if (!Double.isFinite(parsed) || parsed <= 0) {
+                return 1;
+            }
+            return parsed;
         } catch (Exception e) {
             return 1;
         }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
@@ -132,6 +132,10 @@ public class NewPoolController extends JoinstrFormController {
 
                 JoinstrPool pool = new JoinstrPool(joinstrEvent.relay, joinstrEvent.public_key,
                         joinstrEvent.denomination, joinstrEvent.peers, joinstrEvent.timeout, poolPrivateKey);
+                pool.setPoolId(joinstrEvent.id);
+                if (joinstrEvent.fee_rate != null) {
+                    pool.setFeeRate(joinstrEvent.fee_rate);
+                }
                 updatePoolStore(pool);
 
                 getJoinstrController().setSelectedPool(pool);
@@ -170,7 +174,7 @@ public class NewPoolController extends JoinstrFormController {
             coinjoinHandler = new CoinjoinHandler(poolIdentity, pool, wallet, storage, status -> {
                 javafx.application.Platform.runLater(() -> pool.setStatus(status));
             });
-            coinjoinHandler.setFeeRate(1);
+            coinjoinHandler.setFeeRate(pool.getParsedFeeRate());
 
             coinjoinHandler.setOnReadyForInputCallback(() -> {
                 showUtxoSelectionDialog(wallet);
@@ -179,15 +183,7 @@ public class NewPoolController extends JoinstrFormController {
             coinjoinHandler.startOutputPhase(myOutputAddress);
             logger.info("Pool creator started coinjoin flow with output: " + myOutputAddress);
 
-            Map<String, String> poolCredentials = new java.util.HashMap<>();
-            poolCredentials.put("id", pool.getPubkey());
-            poolCredentials.put("private_key", poolPrivateKey);
-            poolCredentials.put("relay", pool.getRelay());
-            poolCredentials.put("public_key", pool.getPubkey());
-            poolCredentials.put("peers", pool.getPeers());
-            poolCredentials.put("timeout", pool.getTimeout());
-
-            shareCredentials(poolIdentity, pool.getRelay(), poolCredentials);
+            shareCredentials(poolIdentity, pool.getRelay(), pool.toCredentials());
 
         } catch (Exception e) {
             logger.severe("Error starting creator coinjoin flow: " + e.getMessage());
@@ -245,7 +241,7 @@ public class NewPoolController extends JoinstrFormController {
 
     }
 
-    public static void shareCredentials(Identity poolIdentity, String relayUrl, Map<String, String> poolCredentials) {
+    public static void shareCredentials(Identity poolIdentity, String relayUrl, Map<String, Object> poolCredentials) {
 
         NostrListener listener = new NostrListener(poolIdentity, relayUrl, poolCredentials);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -32,11 +32,11 @@ public class NostrListener implements AutoCloseable {
     private final String relay;
     private Client client;
     private Consumer<String> messageHandler;
-    private final Map<String, String> poolCredentials;
+    private final Map<String, Object> poolCredentials;
     private static final ConsoleHandler consoleLogHandler = new ConsoleHandler();
     private transient Handler eventMessageHandler = null;
 
-    public NostrListener(Identity identity, String relay, Map<String, String> poolCredentials) {
+    public NostrListener(Identity identity, String relay, Map<String, Object> poolCredentials) {
         this.identity = identity;
         this.relay = relay;
         this.poolCredentials = poolCredentials;
@@ -140,14 +140,6 @@ public class NostrListener implements AutoCloseable {
         }
 
         try {
-            Gson gson = new Gson();
-            Map<String, Object> credentialsMap = new LinkedHashMap<>();
-            credentialsMap.put("id", poolCredentials.get("id"));
-            credentialsMap.put("public_key", poolCredentials.get("public_key"));
-            credentialsMap.put("denomination", poolCredentials.get("denomination"));
-            credentialsMap.put("peers", poolCredentials.get("peers"));
-            credentialsMap.put("timeout", poolCredentials.get("timeout"));
-
             if (AppServices.isTorRunning()) {
                 try {
                     Client.getInstance().disconnect();
@@ -158,10 +150,9 @@ public class NostrListener implements AutoCloseable {
             }
                 TorUtils.logTorIp();
 
-            credentialsMap.put("relay", poolCredentials.get("relay"));
-            credentialsMap.put("private_key", poolCredentials.get("private_key"));
-            credentialsMap.put("fee_rate", poolCredentials.get("fee_rate"));
-            String credentialsJson = gson.toJson(credentialsMap);
+            // Send the payload as built. Re-picking keys here silently dropped any the caller
+            // had not supplied, and turned every value into a string.
+            String credentialsJson = new Gson().toJson(poolCredentials);
 
             List<BaseTag> tags = new ArrayList<>();
             tags.add(new PubKeyTag(new PublicKey(requesterPubkey)));

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -192,6 +192,10 @@ public class OtherPoolsController extends JoinstrFormController {
                                                 pool.setFeeRate(poolData.get("fee_rate").asText());
                                             }
 
+                                            if (poolData.has("id")) {
+                                                pool.setPoolId(poolData.get("id").asText());
+                                            }
+
                                             if (pools.stream().noneMatch(
                                                     (p) -> Objects.equals(p.getPubkey(), pool.getPubkey())) &&
                                                     myPools.stream().noneMatch(

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -87,7 +87,7 @@ public class JoinstrInfoPane extends VBox {
             relayValueLabel.setText(pool.getRelay());
             pubkeyValueLabel.setText(pool.getPubkey());
             denominationValueLabel.setText(pool.getDenomination());
-            feeRateValueLabel.setText(pool.getParsedFeeRate() + " sat/vB");
+            feeRateValueLabel.setText(com.sparrowwallet.sparrow.joinstr.CoinjoinMath.formatFeeRate(pool.getParsedFeeRate()) + " sat/vB");
             statusValueLabel.textProperty().bind(pool.statusProperty());
         } else {
             clearPoolInfo();

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
@@ -49,6 +49,31 @@ public class FeeRateValidationTest {
     }
 
     @Test
+    public void poolParsesFractionalAdvertisedFeeRate() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
+        pool.setFeeRate("2.5");
+        assertEquals(2.5, pool.getParsedFeeRate());
+        // a whole rate written as a decimal is what the electrum plugin usually publishes
+        pool.setFeeRate("3.0");
+        assertEquals(3.0, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void fractionalRatesAreComparedAgainstTheAdvertisedBand() {
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(3.0, 2.5));
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(2.5, 2.5));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(5.1, 2.5));
+        // the advertised rate no longer collapses to 1, so a normal pool is not refused
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(3.0, 3.0));
+    }
+
+    @Test
+    public void nonFiniteRatesAreRefused() {
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(Double.NaN, 4));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(4, Double.POSITIVE_INFINITY));
+    }
+
+    @Test
     public void poolFeeRateDefaultsOnMalformedValue() {
         JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
         pool.setFeeRate("abc");
@@ -57,5 +82,15 @@ public class FeeRateValidationTest {
         assertEquals(1, pool.getParsedFeeRate());
         pool.setFeeRate(null);
         assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("0");
+        assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("-4");
+        assertEquals(1, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void feeRateIsRenderedWithoutATrailingZero() {
+        assertEquals("3", CoinjoinMath.formatFeeRate(3.0));
+        assertEquals("2.5", CoinjoinMath.formatFeeRate(2.5));
     }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrCredentialsTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrCredentialsTest.java
@@ -1,0 +1,130 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A joiner checks the credentials it is sent against the pool announcement it chose, field by
+ * field, before trusting the private key inside them. These cover that the payload this client
+ * sends survives that check.
+ */
+public class JoinstrCredentialsTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Gson GSON = new Gson();
+
+    /** The fields a joiner compares against the announcement. */
+    private static final String[] CHECKED_FIELDS =
+            {"id", "public_key", "denomination", "peers", "timeout", "relay"};
+
+    private static final String ANNOUNCEMENT = "{"
+            + "\"versions\":[\"1\"],"
+            + "\"type\":\"new_pool\","
+            + "\"id\":\"0123456789abcdef\","
+            + "\"network\":\"regtest\","
+            + "\"public_key\":\"e37076afaf4a0054fd144f0b843c174173e7d0620a572572c0a34e6b78023afe\","
+            + "\"denomination\":0.001,"
+            + "\"peers\":3,"
+            + "\"timeout\":1750000000,"
+            + "\"relay\":\"wss://nos.lol\","
+            + "\"fee_rate\":2.5"
+            + "}";
+
+    /** Build the pool the way OtherPoolsController does when it reads an announcement. */
+    private JoinstrPool poolFromAnnouncement() throws Exception {
+        JsonNode a = MAPPER.readTree(ANNOUNCEMENT);
+        JoinstrPool pool = new JoinstrPool(
+                a.get("relay").asText(),
+                a.get("public_key").asText(),
+                a.get("denomination").asText(),
+                a.get("peers").asText(),
+                a.get("timeout").asText(),
+                "aabbcc");
+        pool.setFeeRate(a.get("fee_rate").asText());
+        pool.setPoolId(a.get("id").asText());
+        return pool;
+    }
+
+    @Test
+    public void credentialsCarryEveryRequiredField() throws Exception {
+        Map<String, Object> credentials = poolFromAnnouncement().toCredentials();
+
+        for(String field : CHECKED_FIELDS) {
+            assertTrue(credentials.containsKey(field), "missing field: " + field);
+            assertNotNull(credentials.get(field), "null field: " + field);
+        }
+        // denomination and fee_rate were absent from the map that was serialised, so both went out
+        // as JSON null and the credentials were refused
+        assertNotNull(credentials.get("fee_rate"));
+        assertNotNull(credentials.get("private_key"));
+    }
+
+    @Test
+    public void credentialsIdIsTheAnnouncedPoolIdNotThePubkey() throws Exception {
+        JoinstrPool pool = poolFromAnnouncement();
+        Map<String, Object> credentials = pool.toCredentials();
+
+        assertEquals("0123456789abcdef", credentials.get("id"));
+        assertNotEquals(pool.getPubkey(), credentials.get("id"));
+    }
+
+    @Test
+    public void credentialsMatchTheAnnouncementFieldByField() throws Exception {
+        JsonNode announced = MAPPER.readTree(ANNOUNCEMENT);
+        JsonNode sent = MAPPER.readTree(GSON.toJson(poolFromAnnouncement().toCredentials()));
+
+        for(String field : CHECKED_FIELDS) {
+            JsonNode a = announced.get(field);
+            JsonNode s = sent.get(field);
+            assertNotNull(s, "credentials dropped " + field);
+            if(a.isNumber()) {
+                assertEquals(a.asDouble(), s.asDouble(), field + " changed value");
+                assertTrue(s.isNumber(), field + " must stay a number, was: " + s);
+            } else {
+                assertEquals(a.asText(), s.asText(), field + " changed value");
+            }
+        }
+    }
+
+    /**
+     * The announcement publishes these as JSON numbers. Sending them back as quoted strings fails
+     * the joiner's comparison even when the value is right.
+     */
+    @Test
+    public void numericFieldsAreSerialisedAsNumbers() throws Exception {
+        JsonNode sent = MAPPER.readTree(GSON.toJson(poolFromAnnouncement().toCredentials()));
+
+        assertTrue(sent.get("denomination").isNumber(), "denomination was: " + sent.get("denomination"));
+        assertTrue(sent.get("peers").isNumber(), "peers was: " + sent.get("peers"));
+        assertTrue(sent.get("timeout").isNumber(), "timeout was: " + sent.get("timeout"));
+        assertTrue(sent.get("fee_rate").isNumber(), "fee_rate was: " + sent.get("fee_rate"));
+        assertTrue(sent.get("id").isTextual());
+        assertTrue(sent.get("relay").isTextual());
+    }
+
+    @Test
+    public void credentialsValuesArePositive() throws Exception {
+        JsonNode sent = MAPPER.readTree(GSON.toJson(poolFromAnnouncement().toCredentials()));
+
+        // a joiner rejects the credentials unless all four parse positive
+        assertTrue(sent.get("denomination").asDouble() > 0);
+        assertTrue(sent.get("peers").asInt() > 0);
+        assertTrue(sent.get("fee_rate").asDouble() > 0);
+        assertTrue(sent.get("timeout").asLong() > 0);
+    }
+
+    @Test
+    public void missingPoolIdDoesNotProduceANullField() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000", "aabbcc");
+
+        assertEquals("", pool.getPoolId());
+        assertNotNull(pool.toCredentials().get("id"));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
@@ -41,7 +41,7 @@ public class JoinstrMessageTest {
         JoinstrMessage message = new JoinstrMessage();
         message.setType("credentials");
         message.setPrivateKey("deadbeef");
-        message.setFeeRate(5L);
+        message.setFeeRate(5.0);
 
         String json = message.toJson();
 
@@ -59,7 +59,29 @@ public class JoinstrMessageTest {
 
         assertEquals("credentials", parsed.getType());
         assertEquals("deadbeef", parsed.getPrivateKey());
-        assertEquals(7L, parsed.getFeeRate());
+        assertEquals(7.0, parsed.getFeeRate());
+    }
+
+    /**
+     * The electrum plugin derives fee_rate from its own estimator (fee_per_kb / 1000), so the
+     * value on the wire is usually fractional. Parsing it must not throw.
+     */
+    @Test
+    public void parsesFractionalFeeRate() {
+        String json = "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":2.5}";
+
+        JoinstrMessage parsed = JoinstrMessage.fromJson(json);
+
+        assertEquals(2.5, parsed.getFeeRate());
+        assertEquals("deadbeef", parsed.getPrivateKey());
+    }
+
+    @Test
+    public void parsesWholeFeeRateWrittenAsDecimal() {
+        JoinstrMessage parsed = JoinstrMessage.fromJson(
+                "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":3.0}");
+
+        assertEquals(3.0, parsed.getFeeRate());
     }
 
     @Test


### PR DESCRIPTION
Closes #50.

Based on #70, so it is two commits on top of that branch. Review and merge that one first.

The credentials a pool creator sends in reply to a `join_pool` request were built by re-picking keys out of a `Map<String, String>` that never contained `denomination` or `fee_rate`, so both went out as JSON `null`. `id` was set to the pool pubkey rather than the pool id from the announcement, and because the map was `Map<String, String>`, every numeric field was serialised as a quoted string while the announcement had published it as a number.

A joiner checks the credentials against the announcement it chose before trusting the private key inside them, comparing `id`, `public_key`, `denomination`, `peers`, `timeout` and `relay` (`plugin/joinstr.py:929-936`) and then requiring `denomination`, `peers`, `fee_rate` and `timeout` to parse positive (`plugin/joinstr.py:983-993`). A Sparrow pool failed that on three counts at once, so no Electrum peer could join one.

## Changes

`fix: send complete pool credentials with the announced types`

- `JoinstrPool` carries the announced pool id, persisted alongside the rest of the pool, and gains `toCredentials()` which renders the payload once with the right types: `denomination` and `fee_rate` as numbers, `peers` as an int, `timeout` as a long, the rest as strings.
- `OtherPoolsController` records `id` from a discovered announcement, and `NewPoolController` records the id and fee rate of a pool it just created.
- `NostrListener` takes the payload as `Map<String, Object>` and serialises it as given. The re-pick was the actual defect: it silently dropped anything the caller had not supplied and stringified everything else.
- `NewPoolController` no longer hardcodes `setFeeRate(1)` for the creator's own coinjoin; it uses the pool's own rate, so the creator and the joiners size outputs the same way. The announcement still hardcodes `fee_rate` to 1, which is #64.

`test: cover the credentials payload against a pool announcement`

New `JoinstrCredentialsTest` builds a pool from a representative announcement, the way `OtherPoolsController` does, then checks the payload the creator would send:

- every field a joiner checks is present and non-null
- `id` is the announced pool id and not the pubkey
- each checked field still equals the announced value, compared numerically where the announcement used a number
- `denomination`, `peers`, `timeout` and `fee_rate` are serialised as JSON numbers, not quoted strings
- all four parse positive
- an unset pool id does not become a null field

## Verification

`./gradlew :test` green, 51 tests.

Reproducing the old payload (id set to the pubkey, denomination and fee_rate absent, peers stringified) fails 5 of the 6 new tests, so they hold the fix down rather than just describing it.

## Not included

Electrum also puts `transport` and `vpn_gateway` in its credentials.
