### PR TITLE
fix: refuse a coinjoin input that is unusable or too costly

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -247,14 +247,12 @@ public class CoinjoinHandler {
         // coinjoin exists to break, so log shapes rather than values.
         logger.info("Starting input registration");
 
-        long value = selectedUtxo.getValue();
-        long minAllowed = CoinjoinMath.minInputSats(poolAmountSats);
-        long maxAllowed = CoinjoinMath.maxInputSats(poolAmountSats);
-        if (!CoinjoinMath.isInputValueInRange(value, poolAmountSats)) {
-            Platform.runLater(() -> {
-                com.sparrowwallet.sparrow.AppServices.showErrorDialog("Invalid UTXO",
-                        "The selected UTXO has a value of " + value + " sats, which is outside the allowed range of "
-                                + minAllowed + " to " + maxAllowed + " sats.\n\nPlease select a different UTXO.");
+        String rejection = CoinjoinInput.rejectionReason(coinFacts(selectedUtxo, utxoNode), poolAmountSats,
+                CoinjoinMath.outputAmount(poolAmountSats, feeRate, numPeers), dustLimit(), outputAddresses);
+        if (rejection != null) {
+            logger.warning("Refusing the selected UTXO for this pool");
+            FxDispatch.run(() -> {
+                com.sparrowwallet.sparrow.AppServices.showErrorDialog("Invalid UTXO", rejection);
                 if (onReadyForInputCallback != null) {
                     onReadyForInputCallback.run();
                 }
@@ -330,6 +328,40 @@ public class CoinjoinHandler {
         };
 
         executorService.submit(task);
+    }
+
+    /** Read the facts CoinjoinInput needs off the wallet. */
+    CoinjoinInput.Coin coinFacts(BlockTransactionHashIndex utxo, WalletNode utxoNode) {
+        boolean confirmed = utxo.getHeight() > 0;
+        boolean spendable = wallet == null || wallet.getSpendableUtxos().containsKey(utxo);
+        String address = null;
+        try {
+            if (utxoNode != null && utxoNode.getAddress() != null) {
+                address = utxoNode.getAddress().toString();
+            }
+        } catch (Exception e) {
+            // an address that cannot be derived cannot be compared against the pool's outputs
+        }
+
+        return new CoinjoinInput.Coin(utxo.getValue(), confirmed, spendable, address);
+    }
+
+    /**
+     * The dust threshold every output in this pool must clear. Peers can register any address
+     * type, so the floor follows the largest one present.
+     */
+    private long dustLimit() {
+        long limit = 0;
+        for (String address : outputAddresses) {
+            try {
+                limit = Math.max(limit, com.sparrowwallet.sparrow.wallet.PaymentController
+                        .getRecipientDustThreshold(Address.fromString(address)));
+            } catch (Exception e) {
+                // an unparseable address never reaches the output list, but do not let one stop
+                // the check for the others
+            }
+        }
+        return limit;
     }
 
     private PSBT createCoinjoinPSBT(BlockTransactionHashIndex utxo, WalletNode utxoNode) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinInput.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinInput.java
@@ -1,0 +1,85 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import java.util.Collection;
+
+/**
+ * Whether a wallet UTXO may be contributed to a pool.
+ *
+ * The value range was the only rule applied before. The rest of these decide whether the coinjoin
+ * can complete at all, and whether it is worth what it costs the user, both of which are better
+ * settled before the wallet is asked for a password.
+ */
+public final class CoinjoinInput {
+
+    /**
+     * The most a coinjoin may cost a peer: the 5000 sats its input may exceed the denomination by,
+     * plus the 10000 sats per participant allowed for the mining fee. The pool creator supplies
+     * the fee rate, so the per output fee is not ours to trust; what can be checked locally is
+     * what the coinjoin actually costs us.
+     */
+    public static final long MAX_PERSONAL_COST = 15000;
+
+    /** The facts about a coin that decide whether it may be used. */
+    public record Coin(long value, boolean confirmed, boolean spendable, String address) {
+    }
+
+    private CoinjoinInput() {
+    }
+
+    /** Why this coin cannot be used, or null if it can. */
+    public static String rejectionReason(Coin coin, long poolAmountSats, long outputAmount, long dustLimit,
+            Collection<String> poolOutputAddresses) {
+        if (coin == null) {
+            return "No UTXO was selected.";
+        }
+
+        if (!coin.confirmed()) {
+            return "Selected UTXO is not confirmed.\n\n"
+                    + "Only confirmed UTXOs can be used in a coinjoin.\n\n"
+                    + "Please wait for the transaction to confirm and try again.";
+        }
+
+        if (!coin.spendable()) {
+            return "Selected UTXO is not spendable by this wallet.\n\n"
+                    + "It is frozen, or an immature coinbase output.\n\n"
+                    + "Please select a different UTXO.";
+        }
+
+        if (coin.address() != null && poolOutputAddresses != null
+                && poolOutputAddresses.contains(coin.address())) {
+            return "Selected UTXO spends from one of the pool's output addresses.\n\n"
+                    + "Reusing an address on both sides of a coinjoin defeats it.\n\n"
+                    + "Please select a UTXO from a different address.";
+        }
+
+        long minSats = CoinjoinMath.minInputSats(poolAmountSats);
+        long maxSats = CoinjoinMath.maxInputSats(poolAmountSats);
+        if (coin.value() < minSats || coin.value() > maxSats) {
+            return "Selected UTXO (" + coin.value() + " sats) is not within the required range.\n\n"
+                    + "Pool denomination: " + poolAmountSats + " sats\n"
+                    + "Required input range: " + minSats + " to " + maxSats + " sats";
+        }
+
+        if (outputAmount <= 0) {
+            return "Pool denomination (" + poolAmountSats + " sats) is too small to cover the fee.\n\n"
+                    + "Please use a larger denomination or a lower fee rate.";
+        }
+
+        if (outputAmount < dustLimit) {
+            return "Output amount (" + outputAmount + " sats) is below the dust limit ("
+                    + dustLimit + " sats).\n\n"
+                    + "The transaction would be rejected by the network.\n"
+                    + "Please use a larger denomination.";
+        }
+
+        long personalCost = coin.value() - outputAmount;
+        if (personalCost > MAX_PERSONAL_COST) {
+            return "This coinjoin would cost you " + personalCost + " sats.\n\n"
+                    + "You would contribute " + coin.value() + " sats and receive " + outputAmount + " sats.\n"
+                    + "The most a coinjoin may cost is " + MAX_PERSONAL_COST + " sats.\n\n"
+                    + "The pool's fee rate may be set too high by its creator.";
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/UtxoCircleDialog.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/UtxoCircleDialog.java
@@ -209,7 +209,13 @@ public class UtxoCircleDialog extends Dialog<Void> {
         double canvasHeight = 600;
         canvas.setPrefSize(canvasWidth, canvasHeight);
 
-        Map<BlockTransactionHashIndex, WalletNode> utxos = wallet.getWalletUtxos();
+        // frozen, immature and unconfirmed coins cannot take part, so do not offer them
+        Map<BlockTransactionHashIndex, WalletNode> utxos = new java.util.LinkedHashMap<>();
+        for (Map.Entry<BlockTransactionHashIndex, WalletNode> entry : wallet.getSpendableUtxos().entrySet()) {
+            if (entry.getKey().getHeight() > 0) {
+                utxos.put(entry.getKey(), entry.getValue());
+            }
+        }
 
         if (!utxos.isEmpty()) {
             long minAmount = utxos.keySet().stream().mapToLong(BlockTransactionHashIndex::getValue).min().orElse(0);

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinInputTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinInputTest.java
@@ -1,0 +1,145 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The value range was the only rule applied to a selected coin. Everything else here decides
+ * whether the coinjoin can complete at all, or whether it is worth what it costs, and all of it
+ * is better settled before the wallet is asked for a password.
+ */
+public class CoinjoinInputTest {
+
+    private static final long POOL = 100_000L;
+    private static final long OUTPUT = 99_900L;
+    private static final long DUST = 294L;
+    private static final String OWN_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    private static final String PEER_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+
+    private CoinjoinInput.Coin coin(long value, boolean confirmed, boolean spendable, String address) {
+        return new CoinjoinInput.Coin(value, confirmed, spendable, address);
+    }
+
+    private String check(CoinjoinInput.Coin coin) {
+        return CoinjoinInput.rejectionReason(coin, POOL, OUTPUT, DUST, Set.of(PEER_ADDRESS));
+    }
+
+    @Test
+    public void aUsableCoinIsAccepted() {
+        assertNull(check(coin(POOL + 500, true, true, OWN_ADDRESS)));
+        assertNull(check(coin(POOL + 5000, true, true, OWN_ADDRESS)));
+    }
+
+    @Test
+    public void anUnconfirmedCoinIsRejected() {
+        String reason = check(coin(POOL + 1000, false, true, OWN_ADDRESS));
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("not confirmed"), reason);
+    }
+
+    @Test
+    public void aFrozenOrImmatureCoinIsRejected() {
+        String reason = check(coin(POOL + 1000, true, false, OWN_ADDRESS));
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("not spendable"), reason);
+    }
+
+    /** Paying an input's own address back out is address reuse on both sides of the coinjoin. */
+    @Test
+    public void aCoinOnOneOfThePoolsOutputAddressesIsRejected() {
+        String reason = check(coin(POOL + 1000, true, true, PEER_ADDRESS));
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("output addresses"), reason);
+    }
+
+    @Test
+    public void aCoinOutsideTheValueRangeIsRejected() {
+        assertNotNull(check(coin(POOL, true, true, OWN_ADDRESS)));
+        assertNotNull(check(coin(POOL + 499, true, true, OWN_ADDRESS)));
+        assertNotNull(check(coin(POOL + 5001, true, true, OWN_ADDRESS)));
+    }
+
+    @Test
+    public void anOutputBelowDustIsRejected() {
+        String reason = CoinjoinInput.rejectionReason(coin(POOL + 1000, true, true, OWN_ADDRESS),
+                POOL, DUST - 1, DUST, Set.of());
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("dust limit"), reason);
+    }
+
+    @Test
+    public void aNonPositiveOutputIsRejected() {
+        String reason = CoinjoinInput.rejectionReason(coin(POOL + 1000, true, true, OWN_ADDRESS),
+                POOL, 0, DUST, Set.of());
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("too small to cover the fee"), reason);
+    }
+
+    /**
+     * The fee rate comes from the pool creator, so the per output fee cannot be trusted. What can
+     * be checked locally is the difference between what this wallet puts in and takes out.
+     */
+    @Test
+    public void aCoinjoinCostingMoreThanTheCapIsRejected() {
+        long costly = OUTPUT - CoinjoinInput.MAX_PERSONAL_COST - 1;
+        String reason = CoinjoinInput.rejectionReason(coin(POOL + 5000, true, true, OWN_ADDRESS),
+                POOL, costly, DUST, Set.of());
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("would cost you"), reason);
+    }
+
+    @Test
+    public void aCostExactlyAtTheCapIsAllowed() {
+        long input = POOL + 5000;
+        long output = input - CoinjoinInput.MAX_PERSONAL_COST;
+
+        assertNull(CoinjoinInput.rejectionReason(coin(input, true, true, OWN_ADDRESS),
+                POOL, output, DUST, Set.of()));
+        assertNotNull(CoinjoinInput.rejectionReason(coin(input, true, true, OWN_ADDRESS),
+                POOL, output - 1, DUST, Set.of()));
+    }
+
+    /**
+     * The cost cap and the fee rate ceiling meet exactly. At 100 sat/vB, the ceiling
+     * JoinPoolHandler allows, the per output fee is 10000 sats and the worst case input exceeds
+     * the denomination by 5000, so the coinjoin costs exactly the 15000 the cap permits. Anything
+     * above that fee rate is refused, which is the property worth pinning: the two limits agree
+     * rather than leaving a gap between them.
+     */
+    @Test
+    public void theCostCapMeetsTheFeeRateCeilingExactly() {
+        long input = CoinjoinMath.maxInputSats(POOL);
+
+        long atCeiling = CoinjoinMath.outputAmount(POOL, 100, 3);
+        assertEquals(CoinjoinInput.MAX_PERSONAL_COST, input - atCeiling);
+        assertNull(CoinjoinInput.rejectionReason(coin(input, true, true, OWN_ADDRESS),
+                POOL, atCeiling, DUST, Set.of()));
+
+        long aboveCeiling = CoinjoinMath.outputAmount(POOL, 101, 3);
+        String reason = CoinjoinInput.rejectionReason(coin(input, true, true, OWN_ADDRESS),
+                POOL, aboveCeiling, DUST, Set.of());
+        assertNotNull(reason, "a pool above the fee rate ceiling was accepted");
+        assertTrue(reason.contains("would cost you"), reason);
+    }
+
+    @Test
+    public void aMissingCoinIsRejected() {
+        assertNotNull(CoinjoinInput.rejectionReason(null, POOL, OUTPUT, DUST, List.of()));
+    }
+
+    @Test
+    public void aCoinWithNoDerivableAddressIsStillRangeChecked() {
+        assertNull(check(coin(POOL + 1000, true, true, null)));
+        assertNotNull(check(coin(POOL + 9999, true, true, null)));
+    }
+}


### PR DESCRIPTION
Closes #55.

The only rule applied to a selected coin was its value range, and the picker offered every UTXO in the wallet. An unconfirmed or frozen coin could be chosen, the wallet password entered, the PSBT signed and published, and the coinjoin then fail. Nothing checked whether the post-fee output cleared dust, or what the coinjoin actually cost the user.

The reference implementation checks all of this before signing (`_validate_coinjoin_input`, `plugin/joinstr.py:1481-1592`).

## Changes

`fix: refuse a coinjoin input that is unusable or too costly`

New `CoinjoinInput.rejectionReason`, taking the facts about a coin rather than a wallet, called from `startInputPhase` in place of the range check. It refuses:

- an unconfirmed coin
- a coin that is not spendable, which covers frozen coins, frozen addresses and immature coinbase in one test via `Wallet.getSpendableUtxos`
- a coin whose address is one of the pool's own output addresses, which is address reuse on both sides of the coinjoin
- a value outside the denomination range, as before
- an output amount at or below zero, or below the dust limit
- a coinjoin costing more than `MAX_PERSONAL_COST`, 15000 sats

The dust limit follows the largest threshold among the pool's registered output addresses, since peers can register any address type, using Sparrow's own `PaymentController.getRecipientDustThreshold`.

`UtxoCircleDialog` now offers only confirmed, spendable coins, so an unusable one cannot be picked in the first place.

`test: cover coinjoin input eligibility`

Twelve cases against the rules above, including the boundaries: exactly at the cost cap is allowed and one sat past it is not, and a coin with no derivable address is still range checked.

One of them pins something worth knowing: **the cost cap and the fee rate ceiling meet exactly.** At 100 sat/vB, the ceiling `JoinPoolHandler` already allows, the per output fee is 10000 sats and the worst case input exceeds the denomination by 5000, so the coinjoin costs exactly the 15000 the cap permits. The two limits agree rather than leaving a gap, and the test fails if either is changed without the other.

## Verification

`./gradlew :test` green, 120 tests.

Reducing the check back to the value range alone fails 8 of the 12.

## Not included

The reference implementation also refuses a coin whose address already takes part in another pool. This client runs one pool at a time (#67), so there is no second pool to compare against yet. That check belongs with #67 and I have left it out rather than adding a parameter nothing can populate.

The picker filters to confirmed and spendable but not to the pool's value range. Filtering by range as well would often leave the dialog empty with no explanation; an out of range coin is instead refused with a message naming the range, which is what the reference implementation does.
