### PR TITLE
fix: stop logging the input to output linkage

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -91,7 +91,7 @@ public class CoinjoinHandler {
         try {
             Address.fromString(myOutputAddress);
         } catch (Exception e) {
-            logger.severe("Invalid address: " + myOutputAddress);
+            logger.severe("Own output address is not a valid bitcoin address");
             updateStatus("Error: Invalid address");
             return;
         }
@@ -175,7 +175,7 @@ public class CoinjoinHandler {
 
                 nip04.send(Map.of("default", relay));
 
-                logger.info("Output registered: " + address);
+                logger.info("Output registered");
             } catch (Exception e) {
                 logger.severe("Failed to send output: " + e.getMessage());
                 updateStatus("Error: Check logs");
@@ -188,7 +188,7 @@ public class CoinjoinHandler {
         messageListener.startListening(this::handleDecryptedMessage);
     }
 
-    private void handleDecryptedMessage(String decryptedMessage) {
+    void handleDecryptedMessage(String decryptedMessage) {
         try {
             JoinstrMessage message = JoinstrMessage.fromJson(decryptedMessage);
             String type = message.getType();
@@ -213,7 +213,7 @@ public class CoinjoinHandler {
             try {
                 Address.fromString(addressStr);
             } catch (Exception e) {
-                logger.warning("Received invalid output address: " + addressStr);
+                logger.warning("Ignoring an output that is not a valid bitcoin address");
                 return;
             }
 
@@ -224,13 +224,13 @@ public class CoinjoinHandler {
 
                 outputAddresses.add(addressStr);
                 pool.setConnectedPeers(outputAddresses.size());
-                logger.info("Received output " + outputAddresses.size() + "/" + numPeers + ": " + addressStr);
+                logger.info("Received output " + outputAddresses.size() + "/" + numPeers);
 
                 if (outputAddresses.size() == numPeers) {
                     logger.info("All outputs registered, ready for input registration");
                     updateStatus("Input registration");
                     if (onReadyForInputCallback != null) {
-                        Platform.runLater(onReadyForInputCallback);
+                        FxDispatch.run(onReadyForInputCallback);
                     }
                 }
             }
@@ -243,8 +243,9 @@ public class CoinjoinHandler {
      * Start input phase - create and sign PSBT with selected UTXO.
      */
     public void startInputPhase(BlockTransactionHashIndex selectedUtxo, WalletNode utxoNode) {
-        logger.info("UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() +
-                ", value=" + selectedUtxo.getValue() + " sats");
+        // The outpoint alongside the registered outputs is the input to output linkage this
+        // coinjoin exists to break, so log shapes rather than values.
+        logger.info("Starting input registration");
 
         long value = selectedUtxo.getValue();
         long minAllowed = CoinjoinMath.minInputSats(poolAmountSats);
@@ -346,7 +347,7 @@ public class CoinjoinHandler {
 
             List<String> sortedOutputs = new ArrayList<>(outputAddresses);
             Collections.sort(sortedOutputs);
-            logger.info("Sorted " + sortedOutputs.size() + " output addresses for deterministic ordering");
+            logger.info("Sorted " + sortedOutputs.size() + " outputs for deterministic ordering");
 
             for (String addr : sortedOutputs) {
                 Address address = Address.fromString(addr);
@@ -407,12 +408,12 @@ public class CoinjoinHandler {
                 return;
             }
 
-            logger.info("Signing PSBT with : " + utxoNode.getDerivationPath());
+            logger.info("Signing the registration PSBT");
 
             com.sparrowwallet.drongo.crypto.ECKey privateKey = keystore.getKey(utxoNode);
 
             if (privateKey == null || !privateKey.hasPrivKey()) {
-                logger.severe("Could not get private key for: " + utxoNode.getDerivationPath());
+                logger.severe("Could not get the private key for the selected UTXO");
                 updateStatus("Error: Check logs");
                 return;
             }
@@ -524,7 +525,7 @@ public class CoinjoinHandler {
                 for (PSBTInput input : psbt.getPsbtInputs()) {
                     String outpoint = input.getInput().getOutpoint().toString();
                     if (allInputs.contains(outpoint)) {
-                        logger.warning("Rejecting duplicate input: " + outpoint);
+                        logger.warning("Rejecting a PSBT that reuses an already registered input");
                         return;
                     }
                 }
@@ -537,13 +538,13 @@ public class CoinjoinHandler {
                         Address outputAddr = output.getScript().getToAddress();
                         String addrStr = outputAddr.toString();
                         if (!outputAddresses.contains(addrStr)) {
-                            logger.warning("Rejecting PSBT with incorrect output address: " + outputAddr);
+                            logger.warning("Rejecting a PSBT paying an output the pool did not register");
                             return;
                         }
 
                         if (output.getValue() != expectedOutputAmount) {
-                            logger.warning("Rejecting PSBT with incorrect output amount for " + addrStr + ": "
-                                    + output.getValue() + " vs expected " + expectedOutputAmount);
+                            logger.warning("Rejecting a PSBT with an output amount of "
+                                    + output.getValue() + " sats, expected " + expectedOutputAmount);
                             return;
                         }
                     } catch (Exception e) {
@@ -785,7 +786,7 @@ public class CoinjoinHandler {
 
     private void updateStatus(String status) {
         if (statusCallback != null) {
-            Platform.runLater(() -> statusCallback.accept(status));
+            FxDispatch.run(() -> statusCallback.accept(status));
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/FxDispatch.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/FxDispatch.java
@@ -1,0 +1,31 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import javafx.application.Platform;
+
+/**
+ * Runs a task on the JavaFX thread, or inline when there is no toolkit. The coinjoin phases are
+ * driven from relay callbacks and report progress to the UI, so they need to marshal, but the
+ * same code has to be runnable without a toolkit to be testable.
+ */
+public final class FxDispatch {
+
+    private FxDispatch() {
+    }
+
+    public static void run(Runnable runnable) {
+        if (runnable == null) {
+            return;
+        }
+
+        try {
+            if (Platform.isFxApplicationThread()) {
+                runnable.run();
+            } else {
+                Platform.runLater(runnable);
+            }
+        } catch (IllegalStateException e) {
+            // no toolkit, so there is no UI thread to marshal onto
+            runnable.run();
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -49,6 +49,73 @@ public class JoinPoolHandler {
     }
 
     /**
+     * Handle one decrypted message received while waiting for credentials. This is what the relay
+     * listener calls for every message addressed to the joiner's throwaway key.
+     */
+    void onDecryptedMessage(String decryptedMessage) {
+        JoinstrMessage message;
+        try {
+            message = JoinstrMessage.fromJson(decryptedMessage);
+        } catch (Exception e) {
+            logger.warning("Ignoring unparseable message while waiting for credentials");
+            return;
+        }
+
+        if (message == null) {
+            return;
+        }
+
+        if ("reject".equals(message.getType())) {
+            handleRejected(message);
+            return;
+        }
+
+        if (message.getPrivateKey() == null) {
+            return;
+        }
+
+        String rejection = credentialsRejectionReason(message, pool);
+        if (rejection != null) {
+            // nip 04 does not authenticate the sender and this key is public on the relay from
+            // the moment the join request is published, so anyone can answer it. Keep waiting
+            // for the pool that was actually chosen instead of taking the first reply.
+            logger.warning("Ignoring credentials that did not come from the pool joined: " + rejection);
+            return;
+        }
+
+        handleCredentialsReceived(message);
+    }
+
+    /** A readable explanation for a reject sent by a pool creator. */
+    static String rejectionMessage(JoinstrMessage reject) {
+        String reason = reject.getReason();
+        if (reason == null || reason.trim().isEmpty()) {
+            return "The pool creator rejected your request.";
+        }
+
+        String detail = switch (reason) {
+            case "missing_proof" -> "An aut-ct proof is required to join this pool.";
+            case "invalid_proof" -> "The provided aut-ct proof could not be verified.";
+            case "duplicate_token" -> "The aut-ct token has already been used.";
+            default -> reason;
+        };
+
+        return "The pool creator rejected your request: " + detail;
+    }
+
+    private void handleRejected(JoinstrMessage reject) {
+        if (!rejected.compareAndSet(false, true)) {
+            return;
+        }
+
+        String message = rejectionMessage(reject);
+        logger.warning(message);
+        FxDispatch.run(() -> statusCallback.accept("Rejected"));
+        FxDispatch.run(() -> errorDialog.accept(message));
+        stop();
+    }
+
+    /**
      * Why the credentials do not belong to this pool, or null if they do.
      *
      * The private key inside them must be the key of the pool that was joined, which nobody but
@@ -129,40 +196,19 @@ public class JoinPoolHandler {
      * Start listening for credentials after sending join request
      */
     public void startListeningForCredentials() {
-        Platform.runLater(() -> statusCallback.accept("Waiting for credentials"));
+        FxDispatch.run(() -> statusCallback.accept("Waiting for credentials"));
 
         credentialsListener = new NostrListener(joinIdentity, relay, null);
 
-        credentialsListener.startListening(decryptedMessage -> {
-            JoinstrMessage message;
-            try {
-                message = JoinstrMessage.fromJson(decryptedMessage);
-            } catch (Exception e) {
-                logger.warning("Ignoring unparseable message while waiting for credentials");
-                return;
-            }
-
-            if (message == null || message.getPrivateKey() == null) {
-                return;
-            }
-
-            String rejection = credentialsRejectionReason(message, pool);
-            if (rejection != null) {
-                // nip 04 does not authenticate the sender and this key is public on the relay from
-                // the moment the join request is published, so anyone can answer it. Keep waiting
-                // for the pool that was actually chosen instead of taking the first reply.
-                logger.warning("Ignoring credentials that did not come from the pool joined: " + rejection);
-                return;
-            }
-
-            handleCredentialsReceived(message);
-        });
+        credentialsListener.startListening(this::onDecryptedMessage);
     }
 
     /**
      * Handle received pool credentials
      */
     private final AtomicBoolean credentialsReceived = new AtomicBoolean(false);
+    private final AtomicBoolean rejected = new AtomicBoolean(false);
+    private Consumer<String> errorDialog = message -> AppServices.showErrorDialog("Join Request Rejected", message);
 
     private void handleCredentialsReceived(JoinstrMessage message) {
         if (!credentialsReceived.compareAndSet(false, true)) {
@@ -200,7 +246,7 @@ public class JoinPoolHandler {
                 logger.warning("Error stopping credentials listener: " + e.getMessage());
             }
 
-            Platform.runLater(() -> statusCallback.accept("Credentials received"));
+            FxDispatch.run(() -> statusCallback.accept("Credentials received"));
 
             double advertisedFeeRate = pool.getParsedFeeRate();
             double credentialsFeeRate = (message.getFeeRate() != null) ? message.getFeeRate() : advertisedFeeRate;
@@ -209,7 +255,7 @@ public class JoinPoolHandler {
                 logger.severe("Rejecting pool: fee rate " + credentialsFeeRate
                         + " sat/vB is outside the accepted range for advertised " + advertisedFeeRate
                         + " sat/vB (absolute max " + MAX_FEE_RATE + ")");
-                Platform.runLater(() -> statusCallback.accept("Error: Fee rate out of range"));
+                FxDispatch.run(() -> statusCallback.accept("Error: Fee rate out of range"));
                 stop();
                 return;
             }
@@ -222,7 +268,7 @@ public class JoinPoolHandler {
         } catch (Exception e) {
             logger.severe("Error processing credentials: " + e.getMessage());
             e.printStackTrace();
-            Platform.runLater(() -> statusCallback.accept("Error " + e.getMessage()));
+            FxDispatch.run(() -> statusCallback.accept("Error " + e.getMessage()));
         }
     }
 
@@ -238,7 +284,7 @@ public class JoinPoolHandler {
             Map.Entry<com.sparrowwallet.drongo.wallet.Wallet, Storage> selectedWallet = selectWallet(openWallets);
             if (selectedWallet == null) {
                 logger.warning("No wallet selected for coinjoin");
-                Platform.runLater(() -> statusCallback.accept("Error: No wallet selected"));
+                FxDispatch.run(() -> statusCallback.accept("Error: No wallet selected"));
                 return;
             }
             com.sparrowwallet.drongo.wallet.Wallet wallet = selectedWallet.getKey();
@@ -262,7 +308,7 @@ public class JoinPoolHandler {
         } catch (Exception e) {
             logger.severe("Error starting coinjoin flow: " + e.getMessage());
             e.printStackTrace();
-            Platform.runLater(() -> statusCallback.accept("Error: " + e.getMessage()));
+            FxDispatch.run(() -> statusCallback.accept("Error: " + e.getMessage()));
         }
     }
 
@@ -288,7 +334,7 @@ public class JoinPoolHandler {
         if (Platform.isFxApplicationThread()) {
             task.run();
         } else {
-            Platform.runLater(task);
+            FxDispatch.run(task);
         }
         return task.get();
     }
@@ -302,12 +348,16 @@ public class JoinPoolHandler {
             coinjoinHandler.startInputPhase(utxo, utxoNode);
         } else {
             logger.severe("CoinjoinHandler not initialized");
-            Platform.runLater(() -> statusCallback.accept("Error: Handler not ready"));
+            FxDispatch.run(() -> statusCallback.accept("Error: Handler not ready"));
         }
     }
 
     public boolean isReadyForInputPhase() {
         return coinjoinHandler != null && coinjoinHandler.isReadyForInputPhase();
+    }
+
+    void setErrorDialog(Consumer<String> errorDialog) {
+        this.errorDialog = errorDialog;
     }
 
     public CoinjoinHandler getCoinjoinHandler() {
@@ -354,19 +404,19 @@ public class JoinPoolHandler {
 
                 if (confirm.isEmpty() || confirm.get() != ButtonType.OK) {
                     logger.info("User cancelled coinjoin input confirmation");
-                    Platform.runLater(() -> statusCallback.accept("Input registration cancelled"));
+                    FxDispatch.run(() -> statusCallback.accept("Input registration cancelled"));
                     return;
                 }
 
                 coinjoinHandler.startInputPhase(selectedUtxo, utxoNode);
             } else {
                 logger.warning("No UTXO selected, input registration cancelled");
-                Platform.runLater(() -> statusCallback.accept("Input registration cancelled"));
+                FxDispatch.run(() -> statusCallback.accept("Input registration cancelled"));
             }
         } catch (Exception e) {
             logger.severe("Error showing UTXO dialog: " + e.getMessage());
             e.printStackTrace();
-            Platform.runLater(() -> statusCallback.accept("Error: " + e.getMessage()));
+            FxDispatch.run(() -> statusCallback.accept("Error: " + e.getMessage()));
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -303,7 +303,7 @@ public class JoinPoolHandler {
             });
 
             coinjoinHandler.startOutputPhase(myOutputAddress.toString());
-            logger.info("Started coinjoin flow with output address: " + myOutputAddress);
+            logger.info("Started coinjoin flow");
 
         } catch (Exception e) {
             logger.severe("Error starting coinjoin flow: " + e.getMessage());
@@ -387,8 +387,7 @@ public class JoinPoolHandler {
                         .getWalletUtxos();
                 com.sparrowwallet.drongo.wallet.WalletNode utxoNode = utxoMap.get(selectedUtxo);
 
-                logger.info("Selected UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() + " value="
-                        + selectedUtxo.getValue());
+                logger.info("UTXO selected for the coinjoin");
 
                 long outputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate,
                         coinjoinHandler.getNumPeers());

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -14,6 +14,7 @@ public class JoinstrMessage {
     private Integer peers;
     private Long timeout;
     private String relay;
+    private String reason;
 
     public String getType() {
         return type;
@@ -93,6 +94,14 @@ public class JoinstrMessage {
 
     public void setRelay(String relay) {
         this.relay = relay;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 
     public Double getFeeRate() {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -167,7 +167,7 @@ public class JoinstrPool {
     }
 
     public void setConnectedPeers(int count) {
-        javafx.application.Platform.runLater(() -> connectedPeers.set(count));
+        FxDispatch.run(() -> connectedPeers.set(count));
     }
 
     public javafx.beans.property.SimpleIntegerProperty connectedPeersProperty() {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
@@ -181,7 +181,7 @@ public class NewPoolController extends JoinstrFormController {
             });
 
             coinjoinHandler.startOutputPhase(myOutputAddress);
-            logger.info("Pool creator started coinjoin flow with output: " + myOutputAddress);
+            logger.info("Pool creator started coinjoin flow");
 
             shareCredentials(poolIdentity, pool.getRelay(), pool.toCredentials());
 
@@ -211,8 +211,7 @@ public class NewPoolController extends JoinstrFormController {
                         .getWalletUtxos();
                 com.sparrowwallet.drongo.wallet.WalletNode utxoNode = utxoMap.get(selectedUtxo);
 
-                logger.info("Selected UTXO: " + selectedUtxo.getHash() + ":" + selectedUtxo.getIndex() + " value="
-                        + selectedUtxo.getValue());
+                logger.info("UTXO selected for the coinjoin");
 
                 coinjoinHandler.startInputPhase(selectedUtxo, utxoNode);
             } else {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -107,8 +107,7 @@ public class NostrListener implements AutoCloseable {
                 return;
             }
 
-            logger.info("Received encrypted DM from: " + senderPubkey + " to: " + recipientPubkey);
-            logger.info("Time: " + new Date(timestamp * 1000));
+            logger.fine("Received an encrypted DM addressed to this key");
 
             try {
                 String decryptedContent = NIP04.decrypt(

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/LogLinkageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/LogLinkageTest.java
@@ -1,0 +1,174 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The selected outpoint together with the registered output addresses is exactly the linkage a
+ * coinjoin exists to break. Writing both into one log file hands it to anyone who reads that file,
+ * or to anyone the user sends it to when reporting a bug.
+ */
+public class LogLinkageTest {
+
+    private static final String PEER_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    private static final String OWN_ADDRESS = "bc1q9d4ywgfnd8h43da5tpcxcn6ajv590cg6d3tg6axemvljvt2k76zs50tv4q";
+
+    private final List<String> logged = new ArrayList<>();
+    private final List<Logger> attached = new ArrayList<>();
+    private Handler capture;
+
+    @BeforeEach
+    public void captureJoinstrLogs() {
+        capture = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logged.add(String.valueOf(record.getMessage()));
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        for(Class<?> type : new Class<?>[] {CoinjoinHandler.class, JoinPoolHandler.class, NostrListener.class}) {
+            Logger logger = Logger.getLogger(type.getName());
+            logger.setLevel(Level.ALL);
+            logger.addHandler(capture);
+            attached.add(logger);
+        }
+    }
+
+    @AfterEach
+    public void detach() {
+        for(Logger logger : attached) {
+            logger.removeHandler(capture);
+        }
+    }
+
+    private void assertNothingLogged(String secret, String what) {
+        assertFalse(logged.isEmpty(), "expected something to be logged");
+        for(String message : logged) {
+            assertFalse(message.contains(secret), what + " was written to the log: " + message);
+        }
+    }
+
+    private CoinjoinHandler handler() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000");
+        return new CoinjoinHandler(null, pool, null, null, status -> {
+        });
+    }
+
+    @Test
+    public void aPeerOutputAddressIsNotLogged() {
+        handler().handleDecryptedMessage(
+                "{\"type\":\"output\",\"address\":\"" + PEER_ADDRESS + "\"}");
+
+        assertNothingLogged(PEER_ADDRESS, "a peer's output address");
+        assertTrue(logged.stream().anyMatch(m -> m.contains("Received output 1/3")),
+                "the output should still be counted in the log: " + logged);
+    }
+
+    @Test
+    public void aRejectedOutputAddressIsNotEchoed() {
+        handler().handleDecryptedMessage("{\"type\":\"output\",\"address\":\"not-a-valid-address\"}");
+
+        assertNothingLogged("not-a-valid-address", "a rejected address");
+    }
+
+    @Test
+    public void ownOutputAddressIsNotLoggedWhenItIsRejected() {
+        handler().startOutputPhase("definitely-not-an-address");
+
+        assertNothingLogged("definitely-not-an-address", "the wallet's own address");
+    }
+
+    @Test
+    public void severalPeerOutputsAreCountedWithoutNamingAny() {
+        CoinjoinHandler handler = handler();
+
+        handler.handleDecryptedMessage("{\"type\":\"output\",\"address\":\"" + PEER_ADDRESS + "\"}");
+        handler.handleDecryptedMessage("{\"type\":\"output\",\"address\":\"" + OWN_ADDRESS + "\"}");
+
+        assertNothingLogged(PEER_ADDRESS, "a peer's output address");
+        assertNothingLogged(OWN_ADDRESS, "a peer's output address");
+        assertTrue(logged.stream().anyMatch(m -> m.contains("2/3")), logged.toString());
+    }
+
+    /**
+     * A backstop for the paths that need a wallet and a relay to reach, which the cases above
+     * cannot drive. Walks the joinstr sources and reassembles each logger statement across wrapped
+     * lines, so a value interpolated on a continuation line is still seen.
+     */
+    @Test
+    public void noLoggerCallInterpolatesAnAddressOrOutpoint() throws IOException {
+        Path dir = Paths.get(System.getProperty("user.dir"),
+                "src", "main", "java", "com", "sparrowwallet", "sparrow", "joinstr");
+        assumeTrue(Files.isDirectory(dir), "joinstr sources not found at " + dir);
+
+        String[] sensitive = {"getHash()", "getOutpoint()", "getDerivationPath()",
+                "myOutputAddress", "addressStr", "senderPubkey", "recipientPubkey"};
+
+        List<String> offenders = new ArrayList<>();
+        try(Stream<Path> files = Files.walk(dir)) {
+            for(Path file : files.filter(f -> f.toString().endsWith(".java")).toList()) {
+                for(String statement : loggerStatements(file)) {
+                    for(String value : sensitive) {
+                        if(statement.contains(value)) {
+                            offenders.add(file.getFileName() + ": " + statement);
+                        }
+                    }
+                }
+            }
+        }
+
+        assertTrue(offenders.isEmpty(),
+                "logger calls must not interpolate an address, outpoint or derivation path:\n"
+                        + String.join("\n", offenders));
+    }
+
+    private List<String> loggerStatements(Path file) throws IOException {
+        List<String> statements = new ArrayList<>();
+        StringBuilder current = null;
+
+        for(String line : Files.readAllLines(file)) {
+            String trimmed = line.trim();
+            if(current == null) {
+                if(trimmed.startsWith("logger.info(") || trimmed.startsWith("logger.warning(")
+                        || trimmed.startsWith("logger.severe(") || trimmed.startsWith("log.info(")
+                        || trimmed.startsWith("log.warn(")) {
+                    current = new StringBuilder(trimmed);
+                } else {
+                    continue;
+                }
+            } else {
+                current.append(' ').append(trimmed);
+            }
+
+            if(current.toString().endsWith(");")) {
+                statements.add(current.toString());
+                current = null;
+            }
+        }
+        return statements;
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/RejectMessageTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/RejectMessageTest.java
@@ -1,0 +1,144 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Drives the same entry point the relay listener drives, so these cover the dispatch that had the
+ * bug rather than a helper beside it. A pool creator answers a join request it will not accept
+ * with a reject carrying a reason; ignoring it left the joiner waiting until the pool timeout.
+ */
+public class RejectMessageTest {
+
+    private static final String RELAY = "wss://nos.lol";
+    private static final String POOL_ID = "0123456789abcdef";
+
+    private final List<String> statuses = new ArrayList<>();
+    private final List<String> dialogs = new ArrayList<>();
+
+    private JoinPoolHandler handlerFor(Identity poolIdentity) {
+        JoinstrPool pool = new JoinstrPool(RELAY, poolIdentity.getPublicKey().toString(),
+                "0.001", "3", "1750000000");
+        pool.setPoolId(POOL_ID);
+
+        JoinPoolHandler handler = new JoinPoolHandler(Identity.generateRandomIdentity(), pool, statuses::add);
+        handler.setErrorDialog(dialogs::add);
+        return handler;
+    }
+
+    private String credentialsJson(Identity identity) {
+        JoinstrMessage credentials = new JoinstrMessage();
+        credentials.setType("credentials");
+        credentials.setPrivateKey(identity.getPrivateKey().toString());
+        credentials.setId(POOL_ID);
+        credentials.setPublicKey(identity.getPublicKey().toString());
+        credentials.setDenomination(0.001);
+        credentials.setPeers(3);
+        credentials.setTimeout(1750000000L);
+        credentials.setRelay(RELAY);
+        credentials.setFeeRate(1.0);
+        return credentials.toJson();
+    }
+
+    @Test
+    public void aRejectStopsTheJoinAndSaysWhy() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"missing_proof\"}");
+
+        assertEquals(List.of("Rejected"), statuses);
+        assertEquals(1, dialogs.size());
+        assertTrue(dialogs.get(0).contains("aut-ct proof is required"), dialogs.get(0));
+    }
+
+    @Test
+    public void anUnknownReasonStillReachesTheUser() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"pool_full\"}");
+
+        assertEquals(1, dialogs.size());
+        assertTrue(dialogs.get(0).contains("pool_full"), dialogs.get(0));
+    }
+
+    @Test
+    public void aRejectWithNoReasonStillStopsTheJoin() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\"}");
+
+        assertEquals(List.of("Rejected"), statuses);
+        assertEquals(1, dialogs.size());
+        assertFalse(dialogs.get(0).isEmpty());
+    }
+
+    @Test
+    public void repeatedRejectsRaiseOneDialog() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"invalid_proof\"}");
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"invalid_proof\"}");
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"invalid_proof\"}");
+
+        assertEquals(1, dialogs.size());
+        assertEquals(1, statuses.size());
+    }
+
+    /** The pre-fix listener silently discarded a reject, which is what this asserts against. */
+    @Test
+    public void aRejectIsNotSilentlyDiscarded() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"duplicate_token\"}");
+
+        assertFalse(statuses.isEmpty(), "a reject produced no status change at all");
+        assertFalse(dialogs.isEmpty(), "a reject produced no message to the user");
+    }
+
+    @Test
+    public void aRejectIsNotMistakenForCredentials() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        JoinPoolHandler handler = handlerFor(poolIdentity);
+
+        handler.onDecryptedMessage("{\"type\":\"reject\",\"reason\":\"missing_proof\"}");
+
+        // a reject carries no private key, so nothing may have been adopted as pool credentials
+        assertEquals("", handler.getPoolPrivateKey());
+        assertNull(handler.getCoinjoinHandler());
+    }
+
+    @Test
+    public void unparseableAndUnrelatedMessagesAreIgnored() {
+        JoinPoolHandler handler = handlerFor(Identity.generateRandomIdentity());
+
+        handler.onDecryptedMessage("not json at all");
+        handler.onDecryptedMessage("{\"type\":\"output\",\"address\":\"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq\"}");
+        handler.onDecryptedMessage("{}");
+
+        assertTrue(statuses.isEmpty(), "unrelated traffic changed the status: " + statuses);
+        assertTrue(dialogs.isEmpty());
+    }
+
+    /**
+     * The hijack from #53, driven through the listener rather than the check in isolation: a relay
+     * observer answers the join request with a pool key it controls, copying every advertised term.
+     */
+    @Test
+    public void credentialsFromAnotherKeyAreIgnoredAndTheJoinKeepsWaiting() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        Identity attacker = Identity.generateRandomIdentity();
+        JoinPoolHandler handler = handlerFor(poolIdentity);
+
+        handler.onDecryptedMessage(credentialsJson(attacker));
+
+        assertEquals("", handler.getPoolPrivateKey(), "an attacker's pool key was adopted");
+        assertNull(handler.getCoinjoinHandler(), "the coinjoin was started with hijacked credentials");
+        assertTrue(statuses.isEmpty(), "the hijack was reported as progress: " + statuses);
+    }
+}


### PR DESCRIPTION
Closes #60.

Based on #74, so it is two commits on top of that branch. Merge #74 first.

The selected outpoint and the registered output addresses were both written to the log at INFO, so one Sparrow log file contained exactly the linkage the coinjoin exists to break. That matters most at the moment a user sends a log to someone to report a bug.

The joinstr project made the same fix on its side in commit `ae4609f`, "fix: stop logging the input to output linkage", replacing values with shapes.

## Changes

`fix: stop logging the input to output linkage`

Values removed from log calls across four files, keeping the counts and phase transitions that make the log useful:

- `CoinjoinHandler`: the selected outpoint and value, the registered output address, each received peer output address, the signing derivation path, the duplicate input outpoint, and the peer address in the two PSBT rejection warnings. The output amount is kept in the amount mismatch warning, since that is the number being diagnosed.
- `JoinPoolHandler` and `NewPoolController`: the selected outpoint and value, and the output address at coinjoin start.
- `NostrListener`: the sender and recipient pubkeys of every decrypted DM, plus its timestamp, dropped to a FINE line with no identifiers.

`CoinjoinHandler.updateStatus`, the ready-for-input callback and `JoinstrPool.setConnectedPeers` now go through `FxDispatch` (added in #74), and `handleDecryptedMessage` is package-private, so the message handling can be driven without a toolkit.

`test: cover that the coinjoin linkage is not logged`

Four of the five cases attach a capturing handler to the joinstr loggers and drive real message handling, then assert the address never appears in anything logged:

- a peer output address is not logged, while "Received output 1/3" still is, so the log stays useful
- an invalid peer address is not echoed back in the rejection warning
- the wallet's own address is not logged when it fails validation
- two peer outputs are counted as "2/3" without either address appearing

The fifth walks the joinstr sources and fails on any logger statement interpolating `getHash()`, `getOutpoint()`, `getDerivationPath()` or a known address variable, reassembling statements across wrapped lines. That one is a backstop for the paths that need a wallet and a live relay to reach, not the primary check.

## Verification

`./gradlew :test` green, 69 tests.

Restoring the three original log strings while leaving everything else in place fails all five, so they hold the change down rather than describing it.
