### PR TITLE
fix: let the pool creator set the fee rate and timeout

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
@@ -37,8 +37,19 @@ public class NewPoolController extends JoinstrFormController {
     @FXML
     private TextField peersField;
 
+    @FXML
+    private TextField feeRateField;
+
+    @FXML
+    private TextField timeoutField;
+
     @Override
     public void initializeView() {
+        Double defaultFeeRate = AppServices.getDefaultFeeRate();
+        if(defaultFeeRate != null) {
+            feeRateField.setPromptText(CoinjoinMath.formatFeeRate(defaultFeeRate));
+        }
+        timeoutField.setPromptText(String.valueOf(PoolParameters.DEFAULT_TIMEOUT_MINUTES));
     }
 
     @Override
@@ -86,6 +97,29 @@ public class NewPoolController extends JoinstrFormController {
                 return;
             }
 
+            String feeRateText = feeRateField.getText().trim();
+            String timeoutText = timeoutField.getText().trim();
+
+            String feeRateError = PoolParameters.feeRateError(feeRateText);
+            if(feeRateError != null) {
+                showError(feeRateError);
+                return;
+            }
+
+            String timeoutError = PoolParameters.timeoutError(timeoutText);
+            if(timeoutError != null) {
+                showError(timeoutError);
+                return;
+            }
+
+            Double defaultFeeRate = AppServices.getDefaultFeeRate();
+            double feeRate = PoolParameters.feeRateOrDefault(feeRateText,
+                    defaultFeeRate == null ? PoolParameters.MIN_FEE_RATE
+                            : Math.min(Math.max(defaultFeeRate, PoolParameters.MIN_FEE_RATE),
+                                    PoolParameters.MAX_FEE_RATE));
+            long timeoutSeconds = PoolParameters.timeoutSeconds(timeoutText,
+                    PoolParameters.DEFAULT_TIMEOUT_MINUTES);
+
             Address bitcoinAddress;
             Wallet wallet;
 
@@ -120,7 +154,8 @@ public class NewPoolController extends JoinstrFormController {
                             + recipientDustThreshold + ")");
                 }
 
-                event = nostrPublisher.publishCustomEvent(denomination, peers, bitcoinAddress.toString());
+                event = nostrPublisher.publishCustomEvent(denomination, peers, bitcoinAddress.toString(),
+                        feeRate, timeoutSeconds);
 
                 if (event == null) {
                     showError("Failed to publish pool event");
@@ -150,6 +185,8 @@ public class NewPoolController extends JoinstrFormController {
 
             denominationField.clear();
             peersField.clear();
+            feeRateField.clear();
+            timeoutField.clear();
 
             showSuccessDialog(
                     "New Pool",

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -49,7 +49,8 @@ public class NostrPublisher implements AutoCloseable {
         return freshEntry.getAddress();
     }
 
-    public GenericEvent publishCustomEvent(String denomination, String peers, String bitcoinAddress) {
+    public GenericEvent publishCustomEvent(String denomination, String peers, String bitcoinAddress,
+            double feeRate, long timeoutSeconds) {
 
         if (bitcoinAddress.isEmpty()) {
             logger.warning("No Bitcoin Address found. Please open a wallet in Sparrow first.");
@@ -71,7 +72,7 @@ public class NostrPublisher implements AutoCloseable {
             poolIdentity = Identity.generateRandomIdentity();
             poolPrivateKey = poolIdentity.getPrivateKey().toString();
 
-            long timeout = Instant.now().getEpochSecond() + 3600;
+            long timeout = Instant.now().getEpochSecond() + timeoutSeconds;
 
             String poolId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
             Map<String, String> relays = relays();
@@ -81,7 +82,7 @@ public class NostrPublisher implements AutoCloseable {
             NIP01 nip01 = new NIP01(poolIdentity);
 
             GenericEvent event = buildPoolEvent(poolIdentity, poolId, network, denomination, peers, timeout,
-                    relayUrl);
+                    relayUrl, feeRate);
 
             nip01.setEvent(event);
             nip01.sign();
@@ -112,7 +113,7 @@ public class NostrPublisher implements AutoCloseable {
      * is what other joinstr clients check before accepting the pool.
      */
     static GenericEvent buildPoolEvent(Identity poolIdentity, String poolId, String network, String denomination,
-            String peers, long timeout, String relayUrl) {
+            String peers, long timeout, String relayUrl, double feeRate) {
 
         String content = String.format(
                 "{\n" +
@@ -126,7 +127,7 @@ public class NostrPublisher implements AutoCloseable {
                         "  \"timeout\": %d,\n" +
                         "  \"relays\": [\"%s\"],\n" +
                         "  \"relay\": \"%s\",\n" +
-                        "  \"fee_rate\": 1,\n" +
+                        "  \"fee_rate\": %s,\n" +
                         "  \"transport\": { \"tor\": { \"enable\": true }, \"vpn\": { \"enable\": false, \"vpn_gateway\": null } }\n" +
                         "}",
                 poolId,
@@ -136,7 +137,8 @@ public class NostrPublisher implements AutoCloseable {
                 peers,
                 timeout,
                 relayUrl,
-                relayUrl);
+                relayUrl,
+                CoinjoinMath.formatFeeRate(feeRate));
 
         List<BaseTag> tags = new ArrayList<>();
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -229,9 +229,10 @@ public class OtherPoolsController extends JoinstrFormController {
 
                 Identity identity = Identity.generateRandomIdentity();
 
+                // Pools are dropped by their own timeout below, so do not also drop them by the
+                // age of the announcement. A pool open for longer than an hour was invisible.
                 Filters filters = Filters.builder()
                         .kinds(List.of(Kind.CONJOIN_POOL))
-                        .since(System.currentTimeMillis() / 1000 - 3600) // Last hour
                         .build();
 
                 String subId = "pools-" + System.currentTimeMillis();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolParameters.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolParameters.java
@@ -1,0 +1,81 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+/**
+ * The pool parameters a creator chooses. Both were hardcoded: every pool advertised a fee rate of
+ * 1 sat/vB and expired one hour after creation.
+ */
+public final class PoolParameters {
+
+    /** Matches the band a joiner will accept, so a pool cannot be created that nobody can join. */
+    public static final double MIN_FEE_RATE = 1;
+    public static final double MAX_FEE_RATE = 100;
+
+    public static final long MIN_TIMEOUT_MINUTES = 5;
+    public static final long MAX_TIMEOUT_MINUTES = 1440;
+
+    public static final long DEFAULT_TIMEOUT_MINUTES = 60;
+
+    private PoolParameters() {
+    }
+
+    /** Why this fee rate cannot be used, or null if it can. Blank means take the default. */
+    public static String feeRateError(String text) {
+        if (isBlank(text)) {
+            return null;
+        }
+
+        double feeRate;
+        try {
+            feeRate = Double.parseDouble(text.trim());
+        } catch (NumberFormatException e) {
+            return "Fee rate must be a number.";
+        }
+
+        if (!Double.isFinite(feeRate) || feeRate < MIN_FEE_RATE || feeRate > MAX_FEE_RATE) {
+            return "Fee rate must be between " + (long) MIN_FEE_RATE + " and " + (long) MAX_FEE_RATE
+                    + " sat/vB.";
+        }
+
+        return null;
+    }
+
+    public static double feeRateOrDefault(String text, double fallback) {
+        if (feeRateError(text) != null || isBlank(text)) {
+            return fallback;
+        }
+        return Double.parseDouble(text.trim());
+    }
+
+    /** Why this timeout cannot be used, or null if it can. Blank means take the default. */
+    public static String timeoutError(String text) {
+        if (isBlank(text)) {
+            return null;
+        }
+
+        long minutes;
+        try {
+            minutes = Long.parseLong(text.trim());
+        } catch (NumberFormatException e) {
+            return "Timeout must be a whole number of minutes.";
+        }
+
+        if (minutes < MIN_TIMEOUT_MINUTES || minutes > MAX_TIMEOUT_MINUTES) {
+            return "Timeout must be between " + MIN_TIMEOUT_MINUTES + " and " + MAX_TIMEOUT_MINUTES
+                    + " minutes.";
+        }
+
+        return null;
+    }
+
+    public static long timeoutSeconds(String text, long fallbackMinutes) {
+        long minutes = fallbackMinutes;
+        if (timeoutError(text) == null && !isBlank(text)) {
+            minutes = Long.parseLong(text.trim());
+        }
+        return minutes * 60;
+    }
+
+    private static boolean isBlank(String text) {
+        return text == null || text.trim().isEmpty();
+    }
+}

--- a/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
@@ -39,6 +39,20 @@
                     <Field text="Number of Peers:" style="-fx-text-fill: #aaaaaa;">
                         <TextField fx:id="peersField" styleClass="textfield-dark" style="-fx-max-width: 200px;" />
                     </Field>
+                    <Field text="Fee Rate (sat/vB):" style="-fx-text-fill: #aaaaaa;">
+                        <TextField fx:id="feeRateField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
+                            <tooltip>
+                                <Tooltip text="Fee rate advertised to peers, defaults to the wallet's estimate"/>
+                            </tooltip>
+                        </TextField>
+                    </Field>
+                    <Field text="Timeout (minutes):" style="-fx-text-fill: #aaaaaa;">
+                        <TextField fx:id="timeoutField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
+                            <tooltip>
+                                <Tooltip text="How long the pool stays open for peers to join"/>
+                            </tooltip>
+                        </TextField>
+                    </Field>
                     <Field>
                         <VBox alignment="CENTER">
                             <ToggleButton fx:id="createButton" text="Create" onAction="#handleCreateButton"

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/NostrPublisherTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/NostrPublisherTest.java
@@ -16,7 +16,7 @@ public class NostrPublisherTest {
 
     private GenericEvent event(Identity poolIdentity) {
         return NostrPublisher.buildPoolEvent(poolIdentity, "0123456789abcdef", "regtest", "0.001", "3",
-                1750000000L, "wss://nos.lol");
+                1750000000L, "wss://nos.lol", 1);
     }
 
     @Test

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolParametersTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolParametersTest.java
@@ -1,0 +1,97 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Every pool advertised a fee rate of 1 sat/vB and expired one hour after creation, neither of
+ * which the creator could change.
+ */
+public class PoolParametersTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void aFeeRateInsideTheBandIsAccepted() {
+        assertNull(PoolParameters.feeRateError("1"));
+        assertNull(PoolParameters.feeRateError("2.5"));
+        assertNull(PoolParameters.feeRateError("100"));
+        assertEquals(2.5, PoolParameters.feeRateOrDefault("2.5", 7));
+    }
+
+    /** The band matches what a joiner will accept, so an unjoinable pool cannot be created. */
+    @Test
+    public void aFeeRateOutsideTheBandIsRejected() {
+        assertNotNull(PoolParameters.feeRateError("0"));
+        assertNotNull(PoolParameters.feeRateError("0.5"));
+        assertNotNull(PoolParameters.feeRateError("101"));
+        assertNotNull(PoolParameters.feeRateError("-3"));
+        assertNotNull(PoolParameters.feeRateError("abc"));
+    }
+
+    @Test
+    public void aBlankFeeRateTakesTheDefault() {
+        assertNull(PoolParameters.feeRateError(""));
+        assertNull(PoolParameters.feeRateError(null));
+        assertEquals(7.0, PoolParameters.feeRateOrDefault("", 7));
+        assertEquals(7.0, PoolParameters.feeRateOrDefault(null, 7));
+        assertEquals(7.0, PoolParameters.feeRateOrDefault("   ", 7));
+    }
+
+    @Test
+    public void aTimeoutInsideTheBandIsAccepted() {
+        assertNull(PoolParameters.timeoutError("5"));
+        assertNull(PoolParameters.timeoutError("60"));
+        assertNull(PoolParameters.timeoutError("1440"));
+        assertEquals(3600L, PoolParameters.timeoutSeconds("60", 30));
+    }
+
+    @Test
+    public void aTimeoutOutsideTheBandIsRejected() {
+        assertNotNull(PoolParameters.timeoutError("4"));
+        assertNotNull(PoolParameters.timeoutError("1441"));
+        assertNotNull(PoolParameters.timeoutError("0"));
+        assertNotNull(PoolParameters.timeoutError("-10"));
+        assertNotNull(PoolParameters.timeoutError("1.5"));
+    }
+
+    @Test
+    public void aBlankTimeoutTakesTheDefault() {
+        assertNull(PoolParameters.timeoutError(""));
+        assertEquals(PoolParameters.DEFAULT_TIMEOUT_MINUTES * 60,
+                PoolParameters.timeoutSeconds("", PoolParameters.DEFAULT_TIMEOUT_MINUTES));
+    }
+
+    @Test
+    public void theChosenFeeRateReachesTheAnnouncement() throws Exception {
+        var event = NostrPublisher.buildPoolEvent(Identity.generateRandomIdentity(), "abc123",
+                "regtest", "0.001", "3", 1750000000L, "wss://nos.lol", 2.5);
+
+        JsonNode content = MAPPER.readTree(event.getContent());
+
+        assertEquals(2.5, content.get("fee_rate").asDouble());
+        assertTrue(content.get("fee_rate").isNumber(), "fee_rate must stay a number on the wire");
+    }
+
+    @Test
+    public void aWholeFeeRateIsAnnouncedWithoutATrailingZero() throws Exception {
+        var event = NostrPublisher.buildPoolEvent(Identity.generateRandomIdentity(), "abc123",
+                "regtest", "0.001", "3", 1750000000L, "wss://nos.lol", 3.0);
+
+        assertEquals("3", MAPPER.readTree(event.getContent()).get("fee_rate").asText());
+    }
+
+    @Test
+    public void theChosenTimeoutReachesTheAnnouncement() throws Exception {
+        var event = NostrPublisher.buildPoolEvent(Identity.generateRandomIdentity(), "abc123",
+                "regtest", "0.001", "3", 1750001234L, "wss://nos.lol", 1);
+
+        assertEquals(1750001234L, MAPPER.readTree(event.getContent()).get("timeout").asLong());
+    }
+}


### PR DESCRIPTION
Closes #64.

Every pool this client created advertised a fee rate of 1 sat/vB and expired one hour after creation, neither of which the creator could change. Separately, discovery filtered announcements by age rather than by the pool's own expiry, so a pool that stayed open longer than an hour was invisible even though it was still valid.

## Changes

`fix: let the pool creator set the fee rate and timeout`

- Two fields on the create form: fee rate in sat/vB and timeout in minutes. Both optional, with the placeholder showing the default that applies when left blank.
- The fee rate defaults to Sparrow's own estimate, `AppServices.getDefaultFeeRate()`, clamped into the accepted band, rather than the constant 1. The timeout defaults to 60 minutes, which is what was hardcoded.
- New `PoolParameters` validates both before anything is published. The fee rate band is 1 to 100 sat/vB, deliberately the same band `JoinPoolHandler` applies when joining, so a pool cannot be created that no joiner will accept. The timeout is 5 to 1440 minutes.
- `NostrPublisher.publishCustomEvent` and `buildPoolEvent` take the fee rate and timeout instead of hardcoding them. The fee rate is rendered through `CoinjoinMath.formatFeeRate`, so a whole rate is announced as `3` rather than `3.0`.
- `NewPoolController` no longer sets the creator's own coinjoin fee rate separately; it flows from the pool.
- Discovery drops the `since(now - 3600)` filter. Expired pools were already dropped by the `timeout` check that follows, so the age filter only ever hid valid pools.

`test: cover pool fee rate and timeout selection`

Nine cases: fee rates inside and outside the band, blank taking the default, timeouts inside and outside the band, blank taking the default, and three that follow the chosen values through into the announcement JSON, including that `fee_rate` stays a JSON number and that a whole rate carries no trailing zero.

## Verification

`./gradlew :test` green, 134 tests.

Restoring the hardcoded `fee_rate` in the announcement fails the two tests that follow the value through, so those hold the wiring rather than just the validation.

## Note

`NostrPublisherTest` needed updating for the new `buildPoolEvent` signature. No behaviour change there, just the extra argument.

The fee rate band being identical to the joiner's accepted band is worth keeping in mind: if #62 or a later change moves one, the other has to move with it, or pools become uncreatable or unjoinable. The two constants are currently declared separately, in `PoolParameters` and `JoinPoolHandler`, which is duplication I have left alone rather than widening this PR.
