### PR TITLE
fix: order coinjoin outputs by announcement time

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -31,6 +31,7 @@ import org.bouncycastle.util.encoders.Base64;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -49,6 +50,7 @@ public class CoinjoinHandler {
     private final Consumer<String> statusCallback;
 
     private final List<String> outputAddresses = new CopyOnWriteArrayList<>();
+    private final Map<String, Long> outputTimes = new ConcurrentHashMap<>();
     private final List<String> inputPSBTs = new CopyOnWriteArrayList<>();
     private final Set<String> allInputs = Collections.synchronizedSet(new HashSet<>());
     private String myOutputAddress;
@@ -97,8 +99,6 @@ public class CoinjoinHandler {
         }
 
         this.myOutputAddress = myOutputAddress;
-        outputAddresses.add(myOutputAddress);
-        pool.setConnectedPeers(outputAddresses.size());
 
         updateStatus("Output registered");
 
@@ -169,6 +169,9 @@ public class CoinjoinHandler {
 
                 nip04.send(Map.of("default", relay));
 
+                Long createdAt = outputEvent.getCreatedAt();
+                recordOutput(address, createdAt == null ? Instant.now().getEpochSecond() : createdAt);
+
                 logger.info("Output registered");
             } catch (Exception e) {
                 logger.severe("Failed to send output: " + e.getMessage());
@@ -183,12 +186,16 @@ public class CoinjoinHandler {
     }
 
     void handleDecryptedMessage(String decryptedMessage) {
+        handleDecryptedMessage(decryptedMessage, Instant.now().getEpochSecond());
+    }
+
+    void handleDecryptedMessage(String decryptedMessage, long createdAt) {
         try {
             JoinstrMessage message = JoinstrMessage.fromJson(decryptedMessage);
             String type = message.getType();
 
             if ("output".equals(type)) {
-                handleOutputReceived(message);
+                handleOutputReceived(message, createdAt);
             } else if ("input".equals(type)) {
                 handleInputReceived(message);
             }
@@ -197,7 +204,7 @@ public class CoinjoinHandler {
         }
     }
 
-    private void handleOutputReceived(JoinstrMessage message) {
+    private void handleOutputReceived(JoinstrMessage message, long createdAt) {
         try {
             String addressStr = message.getAddress();
             if (addressStr == null) {
@@ -216,8 +223,7 @@ public class CoinjoinHandler {
                     return;
                 }
 
-                outputAddresses.add(addressStr);
-                pool.setConnectedPeers(outputAddresses.size());
+                recordOutput(addressStr, createdAt);
                 logger.info("Received output " + outputAddresses.size() + "/" + numPeers);
 
                 if (outputAddresses.size() == numPeers) {
@@ -324,6 +330,32 @@ public class CoinjoinHandler {
         executorService.submit(task);
     }
 
+    /**
+     * Record an output and the time its announcement was published.
+     *
+     * The registration PSBT commits to the outputs in order, so every peer has to arrive at the
+     * same order or the signatures do not agree. Peers see announcements in whatever order their
+     * own relay poll returns, so ordering by publication time is what makes them converge.
+     */
+    private void recordOutput(String address, long createdAt) {
+        synchronized (stateLock) {
+            if (!outputTimes.containsKey(address)) {
+                outputTimes.put(address, createdAt);
+                outputAddresses.add(address);
+            }
+        }
+        pool.setConnectedPeers(outputAddresses.size());
+    }
+
+    /** The registered outputs in the order every peer should build them. */
+    List<String> orderedOutputs() {
+        List<String> ordered = new ArrayList<>(outputAddresses);
+        ordered.sort(Comparator
+                .comparingLong((String address) -> outputTimes.getOrDefault(address, 0L))
+                .thenComparing(Comparator.naturalOrder()));
+        return ordered;
+    }
+
     /** Read the facts CoinjoinInput needs off the wallet. */
     CoinjoinInput.Coin coinFacts(BlockTransactionHashIndex utxo, WalletNode utxoNode) {
         boolean confirmed = utxo.getHeight() > 0;
@@ -371,9 +403,8 @@ public class CoinjoinHandler {
             logger.info("Creating PSBT: pool=" + poolAmountSats + " sats, fee/output=" + feePerOutput + ", output="
                     + outputAmount);
 
-            List<String> sortedOutputs = new ArrayList<>(outputAddresses);
-            Collections.sort(sortedOutputs);
-            logger.info("Sorted " + sortedOutputs.size() + " outputs for deterministic ordering");
+            List<String> sortedOutputs = orderedOutputs();
+            logger.info("Ordered " + sortedOutputs.size() + " outputs by announcement time");
 
             for (String addr : sortedOutputs) {
                 Address address = Address.fromString(addr);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -200,7 +200,7 @@ public class JoinPoolHandler {
 
         credentialsListener = new NostrListener(joinIdentity, relay, null);
 
-        credentialsListener.startListening(this::onDecryptedMessage);
+        credentialsListener.startListening((message, createdAt) -> onDecryptedMessage(message));
     }
 
     /**

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
@@ -281,7 +281,7 @@ public class NewPoolController extends JoinstrFormController {
 
         NostrListener listener = new NostrListener(poolIdentity, relayUrl, poolCredentials);
 
-        listener.startListening(decryptedMessage -> {
+        listener.startListening((decryptedMessage, createdAt) -> {
             logger.info("Received message for credential sharing");
         });
     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -23,7 +23,7 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.Handler;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 public class NostrListener implements AutoCloseable {
     private static final Logger logger = Logger.getLogger(NostrListener.class.getName());
@@ -31,7 +31,7 @@ public class NostrListener implements AutoCloseable {
     private final Identity identity;
     private final String relay;
     private Client client;
-    private Consumer<String> messageHandler;
+    private BiConsumer<String, Long> messageHandler;
     private final Map<String, Object> poolCredentials;
     private static final ConsoleHandler consoleLogHandler = new ConsoleHandler();
     private transient Handler eventMessageHandler = null;
@@ -52,7 +52,7 @@ public class NostrListener implements AutoCloseable {
         }
     }
 
-    public void startListening(Consumer<String> messageHandler) {
+    public void startListening(BiConsumer<String, Long> messageHandler) {
         this.messageHandler = messageHandler;
         setupEventHandler();
         connectAndSubscribe();
@@ -122,7 +122,7 @@ public class NostrListener implements AutoCloseable {
                 }
 
                 if (messageHandler != null) {
-                    messageHandler.accept(decryptedContent);
+                    messageHandler.accept(decryptedContent, timestamp);
                 }
 
                 logger.info("Successfully decrypted message");

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/OutputOrderingTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/OutputOrderingTest.java
@@ -1,0 +1,126 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Registration PSBTs are signed with SIGHASH_ALL | SIGHASH_ANYONECANPAY, so every signature
+ * commits to the whole output list in order. Peers that assemble the list in different orders
+ * cannot all be satisfied by one transaction.
+ *
+ * The electrum plugin builds its list from whatever order its relay poll returns and never sorts
+ * (plugin/joinstr.py:1600-1604, :2220). Sorting the addresses lexicographically, which is what
+ * this client used to do, diverges from that on almost every pool. Ordering by the time each
+ * announcement was published reproduces the order the plugin's peers converge on, and unlike
+ * local arrival order it is the same for everyone.
+ */
+public class OutputOrderingTest {
+
+    private static final String A = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+    private static final String B = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    private static final String C = "bc1q9d4ywgfnd8h43da5tpcxcn6ajv590cg6d3tg6axemvljvt2k76zs50tv4q";
+
+    private CoinjoinHandler handler() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000");
+        return new CoinjoinHandler(null, pool, null, null, status -> {
+        });
+    }
+
+    private void output(CoinjoinHandler handler, String address, long createdAt) {
+        handler.handleDecryptedMessage("{\"type\":\"output\",\"address\":\"" + address + "\"}", createdAt);
+    }
+
+    @Test
+    public void outputsFollowPublicationTimeNotArrival() {
+        CoinjoinHandler handler = handler();
+
+        // B published first, then A, then C, and they arrive in yet another order.
+        // Lexicographically these sort C, A, B, so the expected result below can only come
+        // from publication time.
+        output(handler, A, 200);
+        output(handler, C, 300);
+        output(handler, B, 100);
+
+        assertEquals(List.of(B, A, C), handler.orderedOutputs());
+        assertNotEquals(handler.orderedOutputs().stream().sorted().toList(),
+                handler.orderedOutputs());
+    }
+
+    /** Two peers seeing the same announcements in different orders must agree. */
+    @Test
+    public void twoPeersSeeingDifferentArrivalOrdersAgree() {
+        CoinjoinHandler first = handler();
+        output(first, A, 200);
+        output(first, C, 300);
+        output(first, B, 100);
+
+        CoinjoinHandler second = handler();
+        output(second, C, 300);
+        output(second, B, 100);
+        output(second, A, 200);
+
+        assertEquals(first.orderedOutputs(), second.orderedOutputs());
+        assertEquals(List.of(B, A, C), first.orderedOutputs());
+    }
+
+    /** The old behaviour: lexicographic order, which no plugin peer produces. */
+    @Test
+    public void theOrderIsNotLexicographic() {
+        CoinjoinHandler handler = handler();
+
+        output(handler, B, 100);
+        output(handler, A, 200);
+        output(handler, C, 300);
+
+        List<String> ordered = handler.orderedOutputs();
+        List<String> lexicographic = ordered.stream().sorted().toList();
+
+        assertEquals(List.of(B, A, C), ordered);
+        assertNotEquals(lexicographic, ordered, "outputs were sorted lexicographically");
+    }
+
+    /** Same second for two announcements still has to resolve the same way everywhere. */
+    @Test
+    public void tiesAreBrokenDeterministically() {
+        CoinjoinHandler first = handler();
+        output(first, B, 100);
+        output(first, A, 100);
+
+        CoinjoinHandler second = handler();
+        output(second, A, 100);
+        output(second, B, 100);
+
+        assertEquals(first.orderedOutputs(), second.orderedOutputs());
+        // equal times fall back to the address, which is the only thing both peers share
+        assertEquals(List.of(A, B), first.orderedOutputs());
+    }
+
+    @Test
+    public void aRepeatedAnnouncementDoesNotDuplicateTheOutput() {
+        CoinjoinHandler handler = handler();
+
+        output(handler, A, 100);
+        output(handler, A, 500);
+
+        assertEquals(List.of(A), handler.orderedOutputs());
+        // the first announcement's time is the one that counts, so a peer republishing later
+        // cannot move itself down the list
+        output(handler, B, 200);
+        assertEquals(List.of(A, B), handler.orderedOutputs());
+    }
+
+    @Test
+    public void outputsBeyondThePeerCountAreIgnored() {
+        CoinjoinHandler handler = handler();
+
+        output(handler, A, 100);
+        output(handler, B, 200);
+        output(handler, C, 300);
+        output(handler, "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3", 400);
+
+        assertEquals(3, handler.orderedOutputs().size(), "a fourth output entered a 3 peer pool");
+    }
+}


### PR DESCRIPTION
Closes #59.

Registration PSBTs are signed with `SIGHASH_ALL | SIGHASH_ANYONECANPAY`, so every signature commits to the whole output list in order. Peers that assemble that list in different orders cannot all be satisfied by one transaction.

This client sorted the output addresses lexicographically. The electrum plugin does not sort: it builds `txout` straight from `session.output_list` (`plugin/joinstr.py:1600-1604`), which is appended to in whatever order each relay poll returns (`plugin/joinstr.py:2220`). So a pool containing both clients produced a transaction that at least one peer's signature did not cover.

## Changes

`fix: order coinjoin outputs by announcement time`

- `NostrListener` passes each event's `created_at` to the handler. It was parsed and discarded.
- `CoinjoinHandler` records the publication time alongside each output address and orders by it, with the address as a tie break so equal timestamps resolve the same way for every peer.
- The lexicographic sort in `createCoinjoinPSBT` is gone.
- This client's own output is no longer inserted at position zero before publishing. It is recorded once its event exists, with that event's `created_at`, so it sits where the other peers also see it. Previously a joiner always put its own address first, which no other peer did.

`test: cover coinjoin output ordering`

Six cases: publication time wins over arrival order, two peers seeing different arrival orders agree on the same list, the result is explicitly not lexicographic, equal timestamps break the same way for both peers, a repeated announcement neither duplicates an output nor moves a peer down the list, and a fourth output cannot enter a three peer pool.

## Verification

`./gradlew :test` green, 164 tests.

Putting the lexicographic sort back fails 3 of the 6.

Worth noting on the tests: my first version of them used addresses whose lexicographic order happened to match their timestamps, so 5 of 6 passed under either implementation and proved nothing. The addresses now sort in the reverse of their publication order, so the assertions can only hold for one of the two.

## Upstream

gitlab invincible-privacy/joinstr#50 asks the plugin to sort. If it ever adopts a canonical order this should follow it rather than keep its own. Until then, this is the closest a peer can get to the plugin's behaviour while still being deterministic.
