### PR TITLE
fix: check the combined coinjoin before broadcasting it

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -687,26 +687,20 @@ public class CoinjoinHandler {
                         ", hasFinalWitness=" + (input.getFinalScriptWitness() != null));
             }
 
-            long totalInputValue = 0;
-            for (PSBTInput input : combinedPsbt.getPsbtInputs()) {
-                if (input.getWitnessUtxo() != null) {
-                    totalInputValue += input.getWitnessUtxo().getValue();
-                }
-            }
+            long expectedOutputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers);
+            boolean enforceFeeBounds = com.sparrowwallet.drongo.Network.get()
+                    != com.sparrowwallet.drongo.Network.REGTEST;
 
-            Transaction finalTx = combinedPsbt.extractTransaction();
-
-            if (!validateOutputs(finalTx, outputAddresses)) {
+            String rejection = CoinjoinTransaction.rejectionReason(combinedPsbt, outputAddresses,
+                    expectedOutputAmount, numPeers, enforceFeeBounds);
+            if (rejection != null) {
+                logger.severe("Refusing to broadcast the coinjoin: " + rejection);
                 updateStatus("Error: Check logs");
                 return;
             }
 
-            long totalOutputValue = 0;
-            for (TransactionOutput output : finalTx.getOutputs()) {
-                totalOutputValue += output.getValue();
-            }
-
-            long fee = totalInputValue - totalOutputValue;
+            Transaction finalTx = combinedPsbt.extractTransaction();
+            long fee = CoinjoinTransaction.fee(combinedPsbt);
             logger.info("Final transaction: txid=" + finalTx.getTxId() + ", fee=" + fee + " sats");
 
             updateStatus("broadcast");

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -532,24 +532,11 @@ public class CoinjoinHandler {
 
                 long expectedOutputAmount = CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers);
 
-                Transaction tx = psbt.getTransaction();
-                for (TransactionOutput output : tx.getOutputs()) {
-                    try {
-                        Address outputAddr = output.getScript().getToAddress();
-                        String addrStr = outputAddr.toString();
-                        if (!outputAddresses.contains(addrStr)) {
-                            logger.warning("Rejecting a PSBT paying an output the pool did not register");
-                            return;
-                        }
-
-                        if (output.getValue() != expectedOutputAmount) {
-                            logger.warning("Rejecting a PSBT with an output amount of "
-                                    + output.getValue() + " sats, expected " + expectedOutputAmount);
-                            return;
-                        }
-                    } catch (Exception e) {
-                        // Not an address output, continue
-                    }
+                String rejection = RegistrationPsbt.rejectionReason(psbt, outputAddresses,
+                        expectedOutputAmount, numPeers);
+                if (rejection != null) {
+                    logger.warning("Rejecting a peer registration: " + rejection);
+                    return;
                 }
 
                 inputPSBTs.add(psbtBase64);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -88,6 +88,12 @@ public final class CoinjoinMath {
         Set<String> expected = new HashSet<>(expectedAddresses);
         Set<String> found = new HashSet<>();
 
+        // comparing sets alone lets a duplicated output through, because the extra payment is to an
+        // address that is expected and the set of addresses seen still matches
+        if (outputs.size() != expected.size()) {
+            return false;
+        }
+
         for (OutputView output : outputs) {
             if (!expected.contains(output.address())) {
                 return false;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinTransaction.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinTransaction.java
@@ -1,0 +1,130 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Last checks on the combined coinjoin before it is broadcast.
+ *
+ * Each peer's own registration was already checked as it arrived. These are the properties that
+ * only exist once every registration is put together, so this is the only place they can be seen.
+ */
+public final class CoinjoinTransaction {
+
+    /** Bounds on the total fee, per participant, outside regtest. */
+    static final long MIN_FEE_PER_PEER = 100;
+    static final long MAX_FEE_PER_PEER = 10000;
+
+    private CoinjoinTransaction() {
+    }
+
+    /** Why the combined transaction must not be broadcast, or null if it may be. */
+    public static String rejectionReason(PSBT combined, Collection<String> registeredOutputs,
+            long expectedOutputAmount, int peers, boolean enforceFeeBounds) {
+        if (combined == null) {
+            return "no combined transaction";
+        }
+
+        List<String> inputAddresses = new ArrayList<>();
+        long totalInput = 0;
+
+        for (PSBTInput input : combined.getPsbtInputs()) {
+            TransactionOutput witnessUtxo = input.getWitnessUtxo();
+            if (witnessUtxo == null) {
+                // the fee would otherwise be computed from a total that omits this input
+                return "an input has no witness utxo, so the fee cannot be computed";
+            }
+
+            long value = witnessUtxo.getValue();
+            if (value <= 0) {
+                return "an input value is not positive: " + value;
+            }
+            totalInput += value;
+
+            try {
+                Address address = witnessUtxo.getScript().getToAddress();
+                if (address != null) {
+                    inputAddresses.add(address.toString());
+                }
+            } catch (Exception e) {
+                // an input that does not resolve to an address cannot be compared, and the checks
+                // below are about address reuse only
+            }
+        }
+
+        Transaction tx = combined.extractTransaction();
+
+        Set<String> outputAddresses = new HashSet<>();
+        List<CoinjoinMath.OutputView> views = new ArrayList<>();
+        for (TransactionOutput output : tx.getOutputs()) {
+            try {
+                String address = output.getScript().getToAddress().toString();
+                outputAddresses.add(address);
+                views.add(new CoinjoinMath.OutputView(address, output.getValue()));
+            } catch (Exception e) {
+                return "an output is not a payment to an address";
+            }
+        }
+
+        if (!CoinjoinMath.validateOutputs(views, registeredOutputs, expectedOutputAmount)) {
+            return "outputs do not match the addresses and amount the pool registered";
+        }
+
+        for (String inputAddress : inputAddresses) {
+            if (outputAddresses.contains(inputAddress)) {
+                // paying an input's own address defeats the coinjoin for whoever owns it
+                return "an input address is reused as an output address";
+            }
+        }
+
+        if (new HashSet<>(inputAddresses).size() != inputAddresses.size()) {
+            // two inputs from one address are visibly the same owner, which shrinks the set
+            return "two inputs spend from the same address";
+        }
+
+        long totalOutput = 0;
+        for (TransactionOutput output : tx.getOutputs()) {
+            totalOutput += output.getValue();
+        }
+
+        if (totalInput <= totalOutput) {
+            return "inputs (" + totalInput + ") must exceed outputs (" + totalOutput + ")";
+        }
+
+        if (enforceFeeBounds) {
+            long fee = totalInput - totalOutput;
+            long participants = Math.max(peers, 1);
+            if (fee < MIN_FEE_PER_PEER * participants || fee > MAX_FEE_PER_PEER * participants) {
+                return "fee of " + fee + " sats is outside the expected range for "
+                        + participants + " participants";
+            }
+        }
+
+        return null;
+    }
+
+    public static long fee(PSBT combined) {
+        long totalInput = 0;
+        for (PSBTInput input : combined.getPsbtInputs()) {
+            if (input.getWitnessUtxo() != null) {
+                totalInput += input.getWitnessUtxo().getValue();
+            }
+        }
+
+        long totalOutput = 0;
+        for (TransactionOutput output : combined.extractTransaction().getOutputs()) {
+            totalOutput += output.getValue();
+        }
+
+        return totalInput - totalOutput;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbt.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbt.java
@@ -1,0 +1,85 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import java.util.Collection;
+
+/**
+ * Checks on a registration PSBT received from a peer.
+ *
+ * A peer's PSBT is combined into the transaction this client broadcasts, so anything wrong with it
+ * is only discovered by the network unless it is caught here. The outputs were already checked;
+ * these cover the input side and the shape of the transaction.
+ */
+public final class RegistrationPsbt {
+
+    private RegistrationPsbt() {
+    }
+
+    /** Why this PSBT cannot be accepted into the pool, or null if it can. */
+    public static String rejectionReason(PSBT psbt, Collection<String> registeredOutputs,
+            long expectedOutputAmount, int peers) {
+        if (psbt == null) {
+            return "psbt is missing";
+        }
+
+        if (psbt.getPsbtInputs().size() != 1) {
+            // each peer registers exactly one input, so a PSBT carrying several is either a
+            // different protocol or an attempt to take more than one slot
+            return "psbt must register exactly one input, found " + psbt.getPsbtInputs().size();
+        }
+
+        PSBTInput input = psbt.getPsbtInputs().get(0);
+
+        TransactionOutput witnessUtxo = input.getWitnessUtxo();
+        if (witnessUtxo == null) {
+            // without it the input value is unknown, and the fee cannot be computed at finalization
+            return "input has no witness utxo";
+        }
+
+        if (witnessUtxo.getValue() <= 0) {
+            return "input value is not positive: " + witnessUtxo.getValue();
+        }
+
+        if (!input.isSigned() && !input.isFinalized()) {
+            return "input is not signed";
+        }
+
+        SigHash sigHash = input.getSigHash();
+        if (sigHash != null && sigHash != CoinjoinMath.INPUT_SIGHASH) {
+            // a signature over anything other than all outputs plus this input does not commit to
+            // the coinjoin the pool agreed
+            return "input sighash is " + sigHash + ", expected " + CoinjoinMath.INPUT_SIGHASH;
+        }
+
+        Transaction tx = psbt.getTransaction();
+        if (tx.getOutputs().size() != peers) {
+            return "psbt has " + tx.getOutputs().size() + " outputs, expected " + peers;
+        }
+
+        for (TransactionOutput output : tx.getOutputs()) {
+            Address address;
+            try {
+                address = output.getScript().getToAddress();
+            } catch (Exception e) {
+                return "psbt has an output that is not a payment to an address";
+            }
+
+            if (address == null || !registeredOutputs.contains(address.toString())) {
+                return "psbt pays an output the pool did not register";
+            }
+
+            if (output.getValue() != expectedOutputAmount) {
+                return "psbt has an output of " + output.getValue() + " sats, expected "
+                        + expectedOutputAmount;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinTransactionTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinTransactionTest.java
@@ -1,0 +1,189 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Address reuse and a wrong fee only become visible once every peer's registration has been
+ * combined, so this is the last point at which the transaction can be stopped. After this it is
+ * on the network and on chain.
+ */
+public class CoinjoinTransactionTest {
+
+    private static final int PEERS = 3;
+    private static final long OUTPUT_AMOUNT = 99_900L;
+    private static final long INPUT_VALUE = 100_200L;
+
+    private ECKey key(int seed) {
+        return ECKey.fromPrivate(BigInteger.valueOf(2000003L + seed));
+    }
+
+    private String address(int seed) {
+        return ScriptType.P2WPKH.getAddress(key(seed)).toString();
+    }
+
+    private List<String> outputs(int count) {
+        List<String> addresses = new ArrayList<>();
+        for(int i = 0; i < count; i++) {
+            addresses.add(address(i + 50));
+        }
+        return addresses;
+    }
+
+    /**
+     * Build the combined transaction the way finalizeCoinjoin does: one input per peer, each
+     * carrying its witness utxo, and the agreed output set.
+     */
+    private PSBT combined(List<String> outputAddresses, List<Integer> inputKeySeeds, long inputValue,
+            long outputAmount) throws Exception {
+        Transaction tx = new Transaction();
+        tx.setVersion(2);
+
+        for(int i = 0; i < inputKeySeeds.size(); i++) {
+            tx.addInput(Sha256Hash.wrap(String.format("%064x", 0x1234500L + i)), i, new Script(new byte[0]));
+        }
+
+        List<String> sorted = new ArrayList<>(outputAddresses);
+        Collections.sort(sorted);
+        for(String address : sorted) {
+            tx.addOutput(outputAmount, Address.fromString(address).getOutputScript());
+        }
+
+        PSBT psbt = new PSBT(tx);
+        for(int i = 0; i < inputKeySeeds.size(); i++) {
+            PSBTInput input = psbt.getPsbtInputs().get(i);
+            input.setWitnessUtxo(new TransactionOutput(tx, inputValue,
+                    ScriptType.P2WPKH.getOutputScript(key(inputKeySeeds.get(i)))));
+        }
+        return psbt;
+    }
+
+    private List<Integer> distinctInputs() {
+        return List.of(1, 2, 3);
+    }
+
+    private String check(PSBT psbt, List<String> registered) {
+        return CoinjoinTransaction.rejectionReason(psbt, registered, OUTPUT_AMOUNT, PEERS, true);
+    }
+
+    @Test
+    public void aWellFormedCoinjoinIsAccepted() throws Exception {
+        List<String> registered = outputs(PEERS);
+
+        assertNull(check(combined(registered, distinctInputs(), INPUT_VALUE, OUTPUT_AMOUNT), registered));
+    }
+
+    /** An input paying its own address back out defeats the coinjoin for whoever owns it. */
+    @Test
+    public void anInputAddressReusedAsAnOutputIsRejected() throws Exception {
+        List<String> registered = new ArrayList<>(outputs(PEERS - 1));
+        registered.add(address(1)); // the address input 1 spends from
+
+        PSBT psbt = combined(registered, distinctInputs(), INPUT_VALUE, OUTPUT_AMOUNT);
+
+        assertEquals("an input address is reused as an output address", check(psbt, registered));
+    }
+
+    @Test
+    public void twoInputsFromTheSameAddressAreRejected() throws Exception {
+        List<String> registered = outputs(PEERS);
+        PSBT psbt = combined(registered, List.of(1, 1, 3), INPUT_VALUE, OUTPUT_AMOUNT);
+
+        assertEquals("two inputs spend from the same address", check(psbt, registered));
+    }
+
+    @Test
+    public void aMissingWitnessUtxoIsRejected() throws Exception {
+        List<String> registered = outputs(PEERS);
+        PSBT psbt = combined(registered, distinctInputs(), INPUT_VALUE, OUTPUT_AMOUNT);
+        psbt.getPsbtInputs().get(1).setWitnessUtxo(null);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("no witness utxo"), reason);
+    }
+
+    @Test
+    public void outputsExceedingInputsAreRejected() throws Exception {
+        List<String> registered = outputs(PEERS);
+        // each peer contributes less than it takes out
+        PSBT psbt = combined(registered, distinctInputs(), OUTPUT_AMOUNT - 100, OUTPUT_AMOUNT);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("must exceed outputs"), reason);
+    }
+
+    @Test
+    public void anAbsurdlyHighFeeIsRejected() throws Exception {
+        List<String> registered = outputs(PEERS);
+        // 3 inputs of 200_000 against 3 outputs of 99_900 leaves a fee of 300_300 sats
+        PSBT psbt = combined(registered, distinctInputs(), 200_000L, OUTPUT_AMOUNT);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("outside the expected range"), reason);
+    }
+
+    @Test
+    public void aFeeBelowTheFloorIsRejected() throws Exception {
+        List<String> registered = outputs(PEERS);
+        // 3 sats of total fee across 3 participants will not relay
+        PSBT psbt = combined(registered, distinctInputs(), OUTPUT_AMOUNT + 1, OUTPUT_AMOUNT);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("outside the expected range"), reason);
+    }
+
+    @Test
+    public void theFeeBoundsCanBeDisabledForRegtest() throws Exception {
+        List<String> registered = outputs(PEERS);
+        PSBT psbt = combined(registered, distinctInputs(), 200_000L, OUTPUT_AMOUNT);
+
+        assertNotNull(CoinjoinTransaction.rejectionReason(psbt, registered, OUTPUT_AMOUNT, PEERS, true));
+        assertNull(CoinjoinTransaction.rejectionReason(psbt, registered, OUTPUT_AMOUNT, PEERS, false));
+    }
+
+    @Test
+    public void anUnregisteredOutputIsRejected() throws Exception {
+        List<String> registered = outputs(PEERS);
+        List<String> paid = new ArrayList<>(registered.subList(0, PEERS - 1));
+        paid.add(address(99));
+
+        PSBT psbt = combined(paid, distinctInputs(), INPUT_VALUE, OUTPUT_AMOUNT);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("do not match"), reason);
+    }
+
+    @Test
+    public void theReportedFeeIsInputsMinusOutputs() throws Exception {
+        List<String> registered = outputs(PEERS);
+        PSBT psbt = combined(registered, distinctInputs(), INPUT_VALUE, OUTPUT_AMOUNT);
+
+        assertEquals(PEERS * (INPUT_VALUE - OUTPUT_AMOUNT), CoinjoinTransaction.fee(psbt));
+    }
+
+    @Test
+    public void aMissingTransactionIsRejected() {
+        assertNotNull(CoinjoinTransaction.rejectionReason(null, outputs(PEERS), OUTPUT_AMOUNT, PEERS, true));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbtTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/RegistrationPsbtTest.java
@@ -1,0 +1,207 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A peer's registration PSBT is combined straight into the transaction this client broadcasts, so
+ * anything wrong with it is otherwise only discovered by the network, after the coinjoin has
+ * already failed and the UTXOs have been tied up for the length of the pool.
+ */
+public class RegistrationPsbtTest {
+
+    private static final long OUTPUT_AMOUNT = 99_900L;
+    private static final long INPUT_VALUE = 100_500L;
+    private static final int PEERS = 3;
+
+    private ECKey key(int seed) {
+        return ECKey.fromPrivate(BigInteger.valueOf(1000003L + seed));
+    }
+
+    private List<String> addresses(int count) {
+        List<String> addresses = new ArrayList<>();
+        for(int i = 0; i < count; i++) {
+            addresses.add(ScriptType.P2WPKH.getAddress(key(i + 50)).toString());
+        }
+        return addresses;
+    }
+
+    /** Build a registration PSBT the way CoinjoinHandler builds its own. */
+    private PSBT psbt(List<String> outputs, long outputAmount, long inputValue, SigHash sigHash,
+            boolean withWitnessUtxo, boolean sign, int inputCount) throws Exception {
+        Transaction tx = new Transaction();
+        tx.setVersion(2);
+
+        for(int i = 0; i < inputCount; i++) {
+            tx.addInput(Sha256Hash.wrap(String.format("%064x", 0xabcdef00L + i)), i, new Script(new byte[0]));
+        }
+
+        List<String> sorted = new ArrayList<>(outputs);
+        java.util.Collections.sort(sorted);
+        for(String address : sorted) {
+            tx.addOutput(outputAmount, Address.fromString(address).getOutputScript());
+        }
+
+        PSBT psbt = new PSBT(tx);
+        ECKey signingKey = key(1);
+
+        for(PSBTInput input : psbt.getPsbtInputs()) {
+            if(sigHash != null) {
+                input.setSigHash(sigHash);
+            }
+            if(withWitnessUtxo) {
+                input.setWitnessUtxo(new TransactionOutput(tx, inputValue,
+                        ScriptType.P2WPKH.getOutputScript(signingKey)));
+            }
+            if(sign) {
+                assertTrue(input.sign(signingKey), "test setup: signing the input failed");
+            }
+        }
+
+        return psbt;
+    }
+
+    private PSBT valid(List<String> outputs) throws Exception {
+        return psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 1);
+    }
+
+    private String check(PSBT psbt, List<String> registered) {
+        return RegistrationPsbt.rejectionReason(psbt, registered, OUTPUT_AMOUNT, PEERS);
+    }
+
+    @Test
+    public void aWellFormedRegistrationIsAccepted() throws Exception {
+        List<String> outputs = addresses(PEERS);
+
+        assertNull(check(valid(outputs), outputs));
+    }
+
+    @Test
+    public void anUnsignedInputIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT unsigned = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, false, 1);
+
+        assertEquals("input is not signed", check(unsigned, outputs));
+    }
+
+    @Test
+    public void aMissingWitnessUtxoIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT noUtxo = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, false, false, 1);
+
+        // without it the input value is unknown and the fee at finalization is computed from a
+        // total that silently omits this peer's contribution
+        assertEquals("input has no witness utxo", check(noUtxo, outputs));
+    }
+
+    @Test
+    public void aNonPositiveInputValueIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT zeroValue = psbt(outputs, OUTPUT_AMOUNT, 0, SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        assertNotNull(check(zeroValue, outputs));
+        assertTrue(check(zeroValue, outputs).contains("not positive"), check(zeroValue, outputs));
+    }
+
+    @Test
+    public void theWrongSighashIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT wrongSighash = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ALL, true, true, 1);
+
+        String reason = check(wrongSighash, outputs);
+        assertNotNull(reason);
+        assertTrue(reason.contains("sighash"), reason);
+    }
+
+    @Test
+    public void severalInputsInOneRegistrationAreRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT twoInputs = psbt(outputs, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 2);
+
+        String reason = check(twoInputs, outputs);
+        assertNotNull(reason);
+        assertTrue(reason.contains("exactly one input"), reason);
+    }
+
+    @Test
+    public void tooFewOutputsAreRejected() throws Exception {
+        List<String> registered = addresses(PEERS);
+        PSBT short2 = psbt(registered.subList(0, 2), OUTPUT_AMOUNT, INPUT_VALUE,
+                SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        String reason = check(short2, registered);
+        assertNotNull(reason);
+        assertTrue(reason.contains("outputs, expected 3"), reason);
+    }
+
+    /**
+     * The hole in the old set based check. Every registered address is present, so the set of
+     * addresses seen matches, but one peer is paid a second time. Only counting the outputs
+     * catches it.
+     */
+    @Test
+    public void anExtraPaymentToARegisteredPeerIsRejected() throws Exception {
+        List<String> registered = addresses(PEERS);
+        List<String> withExtra = new ArrayList<>(registered);
+        withExtra.add(registered.get(0));
+
+        PSBT psbt = psbt(withExtra, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        String reason = check(psbt, registered);
+        assertNotNull(reason, "a transaction paying one peer twice was accepted");
+        assertTrue(reason.contains("4 outputs, expected 3"), reason);
+
+        // and the pool's own output validation refuses it too, rather than relying on the shape
+        // check alone
+        List<CoinjoinMath.OutputView> views = new ArrayList<>();
+        for(TransactionOutput output : psbt.getTransaction().getOutputs()) {
+            views.add(new CoinjoinMath.OutputView(output.getScript().getToAddress().toString(),
+                    output.getValue()));
+        }
+        assertFalse(CoinjoinMath.validateOutputs(views, registered, OUTPUT_AMOUNT),
+                "validateOutputs accepted an extra payment to an already registered peer");
+    }
+
+    @Test
+    public void anUnregisteredOutputIsRejected() throws Exception {
+        List<String> registered = addresses(PEERS);
+        List<String> withStranger = new ArrayList<>(registered.subList(0, 2));
+        withStranger.add(ScriptType.P2WPKH.getAddress(key(99)).toString());
+
+        PSBT psbt = psbt(withStranger, OUTPUT_AMOUNT, INPUT_VALUE, SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        assertEquals("psbt pays an output the pool did not register", check(psbt, registered));
+    }
+
+    @Test
+    public void theWrongOutputAmountIsRejected() throws Exception {
+        List<String> outputs = addresses(PEERS);
+        PSBT shortChanged = psbt(outputs, OUTPUT_AMOUNT - 1000, INPUT_VALUE,
+                SigHash.ANYONECANPAY_ALL, true, true, 1);
+
+        String reason = check(shortChanged, outputs);
+        assertNotNull(reason);
+        assertTrue(reason.contains("expected " + OUTPUT_AMOUNT), reason);
+    }
+
+    @Test
+    public void aMissingPsbtIsRejected() {
+        assertNotNull(RegistrationPsbt.rejectionReason(null, addresses(PEERS), OUTPUT_AMOUNT, PEERS));
+    }
+}


### PR DESCRIPTION
Closes #58. Also completes the finalization half of #57.

Based on #78, so it is two commits on top of that branch. Merge #78 first.

`finalizeCoinjoin` validated the outputs and broadcast. It did not check whether an input address also appeared as an output address, or whether two inputs spent from the same address. Both defeat the coinjoin, and neither is visible on any single peer's registration, so this is the only place they can be caught. The reference implementation gates on both (`plugin/joinstr.py:1291-1308`).

While there, the two remaining finalization items from #57: the total input had to exceed the total output, and the fee had to be sane. Neither was checked, and the fee was computed by summing only the inputs that happened to carry a witness UTXO, so a peer omitting one silently deflated the number handed to the broadcast service.

## Changes

`fix: check the combined coinjoin before broadcasting it`

New `CoinjoinTransaction.rejectionReason`, called from `finalizeCoinjoin` in place of the inline output validation and fee arithmetic. It checks, on the combined PSBT:

- every input carries a witness UTXO with a positive value
- the outputs match the registered addresses and amount
- no input address appears among the output addresses
- no two inputs spend from the same address
- the total input exceeds the total output
- the fee falls within 100 to 10000 sats per participant

The fee bounds are skipped on regtest, matching `plugin/joinstr.py:1327`, so a regtest run with an unusual fee still completes.

`test: cover the pre broadcast coinjoin checks`

New `CoinjoinTransactionTest`, eleven cases, assembling real multi-input PSBTs with drongo the way `finalizeCoinjoin` assembles them. A well formed coinjoin is accepted; an input address reused as an output, two inputs from one address, a missing witness UTXO, outputs exceeding inputs, a fee above the ceiling, a fee below the floor, an unregistered output and a null transaction are each rejected. Two more pin the regtest exemption and the reported fee.

## Verification

`./gradlew :test` green, 91 tests.

Removing the reuse and fee checks fails 5 of the 11.

## Note on the address checks

These only see an address when the input's witness UTXO resolves to one, which for P2WPKH it does. An input whose script does not resolve is skipped rather than rejected, since the check is about reuse and a non-address input cannot be compared. That is a deliberate gap and it is narrow: #78 already requires every registration to be a single signed P2WPKH-shaped input with a witness UTXO before it can reach this point.
