### PR TITLE
fix: write the pool store so only its owner can read it

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrHistoryEntry.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrHistoryEntry.java
@@ -101,8 +101,6 @@ public class JoinstrHistoryEntry {
         Gson gson = new Gson();
         ArrayList<JoinstrHistoryEntry> historyStore = Config.get().getHistoryStore();
         String historyJson = gson.toJson(new JoinstrHistoryStoreWrapper(historyStore));
-        try (FileWriter writer = new FileWriter(filePath)) {
-            writer.write(historyJson);
-        }
+        SecureFile.write(filePath, historyJson);
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -289,9 +289,8 @@ public class JoinstrPool {
         ArrayList<JoinstrPool> poolStore = Config.get().getPoolStore();
         JoinstrPool[] pools = poolStore.toArray(new JoinstrPool[0]);
         String poolsJson = gson.toJson(new JoinstrPoolStoreWrapper(pools));
-        try (FileWriter writer = new FileWriter(filePath)) {
-            writer.write(poolsJson);
-        }
+        // This file holds the private key of every pool, so it must not be world readable.
+        SecureFile.write(filePath, poolsJson);
 
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/SecureFile.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/SecureFile.java
@@ -1,0 +1,72 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+/**
+ * Writes a file only its owner can read. The joinstr pool store holds the nostr private key of
+ * every pool, which is the key to that pool's encrypted channel.
+ */
+public final class SecureFile {
+
+    static final String OWNER_ONLY = "rw-------";
+
+    private SecureFile() {
+    }
+
+    public static void write(String filePath, String content) throws IOException {
+        Path path = Paths.get(filePath);
+
+        if (!Files.exists(path)) {
+            createRestricted(path);
+        } else {
+            restrict(path);
+        }
+
+        Files.writeString(path, content, StandardCharsets.UTF_8,
+                StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private static void createRestricted(Path path) throws IOException {
+        if (supportsPosix(path)) {
+            Files.createFile(path,
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(OWNER_ONLY)));
+        } else {
+            Files.createFile(path);
+            restrictWithFileApi(path);
+        }
+    }
+
+    private static void restrict(Path path) throws IOException {
+        if (supportsPosix(path)) {
+            Set<PosixFilePermission> permissions = PosixFilePermissions.fromString(OWNER_ONLY);
+            if (!permissions.equals(Files.getPosixFilePermissions(path))) {
+                Files.setPosixFilePermissions(path, permissions);
+            }
+        } else {
+            restrictWithFileApi(path);
+        }
+    }
+
+    /** Best effort on a filesystem without posix permissions, such as Windows. */
+    private static void restrictWithFileApi(Path path) {
+        File file = path.toFile();
+        file.setReadable(false, false);
+        file.setWritable(false, false);
+        file.setExecutable(false, false);
+        file.setReadable(true, true);
+        file.setWritable(true, true);
+    }
+
+    private static boolean supportsPosix(Path path) {
+        return path.getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/SecureFileTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/SecureFileTest.java
@@ -1,0 +1,83 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The pool store holds the nostr private key of every pool, which is the key to that pool's
+ * encrypted channel. It used to be written through a plain FileWriter, so it landed at the
+ * process umask and was typically readable by any local user.
+ */
+public class SecureFileTest {
+
+    private boolean posix(Path path) {
+        return path.getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+
+    @Test
+    public void aNewFileIsOwnerReadableOnly(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("pools.json");
+        SecureFile.write(file.toString(), "{\"poolsList\":[]}");
+
+        assumeTrue(posix(file), "no posix permissions on this filesystem");
+        assertEquals(PosixFilePermissions.fromString("rw-------"), Files.getPosixFilePermissions(file));
+    }
+
+    @Test
+    public void contentRoundTrips(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("pools.json");
+        String content = "{\"poolsList\":[{\"privateKey\":\"deadbeef\"}]}";
+
+        SecureFile.write(file.toString(), content);
+
+        assertEquals(content, Files.readString(file));
+    }
+
+    /** A store written by an older version is already world readable, so tighten it on write. */
+    @Test
+    public void anExistingWorldReadableFileIsTightened(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("pools.json");
+        Files.writeString(file, "old");
+        assumeTrue(posix(file), "no posix permissions on this filesystem");
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r--r--"));
+
+        SecureFile.write(file.toString(), "new");
+
+        assertEquals(PosixFilePermissions.fromString("rw-------"), Files.getPosixFilePermissions(file));
+        assertEquals("new", Files.readString(file));
+    }
+
+    @Test
+    public void rewritingTruncates(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("pools.json");
+
+        SecureFile.write(file.toString(), "a much longer original payload");
+        SecureFile.write(file.toString(), "short");
+
+        assertEquals("short", Files.readString(file));
+    }
+
+    @Test
+    public void groupAndOtherNeverGetAccess(@TempDir Path dir) throws IOException {
+        Path file = dir.resolve("pools.json");
+        SecureFile.write(file.toString(), "{}");
+
+        assumeTrue(posix(file), "no posix permissions on this filesystem");
+        Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(file);
+        for(PosixFilePermission denied : new PosixFilePermission[] {
+                PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE,
+                PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_WRITE}) {
+            assertFalse(permissions.contains(denied), denied + " must not be granted");
+        }
+    }
+}


### PR DESCRIPTION
Closes #61. Partial progress on #34.

`pools.json` holds the nostr private key of every pool, which is the key to that pool's encrypted channel, and it was written through a plain `FileWriter`. That lands at the process umask, so on a typical Linux install the file is readable by any local user.

The reference implementation writes all pool state at mode 0600 (`_write_secure_json`, `plugin/joinstr.py:82-90`).

## Changes

`fix: write the pool store so only its owner can read it`

- New `SecureFile.write`, which creates the file with `rw-------` where the filesystem supports posix permissions, and tightens an existing file that was written by an older version before overwriting it. On a filesystem without posix permissions it falls back to the `File` setter API, clearing group and other access first and then granting owner access.
- `JoinstrPool.savePoolsFile` and `JoinstrHistoryEntry.saveHistoryFile` both go through it. The history file records coinjoin txids, so it gets the same treatment.

`test: cover owner only permissions on the pool store`

Five cases: a new file is `rw-------`; content round-trips; an existing world readable file is tightened on the next write, which is the upgrade path for anyone who already has a `pools.json`; rewriting truncates rather than leaving a tail of the previous payload; and group and other never hold read or write.

The three permission assertions skip themselves with an assumption on a filesystem without posix support, so the suite still passes on Windows.

## Verification

`./gradlew :test` green, 70 tests.

## Scope

This is the file permission half only. #34 asks for the pool private key to be encrypted, which needs a decision about where the key comes from, most naturally the wallet password. That is worth doing but is a larger change, so I have left #34 open.
