### PR TITLE
fix: validate a peer registration PSBT before accepting it

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -532,24 +532,11 @@ public class CoinjoinHandler {
 
                 long expectedOutputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers);
 
-                Transaction tx = psbt.getTransaction();
-                for (TransactionOutput output : tx.getOutputs()) {
-                    try {
-                        Address outputAddr = output.getScript().getToAddress();
-                        String addrStr = outputAddr.toString();
-                        if (!outputAddresses.contains(addrStr)) {
-                            logger.warning("Rejecting a PSBT paying an output the pool did not register");
-                            return;
-                        }
-
-                        if (output.getValue() != expectedOutputAmount) {
-                            logger.warning("Rejecting a PSBT with an output amount of "
-                                    + output.getValue() + " sats, expected " + expectedOutputAmount);
-                            return;
-                        }
-                    } catch (Exception e) {
-                        // Not an address output, continue
-                    }
+                String rejection = RegistrationPsbt.rejectionReason(psbt, outputAddresses,
+                        expectedOutputAmount, numPeers);
+                if (rejection != null) {
+                    logger.warning("Rejecting a peer registration: " + rejection);
+                    return;
                 }
 
                 inputPSBTs.add(psbtBase64);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -88,6 +88,12 @@ public final class CoinjoinMath {
         Set<String> expected = new HashSet<>(expectedAddresses);
         Set<String> found = new HashSet<>();
 
+        // comparing sets alone lets a duplicated output through, because the extra payment is to an
+        // address that is expected and the set of addresses seen still matches
+        if (outputs.size() != expected.size()) {
+            return false;
+        }
+
         for (OutputView output : outputs) {
             if (!expected.contains(output.address())) {
                 return false;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbt.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbt.java
@@ -1,0 +1,85 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import java.util.Collection;
+
+/**
+ * Checks on a registration PSBT received from a peer.
+ *
+ * A peer's PSBT is combined into the transaction this client broadcasts, so anything wrong with it
+ * is only discovered by the network unless it is caught here. The outputs were already checked;
+ * these cover the input side and the shape of the transaction.
+ */
+public final class RegistrationPsbt {
+
+    private RegistrationPsbt() {
+    }
+
+    /** Why this PSBT cannot be accepted into the pool, or null if it can. */
+    public static String rejectionReason(PSBT psbt, Collection<String> registeredOutputs,
+            long expectedOutputAmount, int peers) {
+        if (psbt == null) {
+            return "psbt is missing";
+        }
+
+        if (psbt.getPsbtInputs().size() != 1) {
+            // each peer registers exactly one input, so a PSBT carrying several is either a
+            // different protocol or an attempt to take more than one slot
+            return "psbt must register exactly one input, found " + psbt.getPsbtInputs().size();
+        }
+
+        PSBTInput input = psbt.getPsbtInputs().get(0);
+
+        TransactionOutput witnessUtxo = input.getWitnessUtxo();
+        if (witnessUtxo == null) {
+            // without it the input value is unknown, and the fee cannot be computed at finalization
+            return "input has no witness utxo";
+        }
+
+        if (witnessUtxo.getValue() <= 0) {
+            return "input value is not positive: " + witnessUtxo.getValue();
+        }
+
+        if (!input.isSigned() && !input.isFinalized()) {
+            return "input is not signed";
+        }
+
+        SigHash sigHash = input.getSigHash();
+        if (sigHash != null && sigHash != CoinjoinMath.INPUT_SIGHASH) {
+            // a signature over anything other than all outputs plus this input does not commit to
+            // the coinjoin the pool agreed
+            return "input sighash is " + sigHash + ", expected " + CoinjoinMath.INPUT_SIGHASH;
+        }
+
+        Transaction tx = psbt.getTransaction();
+        if (tx.getOutputs().size() != peers) {
+            return "psbt has " + tx.getOutputs().size() + " outputs, expected " + peers;
+        }
+
+        for (TransactionOutput output : tx.getOutputs()) {
+            Address address;
+            try {
+                address = output.getScript().getToAddress();
+            } catch (Exception e) {
+                return "psbt has an output that is not a payment to an address";
+            }
+
+            if (address == null || !registeredOutputs.contains(address.toString())) {
+                return "psbt pays an output the pool did not register";
+            }
+
+            if (output.getValue() != expectedOutputAmount) {
+                return "psbt has an output of " + output.getValue() + " sats, expected "
+                        + expectedOutputAmount;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbtTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbtTest.java
@@ -1,0 +1,207 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A peer's registration PSBT is combined straight into the transaction this client broadcasts, so
+ * anything wrong with it is otherwise only discovered by the network, after the coinjoin has
+ * already failed and the UTXOs have been tied up for the length of the pool.
+ */
+public class RegistrationPsbtTest {
+
+    private static final long OUTPUT_AMOUNT = 99_900L;
+    private static final long INPUT_VALUE = 100_500L;
+    private static final int PEERS = 3;
+
+    private ECKey key(int seed) {
+        return ECKey.fromPrivate(BigInteger.valueOf(1000003L + seed));
+    }
+
+    private List<String> addresses(int count) {
+        List<String> addresses = new ArrayList<>();
+        for(int i = 0; i < count; i++) {
+            addresses.add(ScriptType.P2WPKH.getAddress(key(i + 50)).toString());
+        }
+        return addresses;
+    }
+
+    /** Build a registration PSBT the way CoinjoinHandler builds its own. */
+    private PSBT psbt(List<String> outputs, long outputAmount, long inputValue, SigHash sigHash,
+            boolean withWitnessUtxo, boolean sign, int inputCount) throws Exception {
+        Transaction tx = new Transaction();
+        tx.setVersion(2);
+
+        for(int i = 0; i < inputCount; i++) {
+            tx.addInput(Sha256Hash.wrap(String.format("%064x", 0xabcdef00L + i)), i, new Script(new byte[0]));
+        }
+
+        List<String> sorted = new ArrayList<>(outputs);
+        java.util.Collections.sort(sorted);
+        for(String address : sorted) {
+            tx.addOutput(outputAmount, Address.fromString(address).getOutputScript());
+        }
+
+        PSBT psbt = new PSBT(tx);
+        ECKey signingKey = key(1);
+
+        for(PSBTInput input : psbt.getPsbtInputs()) {
+            if(sigHash != null) {
+                input.setSigHash(sigHash);
+            }
+            if(withWitnessUtxo) {
+                input.setWitnessUtxo(new TransactionOutput(tx, inputValue,
+                        ScriptType.P2WPKH.getOutputScript(signingKey)));
+            }
+            if(sign) {
+                assertTrue(input.sign(signingKey), "test setup: signing the input failed");
+            }
+        }
+
+        return psbt;
+    }
+
+    private PSBT valid(List<String> outputs) throws Exception {
+        return psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 1);
+    }
+
+    private String check(PSBT psbt, List<String> registered) {
+        return RegistrationPsbt.rejectionReason(psbt, registered, OUTPUT_AMOUNT, PEERS);
+    }
+
+    @Test
+    public void aWellFormedRegistrationIsAccepted() throws Exception {
+        List<String> outputs = addresses(PEERS);
+
+        assertNull(check(valid(outputs), outputs));
+    }
+
+    @Test
+    public void anUnsignedInputIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT unsigned = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, false, 1);
+
+        assertEquals("input is not signed", check(unsigned, outputs));
+    }
+
+    @Test
+    public void aMissingWitnessUtxoIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT noUtxo = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, false, false, 1);
+
+        // without it the input value is unknown and the fee at finalization is computed from a
+        // total that silently omits this peer's contribution
+        assertEquals("input has no witness utxo", check(noUtxo, outputs));
+    }
+
+    @Test
+    public void aNonPositiveInputValueIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT zeroValue = psbt(outputs, OUTPUT_AMOUNT, 0, SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        assertNotNull(check(zeroValue, outputs));
+        assertTrue(check(zeroValue, outputs).contains("not positive"), check(zeroValue, outputs));
+    }
+
+    @Test
+    public void theWrongSighashIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT wrongSighash = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ALL, true, true, 1);
+
+        String reason = check(wrongSighash, outputs);
+        assertNotNull(reason);
+        assertTrue(reason.contains("sighash"), reason);
+    }
+
+    @Test
+    public void severalInputsInOneRegistrationAreRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT twoInputs = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 2);
+
+        String reason = check(twoInputs, outputs);
+        assertNotNull(reason);
+        assertTrue(reason.contains("exactly one input"), reason);
+    }
+
+    @Test
+    public void tooFewOutputsAreRejected() throws Exception {
+        List<String> registered = addresses(PEERS);
+        PSBT short2 = psbt(registered.subList(0, 2), OUTPUT_AMOUNT, INPUT_VALUE,
+                SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        String reason = check(short2, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("outputs, expected 3"), reason);
+    }
+
+    /**
+     * The hole in the old set based check. Every registered address is present, so the set of
+     * addresses seen matches, but one peer is paid a second time. Only counting the outputs
+     * catches it.
+     */
+    @Test
+    public void anExtraPaymentToARegisteredPeerIsRejected() throws Exception {
+        List<String> registered = addresses(PEERS);
+        List<String> withExtra = new ArrayList<>(registered);
+        withExtra.add(registered.get(0));
+
+        PSBT psbt = psbt(withExtra, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason, "a transaction paying one peer twice was accepted");
+        assertTrue(reason.contains("4 outputs, expected 3"), reason);
+
+        // and the pool's own output validation refuses it too, rather than relying on the shape
+        // check alone
+        List<CoinjoinMath.OutputView> views = new ArrayList<>();
+        for(TransactionOutput output : psbt.getTransaction().getOutputs()) {
+            views.add(new CoinjoinMath.OutputView(output.getScript().getToAddress().toString(),
+                    output.getValue()));
+        }
+        assertFalse(CoinjoinMath.validateOutputs(views, registered, OUTPUT_AMOUNT),
+                "validateOutputs accepted an extra payment to an already registered peer");
+    }
+
+    @Test
+    public void anUnregisteredOutputIsRejected() throws Exception {
+        List<String> registered = addresses(PEERS);
+        List<String> withStranger = new ArrayList<>(registered.subList(0, 2));
+        withStranger.add(ScriptType.P2WPKH.getAddress(key(99)).toString());
+
+        PSBT psbt = psbt(withStranger, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        assertEquals("psbt pays an output the pool did not register", check(psbt, registered));
+    }
+
+    @Test
+    public void theWrongOutputAmountIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT shortChanged = psbt(outputs, OUTPUT_AMOUNT - 1000, INPUT_VALUE,
+                SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        String reason = check(shortChanged, outputs);
+        assertNotNull(reason);
+        assertTrue(reason.contains("expected " + OUTPUT_AMOUNT), reason);
+    }
+
+    @Test
+    public void aMissingPsbtIsRejected() {
+        assertNotNull(RegistrationPsbt.rejectionReason(null, addresses(PEERS), OUTPUT_AMOUNT, PEERS));
+    }
+}


### PR DESCRIPTION
Closes #57.

A peer's registration PSBT is combined straight into the transaction this client broadcasts. `handleInputReceived` checked the output addresses and amounts but nothing about the input, so a PSBT that was unsigned, carried no witness UTXO, used the wrong sighash, or registered several inputs at once was accepted and only rejected later by the network, after the coinjoin had failed and every peer's UTXO had been tied up for the length of the pool.

`finalizeCoinjoin` compounded the missing witness UTXO: it sums only the inputs that have one (`CoinjoinHandler.java:702-707`), so a peer omitting it silently deflated the total and the fee handed to the broadcast service.

## Changes

`fix: validate a peer registration PSBT before accepting it`

New `RegistrationPsbt.rejectionReason`, returning why a PSBT cannot enter the pool or null if it can. It is called from `handleInputReceived` in place of the inline output loop, and checks:

- exactly one input, since each peer registers one and a PSBT with several is either a different protocol or an attempt at more than one slot
- a witness UTXO is present, with a positive value
- the input is signed or finalized
- the sighash, when the PSBT states one, is `SIGHASH_ALL | SIGHASH_ANYONECANPAY`
- the output count equals the peer count
- every output pays a registered address at exactly the expected amount, which is the check that was already there

`CoinjoinMath.validateOutputs` now also compares the output count. It previously compared sets, so a transaction paying one peer a second time passed: every output went to an expected address and the set of addresses seen still matched.

`test: cover peer registration PSBT validation`

New `RegistrationPsbtTest`, eleven cases, building real PSBTs with drongo and signing them the same way `createCoinjoinPSBT` does, rather than asserting on a stub. A well formed registration is accepted; unsigned, missing witness UTXO, non-positive input value, wrong sighash, two inputs, too few outputs, an extra payment to an already registered peer, an unregistered output, a wrong output amount and a null PSBT are each rejected with the specific reason.

## Verification

`./gradlew :test` green, 80 tests.

Removing the new input checks and both output count checks fails 7 of the 11.

The sighash check is deliberately permissive: it only fires when the PSBT states a sighash. The reference implementation does not check it at all, and a PSBT that omits the field is still legal, so requiring it would reject valid peers for no gain. A wrong stated sighash is caught; a missing one is left to the signature itself.
