### PR TITLE
fix: surface a reject from the pool creator

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/FxDispatch.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/FxDispatch.java
@@ -1,0 +1,31 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import javafx.application.Platform;
+
+/**
+ * Runs a task on the JavaFX thread, or inline when there is no toolkit. The coinjoin phases are
+ * driven from relay callbacks and report progress to the UI, so they need to marshal, but the
+ * same code has to be runnable without a toolkit to be testable.
+ */
+public final class FxDispatch {
+
+    private FxDispatch() {
+    }
+
+    public static void run(Runnable runnable) {
+        if (runnable == null) {
+            return;
+        }
+
+        try {
+            if (Platform.isFxApplicationThread()) {
+                runnable.run();
+            } else {
+                Platform.runLater(runnable);
+            }
+        } catch (IllegalStateException e) {
+            // no toolkit, so there is no UI thread to marshal onto
+            runnable.run();
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -49,6 +49,73 @@ public class JoinPoolHandler {
     }
 
     /**
+     * Handle one decrypted message received while waiting for credentials. This is what the relay
+     * listener calls for every message addressed to the joiner's throwaway key.
+     */
+    void onDecryptedMessage(String decryptedMessage) {
+        JoinstrMessage message;
+        try {
+            message = JoinstrMessage.fromJson(decryptedMessage);
+        } catch (Exception e) {
+            logger.warning("Ignoring unparseable message while waiting for credentials");
+            return;
+        }
+
+        if (message == null) {
+            return;
+        }
+
+        if ("reject".equals(message.getType())) {
+            handleRejected(message);
+            return;
+        }
+
+        if (message.getPrivateKey() == null) {
+            return;
+        }
+
+        String rejection = credentialsRejectionReason(message, pool);
+        if (rejection != null) {
+            // nip 04 does not authenticate the sender and this key is public on the relay from
+            // the moment the join request is published, so anyone can answer it. Keep waiting
+            // for the pool that was actually chosen instead of taking the first reply.
+            logger.warning("Ignoring credentials that did not come from the pool joined: " + rejection);
+            return;
+        }
+
+        handleCredentialsReceived(message);
+    }
+
+    /** A readable explanation for a reject sent by a pool creator. */
+    static String rejectionMessage(JoinstrMessage reject) {
+        String reason = reject.getReason();
+        if (reason == null || reason.trim().isEmpty()) {
+            return "The pool creator rejected your request.";
+        }
+
+        String detail = switch (reason) {
+            case "missing_proof" -> "An aut-ct proof is required to join this pool.";
+            case "invalid_proof" -> "The provided aut-ct proof could not be verified.";
+            case "duplicate_token" -> "The aut-ct token has already been used.";
+            default -> reason;
+        };
+
+        return "The pool creator rejected your request: " + detail;
+    }
+
+    private void handleRejected(JoinstrMessage reject) {
+        if (!rejected.compareAndSet(false, true)) {
+            return;
+        }
+
+        String message = rejectionMessage(reject);
+        logger.warning(message);
+        FxDispatch.run(() -> statusCallback.accept("Rejected"));
+        FxDispatch.run(() -> errorDialog.accept(message));
+        stop();
+    }
+
+    /**
      * Why the credentials do not belong to this pool, or null if they do.
      *
      * The private key inside them must be the key of the pool that was joined, which nobody but
@@ -129,40 +196,19 @@ public class JoinPoolHandler {
      * Start listening for credentials after sending join request
      */
     public void startListeningForCredentials() {
-        Platform.runLater(() -> statusCallback.accept("Waiting for credentials"));
+        FxDispatch.run(() -> statusCallback.accept("Waiting for credentials"));
 
         credentialsListener = new NostrListener(joinIdentity, relay, null);
 
-        credentialsListener.startListening(decryptedMessage -> {
-            JoinstrMessage message;
-            try {
-                message = JoinstrMessage.fromJson(decryptedMessage);
-            } catch (Exception e) {
-                logger.warning("Ignoring unparseable message while waiting for credentials");
-                return;
-            }
-
-            if (message == null || message.getPrivateKey() == null) {
-                return;
-            }
-
-            String rejection = credentialsRejectionReason(message, pool);
-            if (rejection != null) {
-                // nip 04 does not authenticate the sender and this key is public on the relay from
-                // the moment the join request is published, so anyone can answer it. Keep waiting
-                // for the pool that was actually chosen instead of taking the first reply.
-                logger.warning("Ignoring credentials that did not come from the pool joined: " + rejection);
-                return;
-            }
-
-            handleCredentialsReceived(message);
-        });
+        credentialsListener.startListening(this::onDecryptedMessage);
     }
 
     /**
      * Handle received pool credentials
      */
     private final AtomicBoolean credentialsReceived = new AtomicBoolean(false);
+    private final AtomicBoolean rejected = new AtomicBoolean(false);
+    private Consumer<String> errorDialog = message -> AppServices.showErrorDialog("Join Request Rejected", message);
 
     private void handleCredentialsReceived(JoinstrMessage message) {
         if (!credentialsReceived.compareAndSet(false, true)) {
@@ -200,7 +246,7 @@ public class JoinPoolHandler {
                 logger.warning("Error stopping credentials listener: " + e.getMessage());
             }
 
-            Platform.runLater(() -> statusCallback.accept("Credentials received"));
+            FxDispatch.run(() -> statusCallback.accept("Credentials received"));
 
             double advertisedFeeRate = pool.getParsedFeeRate();
             double credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
@@ -209,7 +255,7 @@ public class JoinPoolHandler {
                 logger.severe("Rejecting pool: fee rate " + credentialsFeeRate
                         + " sat/vB is outside the accepted range for advertised " + advertisedFeeRate
                         + " sat/vB (absolute max " + MAX_FEE_RATE + ")");
-                Platform.runLater(() -> statusCallback.accept("Error: Fee rate out of range"));
+                FxDispatch.run(() -> statusCallback.accept("Error: Fee rate out of range"));
                 stop();
                 return;
             }
@@ -222,7 +268,7 @@ public class JoinPoolHandler {
         } catch (Exception e) {
             logger.severe("Error processing credentials: " + e.getMessage());
             e.printStackTrace();
-            Platform.runLater(() -> statusCallback.accept("Error " + e.getMessage()));
+            FxDispatch.run(() -> statusCallback.accept("Error " + e.getMessage()));
         }
     }
 
@@ -238,7 +284,7 @@ public class JoinPoolHandler {
             Map.Entry<com.sparrowwallet.drongo.wallet.Wallet, Storage> selectedWallet = selectWallet(openWallets);
             if (selectedWallet == null) {
                 logger.warning("No wallet selected for coinjoin");
-                Platform.runLater(() -> statusCallback.accept("Error: No wallet selected"));
+                FxDispatch.run(() -> statusCallback.accept("Error: No wallet selected"));
                 return;
             }
             com.sparrowwallet.drongo.wallet.Wallet wallet = selectedWallet.getKey();
@@ -262,7 +308,7 @@ public class JoinPoolHandler {
         } catch (Exception e) {
             logger.severe("Error starting coinjoin flow: " + e.getMessage());
             e.printStackTrace();
-            Platform.runLater(() -> statusCallback.accept("Error: " + e.getMessage()));
+            FxDispatch.run(() -> statusCallback.accept("Error: " + e.getMessage()));
         }
     }
 
@@ -288,7 +334,7 @@ public class JoinPoolHandler {
         if (Platform.isFxApplicationThread()) {
             task.run();
         } else {
-            Platform.runLater(task);
+            FxDispatch.run(task);
         }
         return task.get();
     }
@@ -302,12 +348,16 @@ public class JoinPoolHandler {
             coinjoinHandler.startInputPhase(utxo, utxoNode);
         } else {
             logger.severe("CoinjoinHandler not initialized");
-            Platform.runLater(() -> statusCallback.accept("Error: Handler not ready"));
+            FxDispatch.run(() -> statusCallback.accept("Error: Handler not ready"));
         }
     }
 
     public boolean isReadyForInputPhase() {
         return coinjoinHandler != null && coinjoinHandler.isReadyForInputPhase();
+    }
+
+    void setErrorDialog(Consumer<String> errorDialog) {
+        this.errorDialog = errorDialog;
     }
 
     public CoinjoinHandler getCoinjoinHandler() {
@@ -354,19 +404,19 @@ public class JoinPoolHandler {
 
                 if (confirm.isEmpty() || confirm.get() != ButtonType.OK) {
                     logger.info("User cancelled coinjoin input confirmation");
-                    Platform.runLater(() -> statusCallback.accept("Input registration cancelled"));
+                    FxDispatch.run(() -> statusCallback.accept("Input registration cancelled"));
                     return;
                 }
 
                 coinjoinHandler.startInputPhase(selectedUtxo, utxoNode);
             } else {
                 logger.warning("No UTXO selected, input registration cancelled");
-                Platform.runLater(() -> statusCallback.accept("Input registration cancelled"));
+                FxDispatch.run(() -> statusCallback.accept("Input registration cancelled"));
             }
         } catch (Exception e) {
             logger.severe("Error showing UTXO dialog: " + e.getMessage());
             e.printStackTrace();
-            Platform.runLater(() -> statusCallback.accept("Error: " + e.getMessage()));
+            FxDispatch.run(() -> statusCallback.accept("Error: " + e.getMessage()));
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -14,6 +14,7 @@ public class JoinstrMessage {
     private Integer peers;
     private Long timeout;
     private String relay;
+    private String reason;
 
     public String getType() {
         return type;
@@ -93,6 +94,14 @@ public class JoinstrMessage {
 
     public void setRelay(String relay) {
         this.relay = relay;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 
     public Double getFeeRate() {

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/RejectMessageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/RejectMessageTest.java
@@ -1,0 +1,144 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Drives the same entry point the relay listener drives, so these cover the dispatch that had the
+ * bug rather than a helper beside it. A pool creator answers a join request it will not accept
+ * with a reject carrying a reason; ignoring it left the joiner waiting until the pool timeout.
+ */
+public class RejectMessageTest {
+
+    private static final String RELAY = "wss://nos.lol";
+    private static final String POOL_ID = "0123456789abcdef";
+
+    private final List<String> statuses = new ArrayList<>();
+    private final List<String> dialogs = new ArrayList<>();
+
+    private JoinPoolHandler handlerFor(Identity poolIdentity) {
+        JoinstrPool pool = new JoinstrPool(RELAY, poolIdentity.getPublicKey().toString(),
+                "0.001", "3", "1750000000");
+        pool.setPoolId(POOL_ID);
+
+        JoinPoolHandler handler = new JoinPoolHandler(Identity.generateRandomIdentity(), pool, statuses::add);
+        handler.setErrorDialog(dialogs::add);
+        return handler;
+    }
+
+    private String credentialsJson(Identity identity) {
+        JoinstrMessage credentials = new JoinstrMessage();
+        credentials.setType("credentials");
+        credentials.setPrivateKey(identity.getPrivateKey().toString());
+        credentials.setId(POOL_ID);
+        credentials.setPublicKey(identity.getPublicKey().toString());
+        credentials.setDenomination(0.001);
+        credentials.setPeers(3);
+        credentials.setTimeout(1750000000L);
+        credentials.setRelay(RELAY);
+        credentials.setFeeRate(1.0);
+        return credentials.toJson();
+    }
+
+    @Test
+    public void aRejectStopsTheJoinAndSaysWhy() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"missing_proof\"}");
+
+        assertEquals(List.of("Rejected"), statuses);
+        assertEquals(1, dialogs.size());
+        assertTrue(dialogs.get(0).contains("aut-ct proof is required"), dialogs.get(0));
+    }
+
+    @Test
+    public void anUnknownReasonStillReachesTheUser() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"pool_full\"}");
+
+        assertEquals(1, dialogs.size());
+        assertTrue(dialogs.get(0).contains("pool_full"), dialogs.get(0));
+    }
+
+    @Test
+    public void aRejectWithNoReasonStillStopsTheJoin() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\"}");
+
+        assertEquals(List.of("Rejected"), statuses);
+        assertEquals(1, dialogs.size());
+        assertFalse(dialogs.get(0).isEmpty());
+    }
+
+    @Test
+    public void repeatedRejectsRaiseOneDialog() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"invalid_proof\"}");
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"invalid_proof\"}");
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"invalid_proof\"}");
+
+        assertEquals(1, dialogs.size());
+        assertEquals(1, statuses.size());
+    }
+
+    /** The pre-fix listener silently discarded a reject, which is what this asserts against. */
+    @Test
+    public void aRejectIsNotSilentlyDiscarded() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"duplicate_token\"}");
+
+        assertFalse(statuses.isEmpty(), "a reject produced no status change at all");
+        assertFalse(dialogs.isEmpty(), "a reject produced no message to the user");
+    }
+
+    @Test
+    public void aRejectIsNotMistakenForCredentials() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        JoinPoolHandler handler = handlerFor(poolIdentity);
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"missing_proof\"}");
+
+        // a reject carries no private key, so nothing may have been adopted as pool credentials
+        assertEquals("", handler.getPoolPrivateKey());
+        assertNull(handler.getCoinjoinHandler());
+    }
+
+    @Test
+    public void unparseableAndUnrelatedMessagesAreIgnored() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("not json at all");
+        handler.onDecryptedMessage("{\"type\":\"output\",\"address\":\"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq\"}");
+        handler.onDecryptedMessage("{}");
+
+        assertTrue(statuses.isEmpty(), "unrelated traffic changed the status: " + statuses);
+        assertTrue(dialogs.isEmpty());
+    }
+
+    /**
+     * The hijack from #53, driven through the listener rather than the check in isolation: a relay
+     * observer answers the join request with a pool key it controls, copying every advertised term.
+     */
+    @Test
+    public void credentialsFromAnotherKeyAreIgnoredAndTheJoinKeepsWaiting() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        Identity attacker = Identity.generateRandomIdentity();
+        JoinPoolHandler handler = handlerFor(poolIdentity);
+
+        handler.onDecryptedMessage(credentialsJson(attacker));
+
+        assertEquals("", handler.getPoolPrivateKey(), "an attacker's pool key was adopted");
+        assertNull(handler.getCoinjoinHandler(), "the coinjoin was started with hijacked credentials");
+        assertTrue(statuses.isEmpty(), "the hijack was reported as progress: " + statuses);
+    }
+}


### PR DESCRIPTION
Closes #54.

A pool creator answers a join request it will not accept with `{"type": "reject", "reason": ...}` (NIP.md, and `plugin/joinstr.py:2100-2110`). This client only ever looked for a `private_key`, so a reject was indistinguishable from an unresponsive pool and the joiner waited until the pool timeout with nothing on screen.

This is most visible with aut-ct pools, which this client cannot join at all (#66). Today that is a silent hang; after this change it says why.

## Changes

`fix: surface a reject from the pool creator`

- `JoinstrMessage` gains `reason`.
- The listener body moves out of the lambda into `onDecryptedMessage`, so the dispatch that decides what an incoming message means is a named method that can be driven directly.
- It recognises `type == "reject"`, shows the reason and stops the pool. Guarded with an `AtomicBoolean` so a repeated reject does not stack dialogs.
- `rejectionMessage` maps the three reasons the reference implementation sends to readable text and passes anything else through unchanged.
- New `FxDispatch.run`, which marshals to the JavaFX thread when there is a toolkit and runs inline when there is not. Every UI hop in `JoinPoolHandler` goes through it. Without this the class cannot be exercised at all outside a running application, because `Platform.runLater` throws `IllegalStateException: Toolkit not initialized`.
- The error dialog is behind a settable `Consumer<String>` for the same reason.

`test: cover reject handling through the message listener`

Eight cases, all driving `onDecryptedMessage`, which is the same entry point the relay listener calls. This is the code that had the bug, rather than a helper beside it:

- a reject sets the status to "Rejected" and produces one message naming the reason
- an unknown reason still reaches the user rather than being swallowed
- a reject with no reason at all still stops the join
- three identical rejects raise one dialog, not three
- a reject is not silently discarded, which is the pre-fix behaviour stated directly
- a reject is not mistaken for credentials: no pool key is adopted and no coinjoin handler is created
- unparseable input, an unrelated output message and an empty object all leave the status untouched
- credentials signed by a key other than the pool's are ignored and the join keeps waiting

That last one is the #53 hijack driven end to end through the listener. #53 shipped with the check tested in isolation; this covers the path a relay actually takes to reach it.

## Verification

`./gradlew :test` green, 66 tests.

Removing just the reject branch from `onDecryptedMessage`, which is the pre-fix dispatch, fails 5 of the 8. The remaining 3 cover behaviour that was already correct and is now pinned.
