### PR TITLE
fix: refuse joinstr requests when tor is not running

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -136,15 +136,10 @@ public class CoinjoinHandler {
     private void sendOutputToPool(String address) {
         executorService.submit(() -> {
             try {
-                if (AppServices.isTorRunning()) {
-                    try {
-                        Client.getInstance().disconnect();
-                    } catch (Exception e) {
-                        // Not yet connected, safe to ignore
-                    }
-                    TorUtils.changeIdentity(AppServices.getTorProxy());
+                if (!JoinstrTransport.newCircuit()) {
+                    updateStatus("Error: Tor not running");
+                    return;
                 }
-                    TorUtils.logTorIp();
 
                 JoinstrMessage message = new JoinstrMessage();
                 message.setType("output");
@@ -166,7 +161,7 @@ public class CoinjoinHandler {
                 nip04.setEvent(outputEvent);
                 nip04.sign();
 
-                if (AppServices.isTorRunning()) {
+                {
                     DefaultRequestContext context = new DefaultRequestContext();
                     context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
                     context.setRelays(Map.of("default", relay));
@@ -501,15 +496,10 @@ public class CoinjoinHandler {
 
     private void sendInputToPool(String psbtBase64) {
         try {
-            if (AppServices.isTorRunning()) {
-                try {
-                    Client.getInstance().disconnect();
-                } catch (Exception e) {
-                    // Not yet connected, safe to ignore
-                }
-                TorUtils.changeIdentity(AppServices.getTorProxy());
+            if (!JoinstrTransport.newCircuit()) {
+                updateStatus("Error: Tor not running");
+                return;
             }
-                TorUtils.logTorIp();
 
             JoinstrMessage message = new JoinstrMessage();
             message.setType("input");
@@ -531,7 +521,7 @@ public class CoinjoinHandler {
             nip04.setEvent(inputEvent);
             nip04.sign();
 
-            if (AppServices.isTorRunning()) {
+            {
                 DefaultRequestContext context = new DefaultRequestContext();
                 context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
                 context.setRelays(Map.of("default", relay));

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
@@ -207,7 +207,9 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
                     log.info("[Joinstr] Nostr connections routed through Tor SOCKS proxy {}:{}",
                             proxy.getHost(), proxy.getPort());
                 } else {
-                    log.warn("[Joinstr] Tor not ready after 90s — nostr connections may not be over Tor");
+                    log.warn("[Joinstr] Tor not ready after 90s, joinstr requests will be refused");
+                    javafx.application.Platform.runLater(() -> AppServices.showErrorDialog(
+                            "Tor Not Running", JoinstrTransport.NOT_READY));
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
@@ -1,0 +1,74 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.google.common.net.HostAndPort;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.net.TorUtils;
+
+import nostr.client.Client;
+
+import java.util.function.BooleanSupplier;
+import java.util.logging.Logger;
+
+/**
+ * The transport every joinstr request goes over.
+ *
+ * Publishing a join request, an output address or a signed input from the wallet's real IP links
+ * that IP to the coinjoin. Each of those used to check whether Tor was running and simply carry on
+ * in the clear when it was not, so a slow or failed Tor bootstrap silently downgraded the join
+ * rather than stopping it.
+ */
+public final class JoinstrTransport {
+
+    private static final Logger logger = Logger.getLogger(JoinstrTransport.class.getName());
+
+    public static final String NOT_READY =
+            "Tor is not running, so this request would go out from your real IP address.\n\n"
+                    + "Joinstr requires Tor. Wait for it to finish starting, or check the Tor "
+                    + "settings, and try again.";
+
+    private static BooleanSupplier torRunning = AppServices::isTorRunning;
+
+    private JoinstrTransport() {
+    }
+
+    public static boolean isReady() {
+        return torRunning.getAsBoolean();
+    }
+
+    /** Why this request must not be sent, or null if it may be. */
+    public static String unavailableReason() {
+        return isReady() ? null : NOT_READY;
+    }
+
+    /**
+     * Take a fresh circuit for the next request. Returns false when Tor is not available, in which
+     * case the caller must not send anything.
+     */
+    public static boolean newCircuit() {
+        if (!isReady()) {
+            logger.warning("Refusing to send a joinstr request: tor is not running");
+            return false;
+        }
+
+        try {
+            Client.getInstance().disconnect();
+        } catch (Exception e) {
+            // not yet connected, safe to ignore
+        }
+
+        HostAndPort proxy = AppServices.getTorProxy();
+        if (proxy == null) {
+            logger.warning("Refusing to send a joinstr request: no tor proxy is configured");
+            return false;
+        }
+
+        TorUtils.changeIdentity(proxy);
+        TorUtils.logTorIp();
+        return true;
+    }
+
+    /** Lets a test stand in for the running tor instance. */
+    static void setTorRunningForTesting(BooleanSupplier supplier) {
+        torRunning = supplier == null ? AppServices::isTorRunning : supplier;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -139,15 +139,9 @@ public class NostrListener implements AutoCloseable {
         }
 
         try {
-            if (AppServices.isTorRunning()) {
-                try {
-                    Client.getInstance().disconnect();
-                } catch (Exception e) {
-                    // Not yet connected, safe to ignore
-                }
-                TorUtils.changeIdentity(AppServices.getTorProxy());
+            if (!JoinstrTransport.newCircuit()) {
+                throw new IllegalStateException(JoinstrTransport.NOT_READY);
             }
-                TorUtils.logTorIp();
 
             // Send the payload as built. Re-picking keys here silently dropped any the caller
             // had not supplied, and turned every value into a string.
@@ -181,15 +175,9 @@ public class NostrListener implements AutoCloseable {
 
     private void connectAndSubscribe() {
         try {
-            if (AppServices.isTorRunning()) {
-                try {
-                    Client.getInstance().disconnect();
-                } catch (Exception e) {
-                    // Not yet connected, safe to ignore
-                }
-                TorUtils.changeIdentity(AppServices.getTorProxy());
+            if (!JoinstrTransport.newCircuit()) {
+                throw new IllegalStateException(JoinstrTransport.NOT_READY);
             }
-                TorUtils.logTorIp();
 
             client = Client.getInstance();
             DefaultRequestContext context = new DefaultRequestContext();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -59,15 +59,10 @@ public class NostrPublisher implements AutoCloseable {
 
         Identity poolIdentity;
         try {
-            if (AppServices.isTorRunning()) {
-                try {
-                    Client.getInstance().disconnect();
-                } catch (Exception e) {
-                    // Not yet connected, safe to ignore
-                }
-                TorUtils.changeIdentity(AppServices.getTorProxy());
+            if (!JoinstrTransport.newCircuit()) {
+                AppServices.showErrorDialog("Tor Not Running", JoinstrTransport.NOT_READY);
+                return null;
             }
-                TorUtils.logTorIp();
 
             poolIdentity = Identity.generateRandomIdentity();
             poolPrivateKey = poolIdentity.getPrivateKey().toString();
@@ -87,7 +82,7 @@ public class NostrPublisher implements AutoCloseable {
             nip01.setEvent(event);
             nip01.sign();
 
-            if (AppServices.isTorRunning()) {
+            {
                 DefaultRequestContext context = new DefaultRequestContext();
                 context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
                 context.setRelays(relays);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -245,15 +245,10 @@ public class OtherPoolsController extends JoinstrFormController {
                         JoinstrRelay.relayOrDefault(Config.get().getNostrRelay())));
 
                 try {
-                    if (AppServices.isTorRunning()) {
-                        try {
-                            Client.getInstance().disconnect();
-                        } catch (Exception e) {
-                            // Not yet connected, safe to ignore
-                        }
-                        TorUtils.changeIdentity(AppServices.getTorProxy());
+                    if (!JoinstrTransport.newCircuit()) {
+                        Platform.runLater(() -> showError(JoinstrTransport.NOT_READY));
+                        return;
                     }
-                        TorUtils.logTorIp();
 
                     client.connect(context);
                     client.send(reqMessage);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -1,6 +1,7 @@
 package com.sparrowwallet.sparrow.joinstr.control;
 
 import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
+import com.sparrowwallet.sparrow.joinstr.JoinstrTransport;
 import com.sparrowwallet.sparrow.control.QRDisplayDialog;
 
 import javafx.beans.property.SimpleStringProperty;
@@ -188,15 +189,12 @@ public class JoinstrPoolList extends VBox {
 
                             new Thread(() -> {
                                 try {
-                                    if(AppServices.isTorRunning()) {
-                                        try {
-                                            Client.getInstance().disconnect();
-                                        } catch (Exception e) {
-                                            // Not yet connected, safe to ignore
-                                        }
-                                        TorUtils.changeIdentity(AppServices.getTorProxy());
+                                    if(!JoinstrTransport.newCircuit()) {
+                                        javafx.application.Platform.runLater(() ->
+                                                AppServices.showErrorDialog("Tor Not Running",
+                                                        JoinstrTransport.NOT_READY));
+                                        return;
                                     }
-                                        TorUtils.logTorIp();
 
                                     PublicKey poolPubKey = new PublicKey(pool.getPubkey());
                                     String requestContent = "{\"type\": \"join_pool\"}";
@@ -215,7 +213,7 @@ public class JoinstrPoolList extends VBox {
                                     nip04.setEvent(encrypted_event);
                                     nip04.sign();
 
-                                    if(AppServices.isTorRunning()) {
+                                    {
                                         DefaultRequestContext context = new DefaultRequestContext();
                                         context.setPrivateKey(identity.getPrivateKey().getRawData());
                                         context.setRelays(Map.of("default", pool.getRelay()));

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransportTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransportTest.java
@@ -1,0 +1,58 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Publishing a join request, an output address or a signed input from the wallet's real IP links
+ * that IP to the coinjoin. Every one of those used to check whether Tor was running and carry on
+ * in the clear when it was not, so a slow or failed bootstrap downgraded the join silently.
+ */
+public class JoinstrTransportTest {
+
+    @AfterEach
+    public void restoreRealTor() {
+        JoinstrTransport.setTorRunningForTesting(null);
+    }
+
+    @Test
+    public void nothingIsSentWhenTorIsDown() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        assertFalse(JoinstrTransport.isReady());
+        assertFalse(JoinstrTransport.newCircuit(), "a request would have been sent without tor");
+        assertNotNull(JoinstrTransport.unavailableReason());
+    }
+
+    @Test
+    public void theRefusalSaysWhy() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        String reason = JoinstrTransport.unavailableReason();
+        assertTrue(reason.contains("real IP address"), reason);
+        assertTrue(reason.contains("Tor"), reason);
+    }
+
+    @Test
+    public void aReadyTransportReportsNoReason() {
+        JoinstrTransport.setTorRunningForTesting(() -> true);
+
+        assertTrue(JoinstrTransport.isReady());
+        assertNull(JoinstrTransport.unavailableReason());
+    }
+
+    @Test
+    public void theGateFollowsTheCurrentStateNotACachedOne() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+        assertFalse(JoinstrTransport.isReady());
+
+        JoinstrTransport.setTorRunningForTesting(() -> true);
+        assertTrue(JoinstrTransport.isReady());
+
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+        assertFalse(JoinstrTransport.isReady(), "tor going away mid coinjoin must close the gate");
+        assertFalse(JoinstrTransport.newCircuit());
+    }
+}


### PR DESCRIPTION
Closes #62 in part. See the scope note below.

Every network path checked `AppServices.isTorRunning()` and, when it was false, skipped the circuit isolation and carried on sending anyway:

```java
if (AppServices.isTorRunning()) {
    Client.getInstance().disconnect();
    TorUtils.changeIdentity(AppServices.getTorProxy());
}
TorUtils.logTorIp();
// ... publish regardless
```

So a user who opened the joinstr tab before Tor had bootstrapped, or on a machine where Tor failed to start, published their join request, output address and signed PSBT from their real IP. `applyTorSocksProxy` logged a warning after 90 seconds and nothing else; nothing on screen said the join had been downgraded.

## Changes

`fix: refuse joinstr requests when tor is not running`

- New `JoinstrTransport`. `newCircuit()` takes a fresh circuit and returns false when Tor is unavailable, and callers must not send anything when it does.
- All six call sites now fail closed instead of open: output registration and input registration in `CoinjoinHandler`, pool announcement in `NostrPublisher`, subscription in `NostrListener`, discovery in `OtherPoolsController`, and the join request in `JoinstrPoolList`. Each reports it rather than continuing: a status change, an error dialog, or a thrown listener startup, matching what that call site already does on failure.
- The `if (AppServices.isTorRunning())` guard around each `Client.connect` is gone. Reaching that line now means Tor is up, so the connection context is always applied. Previously a Tor-less run also skipped the connect and relied on `send` to connect implicitly.
- `applyTorSocksProxy` raises an error dialog when Tor has not come up after 90 seconds, instead of only logging.
- Six copies of the disconnect-and-rotate block collapse into one.

`test: cover the tor gate`

Four cases behind a test seam for the running Tor instance: nothing is sent when Tor is down, the refusal explains that the request would otherwise go out from the real IP, a ready transport reports no reason, and the gate follows the current state rather than a cached one, so Tor going away mid coinjoin closes it.

## Verification

`./gradlew :test` green, 138 tests.
