### PR TITLE
fix: never sign a registration PSBT that is spendable on its own

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -354,6 +354,13 @@ public class CoinjoinHandler {
                 tx.addOutput(outputAmount, address.getOutputScript());
             }
 
+            if (CoinjoinMath.isSpendableAlone(utxo.getValue(), outputAmount, sortedOutputs.size())) {
+                logger.severe("Refusing to sign a registration PSBT that is spendable on its own: "
+                        + sortedOutputs.size() + " outputs of " + outputAmount
+                        + " sats do not exceed the input of " + utxo.getValue() + " sats");
+                return null;
+            }
+
             PSBT psbt = new PSBT(tx);
 
             PSBTInput psbtInput = psbt.getPsbtInputs().get(0);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -66,6 +66,19 @@ public final class CoinjoinMath {
         return poolAmountSats - feePerOutput(feeRate, numPeers);
     }
 
+    /**
+     * Whether a registration PSBT would stand on its own as a valid transaction.
+     *
+     * These are signed with SIGHASH_ALL | SIGHASH_ANYONECANPAY so that the other peers' inputs can
+     * be added later, which also means anyone who reads one off the relay can broadcast it as it
+     * stands. It has to stay insolvent by itself: if the single input already covered every
+     * output, whoever broadcast it would keep the difference.
+     */
+    public static boolean isSpendableAlone(long inputSats, long outputAmount, int outputCount) {
+        long totalOut = outputAmount * (long) outputCount;
+        return totalOut < inputSats;
+    }
+
     /** Render a fee rate without a trailing ".0" when it is a whole number of sat/vB. */
     public static String formatFeeRate(double feeRate) {
         if (feeRate == Math.rint(feeRate) && Double.isFinite(feeRate)) {

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMathTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMathTest.java
@@ -98,6 +98,45 @@ public class CoinjoinMathTest {
         assertEquals(0L, CoinjoinMath.feePerOutput(5, 0));
     }
 
+    // --- registration PSBT must not stand alone ---
+
+    /**
+     * A registration PSBT is published to the pool signed with SIGHASH_ALL | SIGHASH_ANYONECANPAY,
+     * so any relay observer can broadcast it. If the single input already covered every output,
+     * they would keep the difference.
+     */
+    @Test
+    public void aNormalRegistrationIsNotSpendableAlone() {
+        long pool = 100_000L;
+        long output = CoinjoinMath.outputAmount(pool, 1, 3);
+
+        // the joiner contributes pool + margin and the outputs total three shares
+        assertFalse(CoinjoinMath.isSpendableAlone(pool + 500, output, 3));
+        assertFalse(CoinjoinMath.isSpendableAlone(pool + 5000, output, 2));
+    }
+
+    @Test
+    public void oneOutputSmallerThanTheInputIsSpendableAlone() {
+        long pool = 100_000L;
+        long output = CoinjoinMath.outputAmount(pool, 1, 1);
+
+        assertTrue(CoinjoinMath.isSpendableAlone(pool + 5000, output, 1));
+    }
+
+    @Test
+    public void outputsEqualToTheInputAreNotSpendableAlone() {
+        // the reference implementation refuses only when the outputs are strictly less than the
+        // input, so an exactly balanced transaction with no fee is not treated as a giveaway
+        assertFalse(CoinjoinMath.isSpendableAlone(200_000L, 100_000L, 2));
+        assertTrue(CoinjoinMath.isSpendableAlone(200_001L, 100_000L, 2));
+    }
+
+    @Test
+    public void aLargeInputAgainstSmallOutputsIsSpendableAlone() {
+        // an oversized input is the case the guard exists for
+        assertTrue(CoinjoinMath.isSpendableAlone(10_000_000L, 99_900L, 3));
+    }
+
     // --- sighash flag (mirrors py-joinstr test_sighash) ---
 
     @Test


### PR DESCRIPTION
Closes #56.

A registration PSBT is published to the pool signed with `SIGHASH_ALL | SIGHASH_ANYONECANPAY`, so that the other peers' inputs can be added to it later. That also means anyone reading the relay can broadcast it exactly as it stands. If the single input already covers every output, whoever does that keeps the difference.

`createCoinjoinPSBT` had no check. The reference implementation refuses (`plugin/joinstr.py:1618-1631`):

```python
total_out = sum(out.value for out in txout)
input_sats = selected_input.value_sats()
if total_out < input_sats:
    _logger.error("Refusing to sign a registration PSBT that is spendable on its own: ...")
    return None
```

## Changes

`fix: never sign a registration PSBT that is spendable on its own`

- New `CoinjoinMath.isSpendableAlone(inputSats, outputAmount, outputCount)`.
- `createCoinjoinPSBT` refuses before constructing the PSBT, so nothing is signed. The refusal names the numbers involved, since they are the user's own and are already known to them.

`test: cover the registration PSBT solvency guard`

Four cases: a normal registration at two and three peers is not spendable alone; a single output smaller than the input is; outputs exactly equal to the input are not, matching the reference implementation's strict `<` so a zero fee transaction is not treated as a giveaway; and an oversized input against small outputs is, which is the case the guard exists for.

## Verification

`./gradlew :test` green, `CoinjoinMathTest` now 18 tests.

## Honest scope note

With `peers >= 2` this cannot currently trigger, because the create form already enforces `peers > 1` (`NewPoolController.java:80-83`) and the outputs then always exceed a single input. This is an invariant guard, not a live exploit: it costs two lines and it fails closed if peer counts, denominations or the fee formula ever change. I would not describe it as a security fix on its own.
