### PR TITLE
fix: do not offer to join a pool this client cannot complete

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -28,6 +28,7 @@ public class JoinstrPool {
     private final javafx.beans.property.SimpleIntegerProperty connectedPeers;
     private String privateKey;
     private String poolId = "";
+    private String unsupportedReason;
     private String feeRate = "1";
     private JoinPoolHandler handler;
 
@@ -77,6 +78,19 @@ public class JoinstrPool {
 
     public String getPrivateKey() {
         return privateKey;
+    }
+
+    /** Why this pool cannot be joined from Sparrow, or null if it can. */
+    public String getUnsupportedReason() {
+        return unsupportedReason;
+    }
+
+    public void setUnsupportedReason(String unsupportedReason) {
+        this.unsupportedReason = unsupportedReason;
+    }
+
+    public boolean isJoinable() {
+        return unsupportedReason == null;
     }
 
     /** The pool id from the announcement, which peers echo back in the credentials. */

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -195,6 +195,12 @@ public class OtherPoolsController extends JoinstrFormController {
                                                 pool.setPoolId(poolData.get("id").asText());
                                             }
 
+                                            String unsupported = PoolSupport.unsupportedReason(poolData);
+                                            pool.setUnsupportedReason(unsupported);
+                                            if (unsupported != null) {
+                                                pool.setStatus("Unsupported");
+                                            }
+
                                             if (pools.stream().noneMatch(
                                                     (p) -> Objects.equals(p.getPubkey(), pool.getPubkey())) &&
                                                     myPools.stream().noneMatch(

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolSupport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolSupport.java
@@ -1,0 +1,88 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Whether a pool announcement describes a pool this client can actually complete.
+ *
+ * A pool can require sybil resistance or a transport this client does not implement. Joining one
+ * regardless means the join request is rejected or ignored and the user waits until the pool
+ * expires with nothing on screen explaining it.
+ */
+public final class PoolSupport {
+
+    public static final String REQUIRES_AUTCT =
+            "This pool requires an aut-ct proof, which Sparrow cannot generate.";
+
+    public static final String REQUIRES_VPN =
+            "This pool requires a VPN transport. Sparrow is Tor only.";
+
+    public static final String TOR_NOT_ENABLED =
+            "This pool does not enable Tor. Sparrow is Tor only.";
+
+    private PoolSupport() {
+    }
+
+    /** Why this pool cannot be joined from Sparrow, or null if it can. */
+    public static String unsupportedReason(JsonNode poolData) {
+        if (poolData == null) {
+            return null;
+        }
+
+        if (requiresAutct(poolData)) {
+            return REQUIRES_AUTCT;
+        }
+
+        return transportReason(poolData.get("transport"));
+    }
+
+    private static boolean requiresAutct(JsonNode poolData) {
+        JsonNode autct = poolData.get("autct");
+        if (autct == null || autct.isNull()) {
+            return false;
+        }
+
+        // the field is only meaningful with a keyset naming the proof requirement
+        JsonNode keyset = autct.get("keyset");
+        return keyset != null && !keyset.asText("").trim().isEmpty();
+    }
+
+    /**
+     * Tor is a transport the protocol defines: NIP.md gives the transport object a `tor.enable`
+     * flag, and a pool that says nothing is Tor by default. A Tor only client is a full
+     * participant, so the only pools refused here are the ones that do not offer Tor at all.
+     *
+     * Pools advertise transport in two shapes: the object in NIP.md, and the bare string the
+     * electrum plugin publishes. Read both.
+     */
+    private static String transportReason(JsonNode transport) {
+        if (transport == null || transport.isNull()) {
+            // NIP.md makes tor the default, so an announcement that omits transport is joinable
+            return null;
+        }
+
+        if (transport.isTextual()) {
+            String value = transport.asText("").trim();
+            if (value.isEmpty() || value.equalsIgnoreCase("tor")) {
+                return null;
+            }
+            return value.equalsIgnoreCase("vpn") ? REQUIRES_VPN : TOR_NOT_ENABLED;
+        }
+
+        if (transport.isObject()) {
+            boolean torEnabled = enabled(transport.get("tor"));
+            boolean vpnEnabled = enabled(transport.get("vpn"));
+
+            if (torEnabled) {
+                return null;
+            }
+            return vpnEnabled ? REQUIRES_VPN : TOR_NOT_ENABLED;
+        }
+
+        return TOR_NOT_ENABLED;
+    }
+
+    private static boolean enabled(JsonNode node) {
+        return node != null && node.get("enable") != null && node.get("enable").asBoolean(false);
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -23,6 +23,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
@@ -182,6 +183,10 @@ public class JoinstrPoolList extends VBox {
 
                         joinButton.setOnAction(event -> {
                             JoinstrPool pool = getTableView().getItems().get(getIndex());
+                            if(!pool.isJoinable()) {
+                                AppServices.showErrorDialog("Pool Not Supported", pool.getUnsupportedReason());
+                                return;
+                            }
                             Identity identity = Identity.generateRandomIdentity();
                             String pubkey = identity.getPublicKey().toString();
                             QRDisplayDialog qrDialog = new QRDisplayDialog(pubkey);
@@ -258,11 +263,23 @@ public class JoinstrPoolList extends VBox {
                     @Override
                     public void updateItem(Void item, boolean empty) {
                         super.updateItem(item, empty);
-                        if (empty) {
+                        if (empty || getIndex() < 0 || getIndex() >= getTableView().getItems().size()) {
                             setGraphic(null);
-                        } else {
-                            setGraphic(joinButton);
+                            return;
                         }
+
+                        JoinstrPool pool = getTableView().getItems().get(getIndex());
+                        boolean joinable = pool.isJoinable();
+
+                        // a pool this client cannot complete is still listed, so the reason is
+                        // visible, but joining it would only wait for a reply that never comes
+                        joinButton.setDisable(!joinable);
+                        joinButton.setTooltip(joinable ? null : new Tooltip(pool.getUnsupportedReason()));
+                        joinButton.setStyle(joinable
+                                ? "-fx-background-color: #2196F3; -fx-text-fill: white; -fx-cursor: hand;"
+                                : "-fx-background-color: #666666; -fx-text-fill: #cccccc;");
+
+                        setGraphic(joinButton);
                     }
                 };
             }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolSupportTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolSupportTest.java
@@ -1,0 +1,108 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A pool can require sybil resistance or a transport this client does not use. Joining one anyway
+ * means waiting until the pool expires with nothing on screen explaining it, because the creator
+ * either rejects the request or ignores it.
+ *
+ * Tor is a transport the protocol defines, so a Tor only client is a full participant. The pools
+ * refused here are the ones that do not offer Tor at all, plus aut-ct pools.
+ */
+public class PoolSupportTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode pool(String fields) throws Exception {
+        return MAPPER.readTree("{\"id\":\"abc\",\"public_key\":\"pk\",\"denomination\":0.001,"
+                + "\"peers\":3,\"timeout\":1750000000,\"relay\":\"wss://nos.lol\"" + fields + "}");
+    }
+
+    @Test
+    public void anOrdinaryPoolIsJoinable() throws Exception {
+        assertNull(PoolSupport.unsupportedReason(pool("")));
+    }
+
+    /** NIP.md makes Tor the default, so an announcement that omits transport is joinable. */
+    @Test
+    public void aPoolWithNoTransportFieldIsJoinable() throws Exception {
+        assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":null")));
+        assertNull(PoolSupport.unsupportedReason(pool(",\"transport\":null")));
+    }
+
+    @Test
+    public void aTorPoolInEitherShapeIsJoinable() throws Exception {
+        assertNull(PoolSupport.unsupportedReason(pool(",\"transport\":\"tor\"")));
+        assertNull(PoolSupport.unsupportedReason(pool(
+                ",\"transport\":{\"tor\":{\"enable\":true},\"vpn\":{\"enable\":false}}")));
+    }
+
+    /** Tor being offered is enough, even if the pool also offers a VPN. */
+    @Test
+    public void aPoolOfferingBothTorAndVpnIsJoinable() throws Exception {
+        assertNull(PoolSupport.unsupportedReason(pool(
+                ",\"transport\":{\"tor\":{\"enable\":true},\"vpn\":{\"enable\":true}}")));
+    }
+
+    @Test
+    public void aVpnOnlyPoolIsRefused() throws Exception {
+        assertEquals(PoolSupport.REQUIRES_VPN, PoolSupport.unsupportedReason(pool(",\"transport\":\"vpn\"")));
+        assertEquals(PoolSupport.REQUIRES_VPN, PoolSupport.unsupportedReason(pool(
+                ",\"transport\":{\"tor\":{\"enable\":false},\"vpn\":{\"enable\":true}}")));
+    }
+
+    @Test
+    public void aPoolOfferingNoTransportAtAllIsRefused() throws Exception {
+        assertEquals(PoolSupport.TOR_NOT_ENABLED, PoolSupport.unsupportedReason(pool(
+                ",\"transport\":{\"tor\":{\"enable\":false},\"vpn\":{\"enable\":false}}")));
+        assertEquals(PoolSupport.TOR_NOT_ENABLED, PoolSupport.unsupportedReason(pool(
+                ",\"transport\":\"i2p\"")));
+    }
+
+    @Test
+    public void anAutctPoolIsRefused() throws Exception {
+        String reason = PoolSupport.unsupportedReason(pool(
+                ",\"autct\":{\"keyset\":\"autct-830000-100000-1-2-1024.aks\",\"min_amount\":100000}"));
+
+        assertEquals(PoolSupport.REQUIRES_AUTCT, reason);
+    }
+
+    /** The field only means anything with a keyset naming the requirement. */
+    @Test
+    public void anEmptyAutctFieldDoesNotRefuseThePool() throws Exception {
+        assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":{}")));
+        assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":{\"keyset\":\"\"}")));
+        assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":{\"keyset\":\"   \"}")));
+    }
+
+    @Test
+    public void autctIsReportedAheadOfTransport() throws Exception {
+        String reason = PoolSupport.unsupportedReason(pool(
+                ",\"autct\":{\"keyset\":\"autct-1-2-3-4-5.aks\"},\"transport\":\"vpn\""));
+
+        // both apply, but the proof requirement is the one the user can do nothing about
+        assertEquals(PoolSupport.REQUIRES_AUTCT, reason);
+    }
+
+    @Test
+    public void aMissingAnnouncementIsNotRefused() {
+        assertNull(PoolSupport.unsupportedReason(null));
+    }
+
+    @Test
+    public void anUnsupportedPoolIsNotJoinable() {
+        JoinstrPool joinable = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000");
+        assertTrue(joinable.isJoinable());
+        assertNull(joinable.getUnsupportedReason());
+
+        joinable.setUnsupportedReason(PoolSupport.REQUIRES_VPN);
+        assertFalse(joinable.isJoinable());
+        assertEquals(PoolSupport.REQUIRES_VPN, joinable.getUnsupportedReason());
+    }
+}


### PR DESCRIPTION
Closes #66. Also closes the transport half of #62.

A pool can require an aut-ct proof, or a transport other than Tor. Both were parsed out of the announcement and thrown away, so such a pool appeared in the list as joinable. Clicking Join sent a request the creator either rejects, which was silent before #74, or ignores, and the user then waited until the pool expired with nothing explaining it.

Sparrow is Tor only. Tor is a transport the protocol defines, with its own `tor.enable` flag in the NIP.md transport object and Tor as the default when the field is absent, so a Tor only client is a full participant. The pools refused here are the ones that do not offer Tor at all, plus aut-ct pools.

## Changes

`fix: do not offer to join a pool this client cannot complete`

- New `PoolSupport.unsupportedReason`, returning why a pool cannot be joined or null if it can. It refuses an `autct` requirement carrying a keyset, a VPN only pool, and a pool that enables no transport this client uses.
- Transport is read in both shapes in use: the object from NIP.md with `tor.enable` and `vpn.enable`, and the bare string the electrum plugin publishes. A pool that offers both Tor and VPN is joinable, since Tor is on offer. A pool that omits transport entirely is joinable, since NIP.md makes Tor the default.
- `JoinstrPool` carries the reason. `OtherPoolsController` sets it during discovery and marks the pool "Unsupported" in the status column.
- The Join button is disabled for those pools, greyed, with the reason as its tooltip. The pool stays listed rather than being hidden, so the reason is visible.

`test: cover detection of pools this client cannot complete`

Eleven cases: an ordinary pool, a pool with no transport field, Tor in either shape, and a pool offering both Tor and VPN are all joinable; a VPN only pool in either shape, a pool enabling neither, an unknown transport, and an aut-ct pool with a keyset are all refused; an `autct` field with no keyset does not refuse the pool; aut-ct is reported ahead of transport when both apply; and a pool marked unsupported reports as not joinable.

## Verification

`./gradlew :test` green, 149 tests.

Reducing `unsupportedReason` to always returning null, which is the pre-fix behaviour, fails 4 of the 11.

## On #62

Its three parts were fail closed on Tor, the JVM-wide SOCKS proxy, and refusing unsupported transports. #83 did the first, this does the third by refusal rather than implementation, since VPN is out of scope for this client. Only the JVM-wide proxy is left, which needs a per-connection proxy from `nostr-java` and so belongs with #68. I have left #62 open for that one item.
