### PR TITLE
fix: use the configured nostr relay for publishing and discovery

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrRelay.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrRelay.java
@@ -1,0 +1,30 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+/**
+ * The nostr relay this client publishes to and discovers pools on.
+ *
+ * Traffic for a pool that already exists always goes to the relay named in that pool's
+ * announcement. This is only for the two cases where there is no pool to take it from: announcing
+ * a new pool, and looking for pools to join.
+ */
+public final class JoinstrRelay {
+
+    public static final String DEFAULT = "wss://nos.lol";
+
+    private JoinstrRelay() {
+    }
+
+    /** The configured relay, or the default when it is unset or not a websocket url. */
+    public static String relayOrDefault(String configured) {
+        if (configured == null) {
+            return DEFAULT;
+        }
+
+        String relay = configured.trim();
+        if (relay.isEmpty() || !(relay.startsWith("wss://") || relay.startsWith("ws://"))) {
+            return DEFAULT;
+        }
+
+        return relay;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -11,6 +11,7 @@ import com.sparrowwallet.drongo.KeyPurpose;
 import com.sparrowwallet.drongo.address.Address;
 import com.sparrowwallet.drongo.wallet.Wallet;
 import com.sparrowwallet.sparrow.wallet.WalletForm;
+import com.sparrowwallet.sparrow.io.Config;
 import com.sparrowwallet.sparrow.io.Storage;
 import com.sparrowwallet.sparrow.wallet.NodeEntry;
 import com.sparrowwallet.sparrow.EventManager;
@@ -37,8 +38,9 @@ public class NostrPublisher implements AutoCloseable {
         return poolPrivateKey;
     }
 
-    private static final Map<String, String> RELAYS = Map.of(
-            "nos", "wss://nos.lol");
+    private static Map<String, String> relays() {
+        return Map.of("default", JoinstrRelay.relayOrDefault(Config.get().getNostrRelay()));
+    }
 
     public Address getNewReceiveAddress(Storage storage, Wallet wallet) {
         WalletForm walletForm = new WalletForm(storage, wallet);
@@ -72,7 +74,8 @@ public class NostrPublisher implements AutoCloseable {
             long timeout = Instant.now().getEpochSecond() + 3600;
 
             String poolId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
-            String relayUrl = RELAYS.values().iterator().next();
+            Map<String, String> relays = relays();
+            String relayUrl = relays.values().iterator().next();
             String network = com.sparrowwallet.drongo.Network.get().getName();
 
             NIP01 nip01 = new NIP01(poolIdentity);
@@ -86,11 +89,11 @@ public class NostrPublisher implements AutoCloseable {
             if (AppServices.isTorRunning()) {
                 DefaultRequestContext context = new DefaultRequestContext();
                 context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
-                context.setRelays(RELAYS);
+                context.setRelays(relays);
                 Client.getInstance().connect(context);
             }
 
-            nip01.send(RELAYS);
+            nip01.send(relays);
 
             logger.info("Event ID: " + event.getId());
             logger.info("Event: " + event);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -31,7 +31,6 @@ public class OtherPoolsController extends JoinstrFormController {
 
     private static final int POOL_REFRESH_TIME = 30000;
     private static final Logger logger = Logger.getLogger(OtherPoolsController.class.getName());
-    private static final String DEFAULT_RELAY = "wss://nos.lol";
     private static final Logger textLogger = Logger.getLogger("nostr.connection.impl.listeners.TextListener");
 
     @FXML
@@ -241,7 +240,8 @@ public class OtherPoolsController extends JoinstrFormController {
                 Client client = Client.getInstance();
                 DefaultRequestContext context = new DefaultRequestContext();
                 context.setPrivateKey(identity.getPrivateKey().getRawData());
-                context.setRelays(Map.of("default", DEFAULT_RELAY));
+                context.setRelays(Map.of("default",
+                        JoinstrRelay.relayOrDefault(Config.get().getNostrRelay())));
 
                 try {
                     if (AppServices.isTorRunning()) {

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrRelayTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrRelayTest.java
@@ -1,0 +1,44 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The relay in the joinstr settings page was stored and never read, so pointing it anywhere had
+ * no effect and pools announced on any other relay were invisible.
+ */
+public class JoinstrRelayTest {
+
+    @Test
+    public void aConfiguredRelayIsUsed() {
+        assertEquals("wss://relay.example", JoinstrRelay.relayOrDefault("wss://relay.example"));
+        assertEquals("ws://127.0.0.1:7777", JoinstrRelay.relayOrDefault("ws://127.0.0.1:7777"));
+    }
+
+    @Test
+    public void surroundingWhitespaceIsTrimmed() {
+        assertEquals("wss://relay.example", JoinstrRelay.relayOrDefault("  wss://relay.example \n"));
+    }
+
+    @Test
+    public void anUnsetRelayFallsBackToTheDefault() {
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault(null));
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault(""));
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault("   "));
+    }
+
+    /** Anything that is not a websocket url would fail at connect time with no explanation. */
+    @Test
+    public void aNonWebsocketUrlFallsBackToTheDefault() {
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault("https://relay.example"));
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault("relay.example"));
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault("nos.lol"));
+    }
+
+    @Test
+    public void theDefaultIsAWebsocketUrl() {
+        assertEquals(JoinstrRelay.DEFAULT, JoinstrRelay.relayOrDefault(JoinstrRelay.DEFAULT));
+        assertTrue(JoinstrRelay.DEFAULT.startsWith("wss://"));
+    }
+}


### PR DESCRIPTION
Closes #63.

`SettingsController` persisted `Config.nostrRelay` and nothing read it. `grep -rn "getNostrRelay" src/main/java` returned only the settings page itself. Both pool discovery and pool publishing used a hardcoded `wss://nos.lol`, so pointing the setting anywhere had no effect and pools announced on any other relay were invisible.

## Changes

`fix: use the configured nostr relay for publishing and discovery`

- New `JoinstrRelay.relayOrDefault`, which returns the configured relay, or `wss://nos.lol` when it is unset, blank or not a websocket url. A non-websocket value would otherwise fail at connect time with nothing explaining why.
- `NostrPublisher` builds its relay map from it instead of the `RELAYS` constant, so a new pool is announced on the configured relay and its announcement names that relay.
- `OtherPoolsController` discovers on it instead of `DEFAULT_RELAY`.

Traffic for a pool that already exists is unchanged: `CoinjoinHandler` and `JoinPoolHandler` already take the relay from `pool.getRelay()`, which is the relay named in that pool's own announcement.

`test: cover relay selection`

Five cases: a configured `wss://` or `ws://` relay is used, surrounding whitespace is trimmed, null, empty and blank fall back to the default, a non-websocket url falls back rather than being attempted, and the default is itself a valid websocket url.

## Verification

`./gradlew :test` green, 125 tests.

The pure selection function is what is tested. `Config.get()` reads and writes the user's real config file, so the two call sites pass it in rather than the function reaching for the singleton, which keeps it out of the test.
