### PR TITLE
fix: accept pool credentials only from the pool that was joined

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -45,7 +45,7 @@ public class CoinjoinHandler {
     private final String relay;
     private final int numPeers;
     private final long poolAmountSats;
-    private long feeRate;
+    private double feeRate;
     private final Consumer<String> statusCallback;
 
     private final List<String> outputAddresses = new CopyOnWriteArrayList<>();
@@ -80,7 +80,7 @@ public class CoinjoinHandler {
         this.poolAmountSats = CoinjoinMath.denominationToSats(pool.getDenomination());
     }
 
-    public void setFeeRate(long feeRate) {
+    public void setFeeRate(double feeRate) {
         this.feeRate = feeRate;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -48,14 +48,26 @@ public final class CoinjoinMath {
         return value >= minInputSats(poolAmountSats) && value <= maxInputSats(poolAmountSats);
     }
 
-    public static long feePerOutput(long feeRate, int numPeers) {
+    public static long feePerOutput(double feeRate, int numPeers) {
+        if (numPeers <= 0) {
+            return 0;
+        }
         long estimatedTxSize = ESTIMATED_VSIZE_PER_PEER * numPeers;
-        long totalFee = feeRate * estimatedTxSize;
-        return numPeers > 0 ? totalFee / numPeers : 0;
+        long totalFee = (long) (feeRate * estimatedTxSize);
+        return totalFee / numPeers;
     }
 
-    public static long outputAmount(long poolAmountSats, long feeRate, int numPeers) {
+    public static long outputAmount(long poolAmountSats, double feeRate, int numPeers) {
         return poolAmountSats - feePerOutput(feeRate, numPeers);
+    }
+
+    /** Render a fee rate without a trailing ".0" when it is a whole number of sat/vB. */
+    public static String formatFeeRate(double feeRate) {
+        if (feeRate == Math.rint(feeRate) && Double.isFinite(feeRate)) {
+            return String.valueOf((long) feeRate);
+        }
+        return new java.math.BigDecimal(feeRate).setScale(2, java.math.RoundingMode.HALF_UP)
+                .stripTrailingZeros().toPlainString();
     }
 
     /** An output reduced to the two fields coinjoin validation cares about. */

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -22,8 +22,8 @@ public class JoinPoolHandler {
     private static final Logger logger = Logger.getLogger(JoinPoolHandler.class.getName());
 
     /** Absolute bounds on an accepted pool fee rate (sat/vB). */
-    static final long MIN_FEE_RATE = 1;
-    static final long MAX_FEE_RATE = 100;
+    static final double MIN_FEE_RATE = 1;
+    static final double MAX_FEE_RATE = 100;
 
     private Identity joinIdentity;
     private JoinstrPool pool;
@@ -31,7 +31,7 @@ public class JoinPoolHandler {
     private NostrListener credentialsListener;
     private Identity poolIdentity;
     private int numPeers;
-    private long feeRate = 1;
+    private double feeRate = 1;
     private Consumer<String> statusCallback;
     private CoinjoinHandler coinjoinHandler;
 
@@ -39,9 +39,12 @@ public class JoinPoolHandler {
      * Accept a fee rate that stays within a tolerance band of the advertised rate (it may drift
      * between pool creation and the coinjoin) and within the absolute [MIN_FEE_RATE, MAX_FEE_RATE] range.
      */
-    static boolean isFeeRateAcceptable(long feeRate, long advertisedFeeRate) {
-        long lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
-        long hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
+    static boolean isFeeRateAcceptable(double feeRate, double advertisedFeeRate) {
+        if (!Double.isFinite(feeRate) || !Double.isFinite(advertisedFeeRate)) {
+            return false;
+        }
+        double lo = Math.max(MIN_FEE_RATE, advertisedFeeRate / 2);
+        double hi = Math.min(MAX_FEE_RATE, advertisedFeeRate * 2);
         return feeRate >= lo && feeRate <= hi;
     }
 
@@ -113,8 +116,8 @@ public class JoinPoolHandler {
 
             Platform.runLater(() -> statusCallback.accept("Credentials received"));
 
-            long advertisedFeeRate = pool.getParsedFeeRate();
-            long credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
+            double advertisedFeeRate = pool.getParsedFeeRate();
+            double credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
 
             if (!isFeeRateAcceptable(credentialsFeeRate, advertisedFeeRate)) {
                 logger.severe("Rejecting pool: fee rate " + credentialsFeeRate
@@ -140,7 +143,7 @@ public class JoinPoolHandler {
     /**
      * Start the coinjoin flow using CoinjoinHandler
      */
-    private void startCoinjoinFlow(long feeRate) {
+    private void startCoinjoinFlow(double feeRate) {
         try {
             Map<com.sparrowwallet.drongo.wallet.Wallet, Storage> openWallets = AppServices.get().getOpenWallets();
             if (openWallets.isEmpty()) {
@@ -251,15 +254,15 @@ public class JoinPoolHandler {
                 logger.info("Selected UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() + " value="
                         + selectedUtxo.getValue());
 
-                long feePerOutput = feeRate * 150;
-                long outputAmount = poolAmountSats - feePerOutput;
+                long outputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate,
+                        coinjoinHandler.getNumPeers());
                 long myFee = selectedUtxo.getValue() - outputAmount;
 
                 java.util.Optional<ButtonType> confirm = AppServices.showAlertDialog(
                         "Confirm Coinjoin Input",
                         "Input: " + selectedUtxo.getValue() + " sats\n" +
                                 "Output: " + outputAmount + " sats\n" +
-                                "Fee: " + myFee + " sats (" + feeRate + " sat/vB)\n\n" +
+                                "Fee: " + myFee + " sats (" + CoinjoinMath.formatFeeRate(feeRate) + " sat/vB)\n\n" +
                                 "Proceed with signing?",
                         Alert.AlertType.CONFIRMATION, ButtonType.CANCEL, ButtonType.OK);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -48,6 +48,74 @@ public class JoinPoolHandler {
         return feeRate >= lo && feeRate <= hi;
     }
 
+    /**
+     * Why the credentials do not belong to this pool, or null if they do.
+     *
+     * The private key inside them must be the key of the pool that was joined, which nobody but
+     * its creator holds, and every term must match what that pool advertised.
+     */
+    static String credentialsRejectionReason(JoinstrMessage credentials, JoinstrPool pool) {
+        if (pool == null) {
+            return "no pool to check against";
+        }
+
+        String derived;
+        try {
+            derived = Identity.create(credentials.getPrivateKey()).getPublicKey().toString();
+        } catch (Exception e) {
+            return "private key is not a nostr key";
+        }
+
+        if (!derived.equals(pool.getPubkey())) {
+            return "private key is not the key of this pool";
+        }
+
+        String announcedId = pool.getPoolId();
+        if (announcedId != null && !announcedId.isEmpty() && !announcedId.equals(credentials.getId())) {
+            return "id does not match the announcement";
+        }
+
+        if (credentials.getDenomination() == null
+                || sats(credentials.getDenomination()) != denominationSats(pool)) {
+            return "denomination does not match the announcement";
+        }
+
+        if (credentials.getPeers() == null || credentials.getPeers() != pool.getParsedPeers()) {
+            return "peers does not match the announcement";
+        }
+
+        Long announcedTimeout = parseTimeout(pool.getTimeout());
+        if (credentials.getTimeout() == null || !credentials.getTimeout().equals(announcedTimeout)) {
+            return "timeout does not match the announcement";
+        }
+
+        if (credentials.getRelay() == null || !credentials.getRelay().equals(pool.getRelay())) {
+            return "relay does not match the announcement";
+        }
+
+        return null;
+    }
+
+    private static long sats(double denominationBtc) {
+        return Math.round(denominationBtc * 100000000d);
+    }
+
+    private static long denominationSats(JoinstrPool pool) {
+        try {
+            return CoinjoinMath.denominationToSats(pool.getDenomination());
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    private static Long parseTimeout(String timeout) {
+        try {
+            return Long.parseLong(timeout.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public JoinPoolHandler(Identity joinIdentity, JoinstrPool pool, Consumer<String> statusCallback) {
         this.joinIdentity = joinIdentity;
         this.pool = pool;
@@ -66,10 +134,28 @@ public class JoinPoolHandler {
         credentialsListener = new NostrListener(joinIdentity, relay, null);
 
         credentialsListener.startListening(decryptedMessage -> {
-            JoinstrMessage message = JoinstrMessage.fromJson(decryptedMessage);
-            if (message.getPrivateKey() != null) {
-                handleCredentialsReceived(message);
+            JoinstrMessage message;
+            try {
+                message = JoinstrMessage.fromJson(decryptedMessage);
+            } catch (Exception e) {
+                logger.warning("Ignoring unparseable message while waiting for credentials");
+                return;
             }
+
+            if (message == null || message.getPrivateKey() == null) {
+                return;
+            }
+
+            String rejection = credentialsRejectionReason(message, pool);
+            if (rejection != null) {
+                // nip 04 does not authenticate the sender and this key is public on the relay from
+                // the moment the join request is published, so anyone can answer it. Keep waiting
+                // for the pool that was actually chosen instead of taking the first reply.
+                logger.warning("Ignoring credentials that did not come from the pool joined: " + rejection);
+                return;
+            }
+
+            handleCredentialsReceived(message);
         });
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -9,6 +9,11 @@ public class JoinstrMessage {
     private String id;
     private String private_key;
     private Double fee_rate;
+    private String public_key;
+    private Double denomination;
+    private Integer peers;
+    private Long timeout;
+    private String relay;
 
     public String getType() {
         return type;
@@ -48,6 +53,46 @@ public class JoinstrMessage {
 
     public void setPrivateKey(String private_key) {
         this.private_key = private_key;
+    }
+
+    public String getPublicKey() {
+        return public_key;
+    }
+
+    public void setPublicKey(String public_key) {
+        this.public_key = public_key;
+    }
+
+    public Double getDenomination() {
+        return denomination;
+    }
+
+    public void setDenomination(Double denomination) {
+        this.denomination = denomination;
+    }
+
+    public Integer getPeers() {
+        return peers;
+    }
+
+    public void setPeers(Integer peers) {
+        this.peers = peers;
+    }
+
+    public Long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Long timeout) {
+        this.timeout = timeout;
+    }
+
+    public String getRelay() {
+        return relay;
+    }
+
+    public void setRelay(String relay) {
+        this.relay = relay;
     }
 
     public Double getFeeRate() {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -8,7 +8,7 @@ public class JoinstrMessage {
     private String psbt;
     private String id;
     private String private_key;
-    private Long fee_rate;
+    private Double fee_rate;
 
     public String getType() {
         return type;
@@ -50,11 +50,11 @@ public class JoinstrMessage {
         this.private_key = private_key;
     }
 
-    public Long getFeeRate() {
+    public Double getFeeRate() {
         return fee_rate;
     }
 
-    public void setFeeRate(Long fee_rate) {
+    public void setFeeRate(Double fee_rate) {
         this.fee_rate = fee_rate;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -27,6 +27,7 @@ public class JoinstrPool {
     private final SimpleStringProperty status;
     private final javafx.beans.property.SimpleIntegerProperty connectedPeers;
     private String privateKey;
+    private String poolId = "";
     private String feeRate = "1";
     private JoinPoolHandler handler;
 
@@ -76,6 +77,50 @@ public class JoinstrPool {
 
     public String getPrivateKey() {
         return privateKey;
+    }
+
+    /** The pool id from the announcement, which peers echo back in the credentials. */
+    public String getPoolId() {
+        return poolId;
+    }
+
+    public void setPoolId(String poolId) {
+        this.poolId = poolId == null ? "" : poolId;
+    }
+
+    /**
+     * The credentials a joiner is sent. Every field the pool announced is repeated here with the
+     * same type, because a joiner checks the credentials against the announcement it chose before
+     * trusting the private key inside them.
+     */
+    public Map<String, Object> toCredentials() {
+        Map<String, Object> credentials = new LinkedHashMap<>();
+        credentials.put("id", poolId);
+        credentials.put("public_key", getPubkey());
+        credentials.put("denomination", asNumber(getDenomination(), 0d));
+        credentials.put("peers", getParsedPeers());
+        credentials.put("timeout", asLong(getTimeout()));
+        credentials.put("relay", getRelay());
+        credentials.put("fee_rate", getParsedFeeRate());
+        credentials.put("private_key", privateKey);
+        return credentials;
+    }
+
+    private static double asNumber(String value, double fallback) {
+        try {
+            double parsed = Double.parseDouble(value.trim());
+            return Double.isFinite(parsed) ? parsed : fallback;
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+
+    private static long asLong(String value) {
+        try {
+            return Long.parseLong(value.trim());
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
     public void setPrivateKey(String privateKey) {
@@ -280,6 +325,7 @@ public class JoinstrPool {
         private final String timeout;
         private final String status;
         private final String privateKey;
+        private final String poolId;
         private final String feeRate;
 
         public JoinstrPoolData(JoinstrPool joinstrPool) {
@@ -290,6 +336,7 @@ public class JoinstrPool {
             this.timeout = joinstrPool.getTimeout();
             this.status = joinstrPool.getStatus();
             this.privateKey = joinstrPool.getPrivateKey();
+            this.poolId = joinstrPool.getPoolId();
             this.feeRate = joinstrPool.getFeeRate();
         }
 
@@ -298,6 +345,7 @@ public class JoinstrPool {
             if (feeRate != null) {
                 pool.setFeeRate(feeRate);
             }
+            pool.setPoolId(poolId);
             return pool;
         }
     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -90,12 +90,20 @@ public class JoinstrPool {
         this.feeRate = feeRate;
     }
 
-    public long getParsedFeeRate() {
+    /**
+      * The advertised fee rate in sat/vB. Pools publish it as a JSON number, which other joinstr
+      * clients derive from their own estimator and so is usually fractional.
+      */
+    public double getParsedFeeRate() {
         try {
             if (feeRate == null || feeRate.trim().isEmpty()) {
                 return 1;
             }
-            return Long.parseLong(feeRate.trim());
+            double parsed = Double.parseDouble(feeRate.trim());
+            if (!Double.isFinite(parsed) || parsed <= 0) {
+                return 1;
+            }
+            return parsed;
         } catch (Exception e) {
             return 1;
         }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
@@ -132,6 +132,10 @@ public class NewPoolController extends JoinstrFormController {
 
                 JoinstrPool pool = new JoinstrPool(joinstrEvent.relay, joinstrEvent.public_key,
                         joinstrEvent.denomination, joinstrEvent.peers, joinstrEvent.timeout, poolPrivateKey);
+                pool.setPoolId(joinstrEvent.id);
+                if (joinstrEvent.fee_rate != null) {
+                    pool.setFeeRate(joinstrEvent.fee_rate);
+                }
                 updatePoolStore(pool);
 
                 getJoinstrController().setSelectedPool(pool);
@@ -170,7 +174,7 @@ public class NewPoolController extends JoinstrFormController {
             coinjoinHandler = new CoinjoinHandler(poolIdentity, pool, wallet, storage, status -> {
                 javafx.application.Platform.runLater(() -> pool.setStatus(status));
             });
-            coinjoinHandler.setFeeRate(1);
+            coinjoinHandler.setFeeRate(pool.getParsedFeeRate());
 
             coinjoinHandler.setOnReadyForInputCallback(() -> {
                 showUtxoSelectionDialog(wallet);
@@ -179,15 +183,7 @@ public class NewPoolController extends JoinstrFormController {
             coinjoinHandler.startOutputPhase(myOutputAddress);
             logger.info("Pool creator started coinjoin flow with output: " + myOutputAddress);
 
-            Map<String, String> poolCredentials = new java.util.HashMap<>();
-            poolCredentials.put("id", pool.getPubkey());
-            poolCredentials.put("private_key", poolPrivateKey);
-            poolCredentials.put("relay", pool.getRelay());
-            poolCredentials.put("public_key", pool.getPubkey());
-            poolCredentials.put("peers", pool.getPeers());
-            poolCredentials.put("timeout", pool.getTimeout());
-
-            shareCredentials(poolIdentity, pool.getRelay(), poolCredentials);
+            shareCredentials(poolIdentity, pool.getRelay(), pool.toCredentials());
 
         } catch (Exception e) {
             logger.severe("Error starting creator coinjoin flow: " + e.getMessage());
@@ -245,7 +241,7 @@ public class NewPoolController extends JoinstrFormController {
 
     }
 
-    public static void shareCredentials(Identity poolIdentity, String relayUrl, Map<String, String> poolCredentials) {
+    public static void shareCredentials(Identity poolIdentity, String relayUrl, Map<String, Object> poolCredentials) {
 
         NostrListener listener = new NostrListener(poolIdentity, relayUrl, poolCredentials);
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -32,11 +32,11 @@ public class NostrListener implements AutoCloseable {
     private final String relay;
     private Client client;
     private Consumer<String> messageHandler;
-    private final Map<String, String> poolCredentials;
+    private final Map<String, Object> poolCredentials;
     private static final ConsoleHandler consoleLogHandler = new ConsoleHandler();
     private transient Handler eventMessageHandler = null;
 
-    public NostrListener(Identity identity, String relay, Map<String, String> poolCredentials) {
+    public NostrListener(Identity identity, String relay, Map<String, Object> poolCredentials) {
         this.identity = identity;
         this.relay = relay;
         this.poolCredentials = poolCredentials;
@@ -140,14 +140,6 @@ public class NostrListener implements AutoCloseable {
         }
 
         try {
-            Gson gson = new Gson();
-            Map<String, Object> credentialsMap = new LinkedHashMap<>();
-            credentialsMap.put("id", poolCredentials.get("id"));
-            credentialsMap.put("public_key", poolCredentials.get("public_key"));
-            credentialsMap.put("denomination", poolCredentials.get("denomination"));
-            credentialsMap.put("peers", poolCredentials.get("peers"));
-            credentialsMap.put("timeout", poolCredentials.get("timeout"));
-
             if (AppServices.isTorRunning()) {
                 try {
                     Client.getInstance().disconnect();
@@ -158,10 +150,9 @@ public class NostrListener implements AutoCloseable {
             }
                 TorUtils.logTorIp();
 
-            credentialsMap.put("relay", poolCredentials.get("relay"));
-            credentialsMap.put("private_key", poolCredentials.get("private_key"));
-            credentialsMap.put("fee_rate", poolCredentials.get("fee_rate"));
-            String credentialsJson = gson.toJson(credentialsMap);
+            // Send the payload as built. Re-picking keys here silently dropped any the caller
+            // had not supplied, and turned every value into a string.
+            String credentialsJson = new Gson().toJson(poolCredentials);
 
             List<BaseTag> tags = new ArrayList<>();
             tags.add(new PubKeyTag(new PublicKey(requesterPubkey)));

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -192,6 +192,10 @@ public class OtherPoolsController extends JoinstrFormController {
                                                 pool.setFeeRate(poolData.get("fee_rate").asText());
                                             }
 
+                                            if (poolData.has("id")) {
+                                                pool.setPoolId(poolData.get("id").asText());
+                                            }
+
                                             if (pools.stream().noneMatch(
                                                     (p) -> Objects.equals(p.getPubkey(), pool.getPubkey())) &&
                                                     myPools.stream().noneMatch(

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -87,7 +87,7 @@ public class JoinstrInfoPane extends VBox {
             relayValueLabel.setText(pool.getRelay());
             pubkeyValueLabel.setText(pool.getPubkey());
             denominationValueLabel.setText(pool.getDenomination());
-            feeRateValueLabel.setText(pool.getParsedFeeRate() + " sat/vB");
+            feeRateValueLabel.setText(com.sparrowwallet.sparrow.joinstr.CoinjoinMath.formatFeeRate(pool.getParsedFeeRate()) + " sat/vB");
             statusValueLabel.textProperty().bind(pool.statusProperty());
         } else {
             clearPoolInfo();

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CredentialsAuthTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CredentialsAuthTest.java
@@ -1,0 +1,141 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Anyone reading the relay sees a join request and can answer it, because nip 04 does not
+ * authenticate the sender. Credentials are only acceptable if they carry the private key of the
+ * pool that was chosen and repeat the terms it advertised.
+ */
+public class CredentialsAuthTest {
+
+    private static final String RELAY = "wss://nos.lol";
+    private static final String POOL_ID = "0123456789abcdef";
+    private static final String DENOMINATION = "0.001";
+    private static final String PEERS = "3";
+    private static final String TIMEOUT = "1750000000";
+
+    private JoinstrPool poolFor(Identity poolIdentity) {
+        JoinstrPool pool = new JoinstrPool(RELAY, poolIdentity.getPublicKey().toString(),
+                DENOMINATION, PEERS, TIMEOUT);
+        pool.setPoolId(POOL_ID);
+        return pool;
+    }
+
+    private JoinstrMessage credentialsFrom(Identity identity) {
+        JoinstrMessage credentials = new JoinstrMessage();
+        credentials.setType("credentials");
+        credentials.setPrivateKey(identity.getPrivateKey().toString());
+        credentials.setId(POOL_ID);
+        credentials.setPublicKey(identity.getPublicKey().toString());
+        credentials.setDenomination(0.001);
+        credentials.setPeers(3);
+        credentials.setTimeout(1750000000L);
+        credentials.setRelay(RELAY);
+        credentials.setFeeRate(1.0);
+        return credentials;
+    }
+
+    @Test
+    public void acceptsCredentialsFromThePoolThatWasJoined() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        assertNull(JoinPoolHandler.credentialsRejectionReason(credentialsFrom(poolIdentity),
+                poolFor(poolIdentity)));
+    }
+
+    /**
+     * The hijack: a relay observer answers the join request first, with a pool key it controls.
+     * Every advertised term is copied, so only the key check catches it.
+     */
+    @Test
+    public void rejectsCredentialsCarryingSomeoneElsesPoolKey() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        Identity attacker = Identity.generateRandomIdentity();
+
+        JoinstrMessage hijack = credentialsFrom(attacker);
+        hijack.setPublicKey(poolIdentity.getPublicKey().toString());
+
+        String reason = JoinPoolHandler.credentialsRejectionReason(hijack, poolFor(poolIdentity));
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("not the key of this pool"), reason);
+    }
+
+    @Test
+    public void rejectsAMalformedPrivateKey() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        JoinstrMessage credentials = credentialsFrom(poolIdentity);
+        credentials.setPrivateKey("not-a-key");
+
+        assertNotNull(JoinPoolHandler.credentialsRejectionReason(credentials, poolFor(poolIdentity)));
+    }
+
+    @Test
+    public void rejectsAChangedPoolId() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        JoinstrMessage credentials = credentialsFrom(poolIdentity);
+        credentials.setId("fedcba9876543210");
+
+        assertEquals("id does not match the announcement",
+                JoinPoolHandler.credentialsRejectionReason(credentials, poolFor(poolIdentity)));
+    }
+
+    @Test
+    public void rejectsChangedTerms() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        JoinstrMessage denomination = credentialsFrom(poolIdentity);
+        denomination.setDenomination(0.01);
+        assertEquals("denomination does not match the announcement",
+                JoinPoolHandler.credentialsRejectionReason(denomination, poolFor(poolIdentity)));
+
+        JoinstrMessage peers = credentialsFrom(poolIdentity);
+        peers.setPeers(9);
+        assertEquals("peers does not match the announcement",
+                JoinPoolHandler.credentialsRejectionReason(peers, poolFor(poolIdentity)));
+
+        JoinstrMessage timeout = credentialsFrom(poolIdentity);
+        timeout.setTimeout(1799999999L);
+        assertEquals("timeout does not match the announcement",
+                JoinPoolHandler.credentialsRejectionReason(timeout, poolFor(poolIdentity)));
+
+        JoinstrMessage relay = credentialsFrom(poolIdentity);
+        relay.setRelay("wss://evil.example");
+        assertEquals("relay does not match the announcement",
+                JoinPoolHandler.credentialsRejectionReason(relay, poolFor(poolIdentity)));
+    }
+
+    /** A term the sender simply omits must not pass as a match. */
+    @Test
+    public void rejectsOmittedTerms() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        for(String omitted : new String[] {"denomination", "peers", "timeout", "relay"}) {
+            JoinstrMessage credentials = credentialsFrom(poolIdentity);
+            switch(omitted) {
+                case "denomination" -> credentials.setDenomination(null);
+                case "peers" -> credentials.setPeers(null);
+                case "timeout" -> credentials.setTimeout(null);
+                case "relay" -> credentials.setRelay(null);
+            }
+            assertNotNull(JoinPoolHandler.credentialsRejectionReason(credentials, poolFor(poolIdentity)),
+                    "omitting " + omitted + " was accepted");
+        }
+    }
+
+    @Test
+    public void acceptsAPoolThatNeverAnnouncedAnId() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        JoinstrPool pool = new JoinstrPool(RELAY, poolIdentity.getPublicKey().toString(),
+                DENOMINATION, PEERS, TIMEOUT);
+
+        assertNull(JoinPoolHandler.credentialsRejectionReason(credentialsFrom(poolIdentity), pool));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/FeeRateValidationTest.java
@@ -49,6 +49,31 @@ public class FeeRateValidationTest {
     }
 
     @Test
+    public void poolParsesFractionalAdvertisedFeeRate() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
+        pool.setFeeRate("2.5");
+        assertEquals(2.5, pool.getParsedFeeRate());
+        // a whole rate written as a decimal is what the electrum plugin usually publishes
+        pool.setFeeRate("3.0");
+        assertEquals(3.0, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void fractionalRatesAreComparedAgainstTheAdvertisedBand() {
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(3.0, 2.5));
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(2.5, 2.5));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(5.1, 2.5));
+        // the advertised rate no longer collapses to 1, so a normal pool is not refused
+        assertTrue(JoinPoolHandler.isFeeRateAcceptable(3.0, 3.0));
+    }
+
+    @Test
+    public void nonFiniteRatesAreRefused() {
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(Double.NaN, 4));
+        assertFalse(JoinPoolHandler.isFeeRateAcceptable(4, Double.POSITIVE_INFINITY));
+    }
+
+    @Test
     public void poolFeeRateDefaultsOnMalformedValue() {
         JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.01", "3", "0");
         pool.setFeeRate("abc");
@@ -57,5 +82,15 @@ public class FeeRateValidationTest {
         assertEquals(1, pool.getParsedFeeRate());
         pool.setFeeRate(null);
         assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("0");
+        assertEquals(1, pool.getParsedFeeRate());
+        pool.setFeeRate("-4");
+        assertEquals(1, pool.getParsedFeeRate());
+    }
+
+    @Test
+    public void feeRateIsRenderedWithoutATrailingZero() {
+        assertEquals("3", CoinjoinMath.formatFeeRate(3.0));
+        assertEquals("2.5", CoinjoinMath.formatFeeRate(2.5));
     }
 }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrCredentialsTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrCredentialsTest.java
@@ -1,0 +1,130 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A joiner checks the credentials it is sent against the pool announcement it chose, field by
+ * field, before trusting the private key inside them. These cover that the payload this client
+ * sends survives that check.
+ */
+public class JoinstrCredentialsTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Gson GSON = new Gson();
+
+    /** The fields a joiner compares against the announcement. */
+    private static final String[] CHECKED_FIELDS =
+            {"id", "public_key", "denomination", "peers", "timeout", "relay"};
+
+    private static final String ANNOUNCEMENT = "{"
+            + "\"versions\":[\"1\"],"
+            + "\"type\":\"new_pool\","
+            + "\"id\":\"0123456789abcdef\","
+            + "\"network\":\"regtest\","
+            + "\"public_key\":\"e37076afaf4a0054fd144f0b843c174173e7d0620a572572c0a34e6b78023afe\","
+            + "\"denomination\":0.001,"
+            + "\"peers\":3,"
+            + "\"timeout\":1750000000,"
+            + "\"relay\":\"wss://nos.lol\","
+            + "\"fee_rate\":2.5"
+            + "}";
+
+    /** Build the pool the way OtherPoolsController does when it reads an announcement. */
+    private JoinstrPool poolFromAnnouncement() throws Exception {
+        JsonNode a = MAPPER.readTree(ANNOUNCEMENT);
+        JoinstrPool pool = new JoinstrPool(
+                a.get("relay").asText(),
+                a.get("public_key").asText(),
+                a.get("denomination").asText(),
+                a.get("peers").asText(),
+                a.get("timeout").asText(),
+                "aabbcc");
+        pool.setFeeRate(a.get("fee_rate").asText());
+        pool.setPoolId(a.get("id").asText());
+        return pool;
+    }
+
+    @Test
+    public void credentialsCarryEveryRequiredField() throws Exception {
+        Map<String, Object> credentials = poolFromAnnouncement().toCredentials();
+
+        for(String field : CHECKED_FIELDS) {
+            assertTrue(credentials.containsKey(field), "missing field: " + field);
+            assertNotNull(credentials.get(field), "null field: " + field);
+        }
+        // denomination and fee_rate were absent from the map that was serialised, so both went out
+        // as JSON null and the credentials were refused
+        assertNotNull(credentials.get("fee_rate"));
+        assertNotNull(credentials.get("private_key"));
+    }
+
+    @Test
+    public void credentialsIdIsTheAnnouncedPoolIdNotThePubkey() throws Exception {
+        JoinstrPool pool = poolFromAnnouncement();
+        Map<String, Object> credentials = pool.toCredentials();
+
+        assertEquals("0123456789abcdef", credentials.get("id"));
+        assertNotEquals(pool.getPubkey(), credentials.get("id"));
+    }
+
+    @Test
+    public void credentialsMatchTheAnnouncementFieldByField() throws Exception {
+        JsonNode announced = MAPPER.readTree(ANNOUNCEMENT);
+        JsonNode sent = MAPPER.readTree(GSON.toJson(poolFromAnnouncement().toCredentials()));
+
+        for(String field : CHECKED_FIELDS) {
+            JsonNode a = announced.get(field);
+            JsonNode s = sent.get(field);
+            assertNotNull(s, "credentials dropped " + field);
+            if(a.isNumber()) {
+                assertEquals(a.asDouble(), s.asDouble(), field + " changed value");
+                assertTrue(s.isNumber(), field + " must stay a number, was: " + s);
+            } else {
+                assertEquals(a.asText(), s.asText(), field + " changed value");
+            }
+        }
+    }
+
+    /**
+     * The announcement publishes these as JSON numbers. Sending them back as quoted strings fails
+     * the joiner's comparison even when the value is right.
+     */
+    @Test
+    public void numericFieldsAreSerialisedAsNumbers() throws Exception {
+        JsonNode sent = MAPPER.readTree(GSON.toJson(poolFromAnnouncement().toCredentials()));
+
+        assertTrue(sent.get("denomination").isNumber(), "denomination was: " + sent.get("denomination"));
+        assertTrue(sent.get("peers").isNumber(), "peers was: " + sent.get("peers"));
+        assertTrue(sent.get("timeout").isNumber(), "timeout was: " + sent.get("timeout"));
+        assertTrue(sent.get("fee_rate").isNumber(), "fee_rate was: " + sent.get("fee_rate"));
+        assertTrue(sent.get("id").isTextual());
+        assertTrue(sent.get("relay").isTextual());
+    }
+
+    @Test
+    public void credentialsValuesArePositive() throws Exception {
+        JsonNode sent = MAPPER.readTree(GSON.toJson(poolFromAnnouncement().toCredentials()));
+
+        // a joiner rejects the credentials unless all four parse positive
+        assertTrue(sent.get("denomination").asDouble() > 0);
+        assertTrue(sent.get("peers").asInt() > 0);
+        assertTrue(sent.get("fee_rate").asDouble() > 0);
+        assertTrue(sent.get("timeout").asLong() > 0);
+    }
+
+    @Test
+    public void missingPoolIdDoesNotProduceANullField() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000", "aabbcc");
+
+        assertEquals("", pool.getPoolId());
+        assertNotNull(pool.toCredentials().get("id"));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessageTest.java
@@ -41,7 +41,7 @@ public class JoinstrMessageTest {
         JoinstrMessage message = new JoinstrMessage();
         message.setType("credentials");
         message.setPrivateKey("deadbeef");
-        message.setFeeRate(5L);
+        message.setFeeRate(5.0);
 
         String json = message.toJson();
 
@@ -59,7 +59,29 @@ public class JoinstrMessageTest {
 
         assertEquals("credentials", parsed.getType());
         assertEquals("deadbeef", parsed.getPrivateKey());
-        assertEquals(7L, parsed.getFeeRate());
+        assertEquals(7.0, parsed.getFeeRate());
+    }
+
+    /**
+     * The electrum plugin derives fee_rate from its own estimator (fee_per_kb / 1000), so the
+     * value on the wire is usually fractional. Parsing it must not throw.
+     */
+    @Test
+    public void parsesFractionalFeeRate() {
+        String json = "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":2.5}";
+
+        JoinstrMessage parsed = JoinstrMessage.fromJson(json);
+
+        assertEquals(2.5, parsed.getFeeRate());
+        assertEquals("deadbeef", parsed.getPrivateKey());
+    }
+
+    @Test
+    public void parsesWholeFeeRateWrittenAsDecimal() {
+        JoinstrMessage parsed = JoinstrMessage.fromJson(
+                "{\"type\":\"credentials\",\"private_key\":\"deadbeef\",\"fee_rate\":3.0}");
+
+        assertEquals(3.0, parsed.getFeeRate());
     }
 
     @Test


### PR DESCRIPTION
Closes #53.

Based on #72, which is based on #70. Three PRs in a stack, so merge #70, then #72, then this.

A joiner accepted any decrypted message that merely had a non-null `private_key`:

```java
credentialsListener.startListening(decryptedMessage -> {
    JoinstrMessage message = JoinstrMessage.fromJson(decryptedMessage);
    if (message.getPrivateKey() != null) {
        handleCredentialsReceived(message);
    }
});
```

Nothing bound that key to the pool the user chose. NIP-04 does not authenticate the sender, and the joiner's throwaway pubkey is public on the relay from the moment the join request is published, so any observer can answer it. The attacker's reply is accepted, the victim registers a fresh receive address and a signed input into a pool where every other participant is the attacker, and the input to output linkage the coinjoin exists to break is handed straight over. The attacker also picks the denomination, peer count and fee rate the victim's client then uses.

`handleCredentialsReceived` compounded it by latching `credentialsReceived` on the first message, so an attacker who answered first also consumed the one attempt and the genuine credentials that arrived afterwards were discarded.

## Changes

`fix: accept pool credentials only from the pool that was joined`

- New `JoinPoolHandler.credentialsRejectionReason`, which returns why the credentials do not belong to this pool, or null if they do. The private key must derive to the pubkey of the pool that was joined, and `id`, `denomination`, `peers`, `timeout` and `relay` must all match what that pool advertised. This mirrors `_authenticated_credentials` in the reference implementation (`plugin/joinstr.py:907-938`).
- The listener now skips a message that fails the check and keeps waiting, rather than taking the first reply. An unparseable message is skipped too instead of throwing inside the handler.
- `JoinstrMessage` gains the `public_key`, `denomination`, `peers`, `timeout` and `relay` fields needed to make the comparison. Gson omits nulls, so output and input messages are unchanged on the wire.
- Denomination is compared in satoshis via `CoinjoinMath.denominationToSats` rather than as a double, so `0.001` and `1e-3` do not disagree.

`test: cover pool credentials authentication`

New `CredentialsAuthTest`, seven cases: genuine credentials accepted; the hijack rejected, where the attacker copies every advertised term and sets `public_key` to the real pool key so only the derivation catches it; a malformed private key rejected; a changed `id` rejected; each of denomination, peers, timeout and relay rejected when changed; each rejected when omitted, so a missing field cannot pass as a match; and a pool that never announced an id still accepted.

## Verification

`./gradlew :test` green, 58 tests across eight joinstr test classes.

These are new-behaviour tests rather than a reproduction, because before this change there was no check to revert to. The pre-fix listener accepts every one of the rejected payloads above by construction, since its only condition was a non-null `private_key`.

## Compatibility note

This makes the joiner strict in the same way the Electrum plugin became strict in its v0.4.1. Credentials from a pool creator running Sparrow 0.1.1 will now be rejected, because those omit `denomination` and `fee_rate` and send the pubkey as `id`, which is #50. That is the same class of break the plugin flagged in its own upgrade notes, and it is the correct direction: those credentials are already rejected by every Electrum peer.
