### PR TITLE
lsag: port the linkable ring signature used by coinjoin recovery

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/Lsag.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/Lsag.java
@@ -1,0 +1,332 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.crypto.ECKey;
+
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.util.BigIntegers;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Linkable Spontaneous Anonymous Group signatures over secp256k1.
+ *
+ * Used by the coinjoin recovery phase: when a pool loses a peer during input registration, the
+ * peers that did register re-register their outputs under a signature proving membership of the
+ * ring of Phase 2 keys, without saying which member they are. The key image links two signatures
+ * by the same key, so nobody can claim two outputs.
+ *
+ * This is a port of the reference implementation's lrs.py and has to agree with it byte for byte,
+ * including the scalar encoding on the wire.
+ */
+public final class Lsag {
+
+    private static final BigInteger CURVE_ORDER = ECKey.CURVE.getN();
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    /** A signature and the key image that links it to its signer. */
+    public static final class Signature {
+        private final String y0;
+        private final List<String> s;
+        private final List<String> c;
+
+        public Signature(String y0, List<String> s, List<String> c) {
+            this.y0 = y0;
+            this.s = List.copyOf(s);
+            this.c = List.copyOf(c);
+        }
+
+        public String getY0() {
+            return y0;
+        }
+
+        public List<String> getS() {
+            return s;
+        }
+
+        public List<String> getC() {
+            return c;
+        }
+
+        /** The key image is the Y0 point; two signatures by one key share it. */
+        public String keyImage() {
+            return y0;
+        }
+    }
+
+    private Lsag() {
+    }
+
+    /**
+     * The compressed lowercase encoding of a key image, or null if it is not a point.
+     *
+     * Hex decoding ignores case, so one key image has many spellings that all verify. Signatures
+     * are linked by comparing the key image, so only the canonical spelling is accepted; otherwise
+     * one signer supplies unlimited distinct looking images for a single key.
+     */
+    public static String canonicalKeyImage(String y0Hex) {
+        try {
+            return encode(decodePoint(y0Hex));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Deterministically map bytes onto a curve point, trying successive nonces. */
+    public static ECPoint hashToPoint(byte[] data) {
+        for (long nonce = 0; nonce < Integer.MAX_VALUE; nonce++) {
+            byte[] candidate = sha256(concat(data, ByteBuffer.allocate(4).putInt((int) nonce).array()));
+            byte[] pointBytes = concat(new byte[] {0x02}, candidate);
+            try {
+                ECPoint point = ECKey.CURVE.getCurve().decodePoint(pointBytes);
+                if (point.isValid()) {
+                    return point.normalize();
+                }
+            } catch (Exception e) {
+                // not on the curve, try the next nonce
+            }
+        }
+        throw new IllegalStateException("no curve point found for the given data");
+    }
+
+    /**
+     * The challenge hash, reduced to a scalar.
+     *
+     * Items are fed in as the reference implementation feeds them: a point as its compressed
+     * encoding, a scalar as its decimal digits, a string as its hex bytes when it decodes as hex
+     * and as its utf8 bytes when it does not, and raw bytes as themselves.
+     */
+    public static BigInteger hashPoints(List<Object> items) {
+        MessageDigest digest = newSha256();
+        for (Object item : items) {
+            if (item instanceof ECPoint point) {
+                digest.update(encodeBytes(point));
+            } else if (item instanceof BigInteger scalar) {
+                digest.update(scalar.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            } else if (item instanceof byte[] bytes) {
+                digest.update(bytes);
+            } else if (item instanceof String text) {
+                byte[] hex = tryDecodeHex(text);
+                digest.update(hex != null ? hex : text.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            } else {
+                digest.update(String.valueOf(item).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+        }
+        return new BigInteger(1, digest.digest()).mod(CURVE_ORDER);
+    }
+
+    /** Sign as ring member {@code identity}, whose public key must be {@code publicKeys.get(identity)}. */
+    public static Signature sign(byte[] message, List<String> publicKeys, String privateKeyHex, int identity) {
+        int n = publicKeys.size();
+        if (n == 0 || identity < 0 || identity >= n) {
+            throw new IllegalArgumentException("signer is not a member of the ring");
+        }
+
+        List<ECPoint> ring = new ArrayList<>(n);
+        for (String publicKey : publicKeys) {
+            ring.add(decodePoint(publicKey));
+        }
+
+        BigInteger privateKey = new BigInteger(1, hexToBytes(privateKeyHex));
+        ECPoint hpSigner = hashToPoint(encodeBytes(ring.get(identity)));
+        ECPoint y0Point = hpSigner.multiply(privateKey).normalize();
+        String y0 = encode(y0Point);
+
+        BigInteger[] c = new BigInteger[n];
+        BigInteger[] s = new BigInteger[n];
+        for (int i = 0; i < n; i++) {
+            c[i] = BigInteger.ZERO;
+            s[i] = BigInteger.ZERO;
+        }
+
+        BigInteger u = randomScalar();
+        BigInteger ringDigest = ringDigest(ring);
+
+        ECPoint lPrime = ECKey.CURVE.getG().multiply(u).normalize();
+        ECPoint rPrime = hpSigner.multiply(u).normalize();
+
+        int idx = (identity + 1) % n;
+        c[idx] = challenge(ringDigest, y0, message, lPrime, rPrime);
+
+        while (idx != identity) {
+            s[idx] = randomScalar();
+
+            ECPoint sg = ECKey.CURVE.getG().multiply(s[idx]);
+            ECPoint cp = ring.get(idx).multiply(c[idx]);
+            lPrime = sg.add(cp).normalize();
+
+            ECPoint hpI = hashToPoint(encodeBytes(ring.get(idx)));
+            ECPoint shp = hpI.multiply(s[idx]);
+            ECPoint cY0 = y0Point.multiply(c[idx]);
+            rPrime = shp.add(cY0).normalize();
+
+            idx = (idx + 1) % n;
+            c[idx] = challenge(ringDigest, y0, message, lPrime, rPrime);
+        }
+
+        s[identity] = u.subtract(c[identity].multiply(privateKey)).mod(CURVE_ORDER);
+
+        return new Signature(y0, toHexList(s), toHexList(c));
+    }
+
+    /** Whether this signature was made by some member of the ring. */
+    public static boolean verify(byte[] message, Signature signature, List<String> publicKeys) {
+        int n = publicKeys.size();
+        if (signature == null || n == 0 || signature.getS().size() != n || signature.getC().size() != n) {
+            return false;
+        }
+
+        if (!signature.getY0().equals(canonicalKeyImage(signature.getY0()))) {
+            return false;
+        }
+
+        List<ECPoint> ring = new ArrayList<>(n);
+        ECPoint y0Point;
+        BigInteger[] s = new BigInteger[n];
+        BigInteger[] c = new BigInteger[n];
+        try {
+            for (String publicKey : publicKeys) {
+                ring.add(decodePoint(publicKey));
+            }
+            y0Point = decodePoint(signature.getY0());
+            for (int i = 0; i < n; i++) {
+                s[i] = parseScalar(signature.getS().get(i));
+                c[i] = parseScalar(signature.getC().get(i));
+            }
+        } catch (Exception e) {
+            return false;
+        }
+
+        BigInteger ringDigest = ringDigest(ring);
+
+        for (int i = 0; i < n; i++) {
+            ECPoint sg = ECKey.CURVE.getG().multiply(s[i]);
+            ECPoint cp = ring.get(i).multiply(c[i]);
+            ECPoint lPrime = sg.add(cp).normalize();
+
+            ECPoint hpI = hashToPoint(encodeBytes(ring.get(i)));
+            ECPoint shp = hpI.multiply(s[i]);
+            ECPoint cY0 = y0Point.multiply(c[i]);
+            ECPoint rPrime = shp.add(cY0).normalize();
+
+            BigInteger next = challenge(ringDigest, signature.getY0(), message, lPrime, rPrime);
+            if (!next.equals(c[(i + 1) % n])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static BigInteger ringDigest(List<ECPoint> ring) {
+        List<Object> items = new ArrayList<>(ring.size());
+        for (ECPoint point : ring) {
+            items.add(encodeBytes(point));
+        }
+        return hashPoints(items);
+    }
+
+    private static BigInteger challenge(BigInteger ringDigest, String y0, byte[] message,
+            ECPoint lPrime, ECPoint rPrime) {
+        return hashPoints(List.of(ringDigest, y0, message, encodeBytes(lPrime), encodeBytes(rPrime)));
+    }
+
+    /** Scalars go on the wire the way python's hex() writes them: "0x" and no leading zeros. */
+    static String toWireScalar(BigInteger value) {
+        return "0x" + value.toString(16);
+    }
+
+    static BigInteger parseScalar(String value) {
+        String text = value.trim();
+        if (text.startsWith("0x") || text.startsWith("0X")) {
+            text = text.substring(2);
+        }
+        return new BigInteger(text, 16);
+    }
+
+    private static List<String> toHexList(BigInteger[] values) {
+        List<String> hex = new ArrayList<>(values.length);
+        for (BigInteger value : values) {
+            hex.add(toWireScalar(value));
+        }
+        return hex;
+    }
+
+    private static BigInteger randomScalar() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return new BigInteger(1, bytes).mod(CURVE_ORDER);
+    }
+
+    private static ECPoint decodePoint(String hex) {
+        ECPoint point = ECKey.CURVE.getCurve().decodePoint(hexToBytes(hex));
+        if (!point.isValid()) {
+            throw new IllegalArgumentException("point is not on the curve");
+        }
+        return point.normalize();
+    }
+
+    private static byte[] encodeBytes(ECPoint point) {
+        return point.normalize().getEncoded(true);
+    }
+
+    private static String encode(ECPoint point) {
+        return bytesToHex(encodeBytes(point));
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        String text = hex.trim();
+        if (text.length() % 2 != 0) {
+            throw new IllegalArgumentException("odd length hex");
+        }
+        byte[] bytes = new byte[text.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) Integer.parseInt(text.substring(i * 2, i * 2 + 2), 16);
+        }
+        return bytes;
+    }
+
+    private static byte[] tryDecodeHex(String text) {
+        try {
+            return hexToBytes(text);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            hex.append(String.format("%02x", b));
+        }
+        return hex.toString();
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        byte[] combined = new byte[first.length + second.length];
+        System.arraycopy(first, 0, combined, 0, first.length);
+        System.arraycopy(second, 0, combined, first.length, second.length);
+        return combined;
+    }
+
+    private static byte[] sha256(byte[] data) {
+        return newSha256().digest(data);
+    }
+
+    private static MessageDigest newSha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    static byte[] scalarBytes(BigInteger value) {
+        return BigIntegers.asUnsignedByteArray(32, value);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/LsagTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/LsagTest.java
@@ -1,0 +1,195 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.bouncycastle.math.ec.ECPoint;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Cross implementation vectors, produced by running the reference implementation's own lrs.py
+ * with a deterministic random source. A ring signature is only useful here if both clients agree
+ * on it exactly, so these pin the wire encoding and every intermediate hash, not just that
+ * signing and verifying agree with themselves.
+ */
+public class LsagTest {
+
+    private static final List<String> PUBS = List.of("02d53c88a0a81f9c3a80638fa81e477625d49aca04568139072c87a36e47ecb96a", "02530247b68e147562021f66c0ffdc08b483104902ca6ccdc514e67c7b5530072c", "0329842957645000d91e22fbb369f953edd1f1afc6cf788cf314ea53c390720cec", "02758d708f7d9ba2e4c8636b8570f80b4d4045e9dba95529106cf4bce13f245c2c");
+    private static final List<String> PRIVS = List.of("00000000000000000000000000000000000000000000000000000000000f4243", "00000000000000000000000000000000000000000000000000000000000f4244", "00000000000000000000000000000000000000000000000000000000000f4245", "00000000000000000000000000000000000000000000000000000000000f4246");
+    private static final String MESSAGE_HEX = "8dbe01bf6007295f60883218d8ba0181fc797976c1e0f04159a86e41df153852";
+    private static final int SIGNER = 2;
+
+    private static final String REF_Y0 = "038866906b4a661234e479319636779381416a18c5025746790ae8c76b5fbf3fec";
+    private static final List<String> REF_S = List.of("0x6a414d970401bdede7ab9c36ac6065d5a7d188ae3914a5684791bd288f0337cf", "0x3f7c6d0c984f549755bb2cb6ffcb93c597b7144f556855ecb67b562300816f90", "0x7054e8bbf0c0df229653d097d8802c40d5a3b90027fe135098f0874fb3697014", "0x26c0fd48e152604affe6c1d695496cba197bc0e138c6b0dff9a8b2b14a48a0af");
+    private static final List<String> REF_C = List.of("0xd6aa60d47db42ab6b8073b422d7dd51ecd11558396234e015e26b39f6819deed", "0x351f35419258c647c8ded1c7a936b5db1b7260ad9cd4e692212b25163030c17", "0x9a987717797bdd132f7dd1f0452312d56ad849c75ddcb9d033ae24fafc603dce", "0xe730a9d3b9e0e63effb59edbd338329302a49f267d7a9d52e2c1d2faab6a49d8");
+
+    private byte[] message() {
+        return bytes(MESSAGE_HEX);
+    }
+
+    private static byte[] bytes(String hex) {
+        byte[] out = new byte[hex.length() / 2];
+        for(int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
+
+    private static String hex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for(byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    /** The whole point: a signature made by the reference implementation must verify here. */
+    @Test
+    public void verifiesASignatureMadeByTheReferenceImplementation() {
+        Lsag.Signature reference = new Lsag.Signature(REF_Y0, REF_S, REF_C);
+
+        assertTrue(Lsag.verify(message(), reference, PUBS));
+    }
+
+    @Test
+    public void rejectsTheReferenceSignatureAgainstADifferentMessage() {
+        Lsag.Signature reference = new Lsag.Signature(REF_Y0, REF_S, REF_C);
+
+        assertFalse(Lsag.verify(bytes("8dbe01bf6007295f60883218d8ba0181fc797976c1e0f04159a86e41df153852".replace("00", "11")), reference, PUBS));
+    }
+
+    @Test
+    public void rejectsTheReferenceSignatureAgainstADifferentRing() {
+        Lsag.Signature reference = new Lsag.Signature(REF_Y0, REF_S, REF_C);
+        List<String> otherRing = new ArrayList<>(PUBS);
+        otherRing.set(0, PUBS.get(1));
+
+        assertFalse(Lsag.verify(message(), reference, otherRing));
+    }
+
+    @Test
+    public void rejectsATamperedScalar() {
+        List<String> tampered = new ArrayList<>(REF_S);
+        tampered.set(0, "0x01");
+
+        assertFalse(Lsag.verify(message(), new Lsag.Signature(REF_Y0, tampered, REF_C), PUBS));
+    }
+
+    @Test
+    public void hashToPointMatchesTheReferenceImplementation() {
+        ECPoint point = Lsag.hashToPoint(bytes("02d53c88a0a81f9c3a80638fa81e477625d49aca04568139072c87a36e47ecb96a"));
+
+        assertEquals("02c796716162e413d0f726f82f714cc2230bd9f1b6cce8e76320ed574fb1cd0aca", hex(point.getEncoded(true)));
+    }
+
+    /** A digest whose first candidate is off the curve, so the nonce loop has to advance. */
+    @Test
+    public void hashToPointMatchesTheReferenceWhenNoncesAreNeeded() {
+        ECPoint point = Lsag.hashToPoint(bytes("0000000000000000000000000000000000000000000000000000000000000000"));
+
+        assertEquals("026db65fd59fd356f6729140571b5bcd6bb3b83492a16e1bf0a3884442fc3c8a0e", hex(point.getEncoded(true)));
+    }
+
+    @Test
+    public void hashPointsOverTheRingMatchesTheReferenceImplementation() {
+        List<Object> items = new ArrayList<>();
+        for(String pub : PUBS) {
+            items.add(bytes(pub));
+        }
+
+        assertEquals(Lsag.parseScalar("0xa476e03164ee1225d69c2c39b31a3c2abafcdbccab25111be106f1cd4e661941"), Lsag.hashPoints(items));
+    }
+
+    /**
+     * The mixed case matters most: the reference feeds the ring digest in as an integer, which it
+     * hashes as its decimal digits, and the key image as a hex string, which it hashes as bytes.
+     */
+    @Test
+    public void hashPointsOverMixedTypesMatchesTheReferenceImplementation() {
+        List<Object> items = new ArrayList<>();
+        List<Object> ring = new ArrayList<>();
+        for(String pub : PUBS) {
+            ring.add(bytes(pub));
+        }
+        items.add(Lsag.hashPoints(ring));
+        items.add(REF_Y0);
+        items.add(message());
+        items.add(bytes(PUBS.get(1)));
+
+        assertEquals(Lsag.parseScalar("0xef29075acae8a11cd93c9243d29efd8653a95c6ca4e54d2b81bd49ac7f41ad45"), Lsag.hashPoints(items));
+    }
+
+    @Test
+    public void aSignatureMadeHereVerifiesHere() {
+        Lsag.Signature signature = Lsag.sign(message(), PUBS, PRIVS.get(SIGNER), SIGNER);
+
+        assertTrue(Lsag.verify(message(), signature, PUBS));
+        assertEquals(PUBS.size(), signature.getS().size());
+        assertEquals(PUBS.size(), signature.getC().size());
+    }
+
+    /** Two signatures by one key share a key image, which is what stops a double registration. */
+    @Test
+    public void twoSignaturesByOneKeyShareAKeyImage() {
+        Lsag.Signature first = Lsag.sign(message(), PUBS, PRIVS.get(SIGNER), SIGNER);
+        Lsag.Signature second = Lsag.sign(bytes("8dbe01bf6007295f60883218d8ba0181fc797976c1e0f04159a86e41df153852"), PUBS, PRIVS.get(SIGNER), SIGNER);
+
+        assertEquals(first.keyImage(), second.keyImage());
+        assertEquals(REF_Y0, first.keyImage());
+    }
+
+    @Test
+    public void differentKeysGiveDifferentKeyImages() {
+        Lsag.Signature first = Lsag.sign(message(), PUBS, PRIVS.get(0), 0);
+        Lsag.Signature second = Lsag.sign(message(), PUBS, PRIVS.get(1), 1);
+
+        assertNotEquals(first.keyImage(), second.keyImage());
+    }
+
+    /** Signing as a member you do not hold the key for must not produce a valid signature. */
+    @Test
+    public void signingAsTheWrongRingMemberDoesNotVerify() {
+        Lsag.Signature signature = Lsag.sign(message(), PUBS, PRIVS.get(0), 1);
+
+        assertFalse(Lsag.verify(message(), signature, PUBS));
+    }
+
+    @Test
+    public void onlyTheCanonicalKeyImageSpellingIsAccepted() {
+        assertEquals(REF_Y0, Lsag.canonicalKeyImage(REF_Y0));
+        assertEquals(REF_Y0, Lsag.canonicalKeyImage(REF_Y0.toUpperCase()));
+        assertNull(Lsag.canonicalKeyImage("not hex"));
+        assertNull(Lsag.canonicalKeyImage(""));
+
+        // an uppercase image decodes to the same point, so accepting it would let one signer
+        // present unlimited distinct looking images for a single key
+        assertFalse(Lsag.verify(message(),
+                new Lsag.Signature(REF_Y0.toUpperCase(), REF_S, REF_C), PUBS));
+    }
+
+    @Test
+    public void scalarsUseTheReferenceWireEncoding() {
+        // python's hex(): lowercase, "0x" prefixed, no leading zeros
+        assertEquals("0x0", Lsag.toWireScalar(BigInteger.ZERO));
+        assertEquals("0xff", Lsag.toWireScalar(BigInteger.valueOf(255)));
+        assertEquals(BigInteger.valueOf(255), Lsag.parseScalar("0xff"));
+        assertEquals(BigInteger.valueOf(255), Lsag.parseScalar("ff"));
+
+        for(String scalar : REF_S) {
+            assertTrue(scalar.startsWith("0x"), scalar);
+            assertEquals(scalar, Lsag.toWireScalar(Lsag.parseScalar(scalar)));
+        }
+    }
+
+    @Test
+    public void aMalformedSignatureIsRejectedRatherThanThrowing() {
+        assertFalse(Lsag.verify(message(), null, PUBS));
+        assertFalse(Lsag.verify(message(), new Lsag.Signature(REF_Y0, List.of("0x1"), REF_C), PUBS));
+        assertFalse(Lsag.verify(message(), new Lsag.Signature("00", REF_S, REF_C), PUBS));
+        assertFalse(Lsag.verify(message(), new Lsag.Signature(REF_Y0, REF_S, REF_C), List.of()));
+    }
+}


### PR DESCRIPTION
Part of #65. This is the cryptography only; the phase 3 and 4 protocol flow follows in a second PR.

The plugin gained ring signature DoS recovery in its v0.3.0. When a pool loses a peer during input registration, the peers that did register re-register their outputs under a signature proving membership of the ring of Phase 2 keys, without revealing which member they are. The key image links two signatures by one key, so nobody can claim two outputs. Without it, any peer griefs a pool for free by registering an output and never an input, and plugin peers recover through phase 3 while this client sits until the pool expires.

This ports `plugin/lrs.py`.

A ring signature is worthless unless both clients compute it identically, so the port had to be checked against the reference rather than against itself. That check is the substance of this PR, and it is worth reviewing separately from the protocol plumbing that will use it.

## Changes

`lsag: port the linkable ring signature used by coinjoin recovery`

New `Lsag`, using the secp256k1 parameters drongo already exposes through `ECKey.CURVE`. Sign, verify, `hashToPoint`, `hashPoints`, and `canonicalKeyImage`.

Three details decide whether the two implementations agree, and all three are pinned by tests:

- `hashPoints` feeds each item in the way the reference does, which is not uniform: a point as its compressed encoding, a scalar as its **decimal digits**, a string as its bytes when it decodes as hex and as utf8 when it does not. The challenge hash mixes an integer ring digest with a hex key image, so getting either wrong silently breaks interop.
- Scalars go on the wire as python's `hex()` writes them: `"0x"` prefixed, lowercase, no leading zeros. `toWireScalar` reproduces that and `parseScalar` accepts both spellings.
- Only the canonical lowercase compressed key image is accepted. Hex decoding ignores case, so one image has many spellings that all verify; linking is done by comparing the image, so accepting variants would let one signer present unlimited distinct looking images for a single key. The reference added this same check.

`test: cover lsag against reference implementation vectors`

Fifteen cases. The vectors were produced by running the reference `lrs.py` itself, with its random source pinned so the signature is reproducible.

- A signature made by the reference implementation verifies here. This is the one that matters.
- That same signature is rejected against a different message, a different ring, and a tampered scalar.
- `hashToPoint` matches the reference for a normal input and for one where the first candidate is off the curve, so the nonce loop has to advance.
- `hashPoints` matches over the ring, and over the mixed integer, hex string, bytes case used by the challenge.
- Sign then verify agrees locally; two signatures by one key share a key image; different keys give different images; signing as a ring member whose key you do not hold does not verify.
- Only the canonical key image spelling is accepted, including that an uppercase image is refused even though it decodes to the same point.
- Malformed input is rejected rather than throwing.

## Verification

`./gradlew :test` green, 179 tests, `LsagTest` 15 of them.

I also checked the other direction, which CI cannot: a signature produced by this Java code is accepted by the reference `lrs.py` under `coincurve`. Ring size 3, verified true. That check needs Python with `coincurve`, so it is not in the suite; the committed vectors cover the direction that can be automated.
