### PR TITLE
fix: identify a join request by parsing it, and stamp the protocol version

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -141,8 +141,7 @@ public class CoinjoinHandler {
                     return;
                 }
 
-                JoinstrMessage message = new JoinstrMessage();
-                message.setType("output");
+                JoinstrMessage message = JoinstrMessage.of("output");
                 message.setAddress(address);
                 String outputContent = message.toJson();
 
@@ -501,8 +500,7 @@ public class CoinjoinHandler {
                 return;
             }
 
-            JoinstrMessage message = new JoinstrMessage();
-            message.setType("input");
+            JoinstrMessage message = JoinstrMessage.of("input");
             message.setPsbt(psbtBase64);
             String inputContent = message.toJson();
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -3,6 +3,10 @@ package com.sparrowwallet.sparrow.joinstr;
 import java.util.Map;
 
 public class JoinstrMessage {
+    /** Every payload in NIP.md carries this. */
+    public static final String VERSION = "1";
+
+    private String version;
     private String type;
     private String address;
     private String psbt;
@@ -15,6 +19,32 @@ public class JoinstrMessage {
     private Long timeout;
     private String relay;
     private String reason;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /** A message this client sends, stamped with the protocol version. */
+    public static JoinstrMessage of(String type) {
+        JoinstrMessage message = new JoinstrMessage();
+        message.setVersion(VERSION);
+        message.setType(type);
+        return message;
+    }
+
+    /** Whether a decrypted payload is a request to join a pool. */
+    public static boolean isJoinRequest(String decryptedContent) {
+        try {
+            JoinstrMessage message = fromJson(decryptedContent);
+            return message != null && "join_pool".equals(message.getType());
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
     public String getType() {
         return type;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -109,6 +109,8 @@ public class JoinstrPool {
      */
     public Map<String, Object> toCredentials() {
         Map<String, Object> credentials = new LinkedHashMap<>();
+        credentials.put("version", JoinstrMessage.VERSION);
+        credentials.put("type", "credentials");
         credentials.put("id", poolId);
         credentials.put("public_key", getPubkey());
         credentials.put("denomination", asNumber(getDenomination(), 0d));

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -115,7 +115,9 @@ public class NostrListener implements AutoCloseable {
                         encryptedContent,
                         new PublicKey(senderPubkey));
 
-                if (decryptedContent.contains("\"type\": \"join_pool\"") && poolCredentials != null) {
+                // matching the raw text depended on the sender's json whitespace, so a peer
+                // serialising compactly was never answered
+                if (poolCredentials != null && JoinstrMessage.isJoinRequest(decryptedContent)) {
                     handleJoinRequest(senderPubkey);
                 }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -1,5 +1,6 @@
 package com.sparrowwallet.sparrow.joinstr.control;
 
+import com.sparrowwallet.sparrow.joinstr.JoinstrMessage;
 import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
 import com.sparrowwallet.sparrow.joinstr.JoinstrTransport;
 import com.sparrowwallet.sparrow.control.QRDisplayDialog;
@@ -202,7 +203,7 @@ public class JoinstrPoolList extends VBox {
                                     }
 
                                     PublicKey poolPubKey = new PublicKey(pool.getPubkey());
-                                    String requestContent = "{\"type\": \"join_pool\"}";
+                                    String requestContent = JoinstrMessage.of("join_pool").toJson();
                                     List<BaseTag> tags = new ArrayList<>();
                                     tags.add(new PubKeyTag(poolPubKey)); // Send to pool creator's pubkey
 

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinRequestParsingTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/JoinRequestParsingTest.java
@@ -1,0 +1,91 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A pool creator recognised a join request by looking for the literal text
+ * {@code "type": "join_pool"} in the decrypted payload, which depended on the sender's json
+ * whitespace. A peer serialising compactly was never answered, and never told why.
+ */
+public class JoinRequestParsingTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void aJoinRequestIsRecognisedWhateverTheSpacing() {
+        assertTrue(JoinstrMessage.isJoinRequest("{\"type\": \"join_pool\"}"));
+        assertTrue(JoinstrMessage.isJoinRequest("{\"type\":\"join_pool\"}"));
+        assertTrue(JoinstrMessage.isJoinRequest("{\n  \"type\"  :  \"join_pool\"\n}"));
+        assertTrue(JoinstrMessage.isJoinRequest("{\"version\":\"1\",\"type\":\"join_pool\"}"));
+    }
+
+    /** Field order is not fixed on the wire either. */
+    @Test
+    public void aJoinRequestIsRecognisedWhateverTheFieldOrder() {
+        assertTrue(JoinstrMessage.isJoinRequest("{\"npub\":\"abc\",\"type\":\"join_pool\"}"));
+    }
+
+    @Test
+    public void thisClientsOwnJoinRequestIsRecognised() {
+        assertTrue(JoinstrMessage.isJoinRequest(JoinstrMessage.of("join_pool").toJson()));
+    }
+
+    @Test
+    public void otherMessagesAreNotJoinRequests() {
+        assertFalse(JoinstrMessage.isJoinRequest("{\"type\":\"output\",\"address\":\"bc1q\"}"));
+        assertFalse(JoinstrMessage.isJoinRequest("{\"type\":\"reject\",\"reason\":\"missing_proof\"}"));
+        assertFalse(JoinstrMessage.isJoinRequest("{}"));
+    }
+
+    /** A payload merely mentioning the words must not be treated as a request. */
+    @Test
+    public void textMentioningJoinPoolIsNotARequest() {
+        assertFalse(JoinstrMessage.isJoinRequest("{\"type\":\"output\",\"address\":\"join_pool\"}"));
+        assertFalse(JoinstrMessage.isJoinRequest("this mentions \"type\": \"join_pool\" but is not json"));
+    }
+
+    @Test
+    public void unparseableInputIsNotARequest() {
+        assertFalse(JoinstrMessage.isJoinRequest("not json"));
+        assertFalse(JoinstrMessage.isJoinRequest(""));
+        assertFalse(JoinstrMessage.isJoinRequest("[1,2,3]"));
+    }
+
+    @Test
+    public void outgoingMessagesCarryTheProtocolVersion() throws Exception {
+        for(String type : new String[] {"output", "input", "join_pool"}) {
+            JsonNode sent = MAPPER.readTree(JoinstrMessage.of(type).toJson());
+            assertEquals("1", sent.get("version").asText(), type + " is missing a version");
+            assertEquals(type, sent.get("type").asText());
+        }
+    }
+
+    @Test
+    public void credentialsCarryTheVersionAndType() throws Exception {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000", "aabbcc");
+        pool.setPoolId("abc123");
+
+        JsonNode sent = MAPPER.readTree(new Gson().toJson(pool.toCredentials()));
+
+        assertEquals("1", sent.get("version").asText());
+        assertEquals("credentials", sent.get("type").asText());
+        // and the fields a joiner checks are still there and unchanged
+        assertEquals("abc123", sent.get("id").asText());
+        assertEquals(0.001, sent.get("denomination").asDouble());
+        assertEquals(3, sent.get("peers").asInt());
+    }
+
+    @Test
+    public void anIncomingMessageWithoutAVersionIsStillParsed() {
+        JoinstrMessage parsed = JoinstrMessage.fromJson("{\"type\":\"output\",\"address\":\"bc1q\"}");
+
+        assertEquals("output", parsed.getType());
+        assertNull(parsed.getVersion());
+    }
+}


### PR DESCRIPTION
Part of #68. Does two of its four items; see the scope note.

## Changes

`fix: identify a join request by parsing it, and stamp the protocol version`

- A pool creator recognised a join request with `decryptedContent.contains("\"type\": \"join_pool\"")`, matching raw text including the sender's json whitespace. A peer serialising compactly was never answered and never told why. It now parses the payload and compares the `type` field.

  This worked by luck until now: this client's request was a hand written string literal with the space, and Python's `json.dumps` also emits one. Any client using a compact serialiser was silently ignored.

- NIP.md carries `"version": "1"` on every payload and this client sent none. Outgoing output, input, join_pool and credentials messages now carry it, via a `JoinstrMessage.of(type)` factory. Incoming messages without a version are still accepted, since the reference implementation does not send one either.

- The join request is now built from `JoinstrMessage` rather than a hand written json string, so it cannot drift from what the parser expects.

`test: cover join request parsing and message versioning`

Nine cases: a join request recognised with spacing, without spacing, across newlines, with extra fields and in any field order; this client's own request recognised; other message types and empty objects not treated as requests; a payload that merely mentions the words not treated as one; unparseable input handled; and the version present on all four outgoing message types plus credentials, with the fields a joiner checks unchanged.

## Verification

`./gradlew :test` green, 158 tests.

Restoring the substring match and dropping the version stamp fails 5 of the 9.

## Scope note

#68 lists four things. This does the second and the fourth. The other two are one piece of work and I have not started them:

- **Relay events scraped from log records.** `NostrListener` and `OtherPoolsController` receive events by attaching a `java.util.logging.Handler` to the nostr library's internal `TextListener` logger and string matching `WebSocket received: ["EVENT"`.
- **The shared client singleton.** `nostr.client.Client` exposes only `getInstance()`, `connect`, `disconnect` and `send`. There is no per-connection instance in practice and no callback API, which is why the log scraping exists at all.

There is a real path to fixing both. `nostr-java` has a `CommandHandler` service provider interface, loaded from `META-INF/services/nostr.command.CommandHandler`, and `DefaultCommandContext.getMessage()` hands over the actual `BaseMessage`. A handler registered that way would receive real events with no log scraping.

That needs a change in `nostr-java` itself to expose the registration cleanly. The dependency is `com.github.1440000bytes:nostr-java`, which is this project's own fork, so it is available to change. It is a cross repository change and a dependency bump, so I have not started it without asking. It would also resolve the last item in #62, since a per-connection proxy would remove the JVM-wide system properties.
