### PR TITLE
recovery: add the ring, the reregister message and the recovery fee

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinMath.java
@@ -88,6 +88,28 @@ public final class CoinjoinMath {
                 .stripTrailingZeros().toPlainString();
     }
 
+    /**
+     * The per output fee for the recovery transaction.
+     *
+     * Recovery signs a fresh transaction with every input and output known up front, so the size
+     * is estimated properly rather than at a flat rate per peer: 100 vB per output, 68 vB per
+     * input and 100 vB of overhead. This mirrors the reference implementation, which uses the
+     * same figures, so both clients arrive at the same output amount.
+     */
+    public static long recoveryFeePerOutput(double feeRate, int outputCount, int inputCount) {
+        if (outputCount <= 0) {
+            return 0;
+        }
+        long estimatedVsize = 100L * outputCount + 68L * inputCount + 100L;
+        long estimatedFee = (long) (feeRate * estimatedVsize);
+        return estimatedFee / outputCount;
+    }
+
+    public static long recoveryOutputAmount(long poolAmountSats, double feeRate, int outputCount,
+            int inputCount) {
+        return poolAmountSats - recoveryFeePerOutput(feeRate, outputCount, inputCount);
+    }
+
     /** An output reduced to the two fields coinjoin validation cares about. */
     public record OutputView(String address, long value) {
     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/Reregister.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/Reregister.java
@@ -1,0 +1,111 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import com.sparrowwallet.drongo.address.Address;
+
+import org.bouncycastle.util.encoders.Base64;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The phase 3 re-registration message.
+ *
+ * When a pool loses a peer during input registration, the peers that did register claim an output
+ * again, this time proving ring membership rather than naming themselves. The pool keeps one
+ * output per key image, so a peer cannot claim two.
+ */
+public final class Reregister {
+
+    private static final Gson GSON = new Gson();
+
+    private Reregister() {
+    }
+
+    /** The message a re-registration signs: the claimed address bound to this pool. */
+    public static byte[] message(String address, String poolId) {
+        try {
+            return MessageDigest.getInstance("SHA-256")
+                    .digest((address + poolId).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    /** Build the payload published to the pool. */
+    public static String build(String address, String poolId, Lsag.Signature signature) {
+        JsonObject sig = new JsonObject();
+        sig.addProperty("Y0", signature.getY0());
+        sig.add("S", GSON.toJsonTree(signature.getS()));
+        sig.add("C", GSON.toJsonTree(signature.getC()));
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("version", JoinstrMessage.VERSION);
+        payload.addProperty("type", "reregister");
+        payload.addProperty("address", address);
+        payload.addProperty("sig", Base64.toBase64String(GSON.toJson(sig).getBytes(StandardCharsets.UTF_8)));
+        payload.addProperty("key_image", signature.getY0());
+        payload.addProperty("pool_id", poolId);
+
+        return GSON.toJson(payload);
+    }
+
+    /** An accepted re-registration: the address claimed, and the key image that claimed it. */
+    public record Accepted(String address, String keyImage) {
+    }
+
+    /**
+     * Check one re-registration, returning what to accept or null to skip.
+     *
+     * The key image compared is the one inside the verified signature, never the {@code key_image}
+     * field beside it. That field is the sender's claim; the signature's own Y0 is bound to the
+     * signing key, so dedup has to use it or one ring member varies the field and claims an output
+     * for every peer.
+     */
+    public static Accepted validate(String decrypted, String poolId, List<String> ringPubKeys,
+            Collection<String> claimedAddresses, Collection<String> seenKeyImages) {
+        try {
+            JsonObject payload = GSON.fromJson(decrypted, JsonObject.class);
+            if (payload == null || !payload.has("type")
+                    || !"reregister".equals(payload.get("type").getAsString())) {
+                return null;
+            }
+
+            String address = payload.get("address").getAsString();
+            try {
+                Address.fromString(address);
+            } catch (Exception e) {
+                return null;
+            }
+
+            JsonObject sig = GSON.fromJson(
+                    new String(Base64.decode(payload.get("sig").getAsString()), StandardCharsets.UTF_8),
+                    JsonObject.class);
+
+            List<String> s = new ArrayList<>();
+            sig.getAsJsonArray("S").forEach(element -> s.add(element.getAsString()));
+            List<String> c = new ArrayList<>();
+            sig.getAsJsonArray("C").forEach(element -> c.add(element.getAsString()));
+
+            Lsag.Signature signature = new Lsag.Signature(sig.get("Y0").getAsString(), s, c);
+
+            if (!Lsag.verify(message(address, poolId), signature, ringPubKeys)) {
+                return null;
+            }
+
+            String keyImage = signature.getY0();
+            if (seenKeyImages.contains(keyImage) || claimedAddresses.contains(address)) {
+                return null;
+            }
+
+            return new Accepted(address, keyImage);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/RingInput.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/RingInput.java
@@ -1,0 +1,113 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.Utils;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.protocol.TransactionWitness;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The ring used by coinjoin recovery: the public keys behind the inputs registered in phase 2.
+ *
+ * Registration PSBTs carry no derivation paths, by design, so the key has to come from the
+ * witness. Taking it from there alone would let a peer name any key it likes, so it is bound to
+ * the input by checking the scriptPubKey is the hash of that key.
+ */
+public final class RingInput {
+
+    /** One ring member: the key that signed an input, and the input it signed. */
+    public record Member(String pubKeyHex, String prevout, String psbtBase64) {
+    }
+
+    private RingInput() {
+    }
+
+    /**
+     * The key and outpoint behind a registration PSBT, or null if it does not qualify.
+     * Only P2WPKH inputs are accepted, matching the reference implementation.
+     */
+    public static Member member(String psbtBase64) {
+        try {
+            PSBT psbt = new PSBT(org.bouncycastle.util.encoders.Base64.decode(psbtBase64), false);
+            if (psbt.getPsbtInputs().size() != 1) {
+                return null;
+            }
+
+            PSBTInput input = psbt.getPsbtInputs().get(0);
+            TransactionOutput witnessUtxo = input.getWitnessUtxo();
+            if (witnessUtxo == null) {
+                return null;
+            }
+
+            byte[] scriptPubKey = witnessUtxo.getScript().getProgram();
+            // P2WPKH scriptPubKey is OP_0 PUSH20 <hash160(pubkey)>
+            if (scriptPubKey == null || scriptPubKey.length != 22
+                    || scriptPubKey[0] != 0x00 || scriptPubKey[1] != 0x14) {
+                return null;
+            }
+
+            TransactionWitness witness = input.getFinalScriptWitness();
+            if (witness == null || witness.getPushes().isEmpty()) {
+                return null;
+            }
+
+            List<byte[]> pushes = witness.getPushes();
+            byte[] pubKey = pushes.get(pushes.size() - 1);
+            byte[] expected = Arrays.copyOfRange(scriptPubKey, 2, 22);
+            if (!Arrays.equals(Utils.sha256hash160(pubKey), expected)) {
+                return null;
+            }
+
+            String prevout = input.getInput().getOutpoint().getHash().toString() + ":"
+                    + input.getInput().getOutpoint().getIndex();
+
+            return new Member(Utils.bytesToHex(pubKey), prevout, psbtBase64);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * The ring for a set of phase 2 registrations, sorted so every peer builds the same one.
+     *
+     * A registration that does not qualify is dropped, and so is one that repeats a key or an
+     * outpoint already in the ring: without that a peer could inflate the ring, which weakens
+     * every other member's anonymity, or displace another member's input.
+     */
+    public static List<Member> ring(List<String> registrations) {
+        Map<String, Member> byKey = new LinkedHashMap<>();
+        Set<String> seenPrevouts = new HashSet<>();
+
+        for (String registration : registrations) {
+            Member member = member(registration);
+            if (member == null) {
+                continue;
+            }
+            if (byKey.containsKey(member.pubKeyHex()) || seenPrevouts.contains(member.prevout())) {
+                continue;
+            }
+            seenPrevouts.add(member.prevout());
+            byKey.put(member.pubKeyHex(), member);
+        }
+
+        List<Member> ring = new ArrayList<>(byKey.values());
+        ring.sort((a, b) -> a.pubKeyHex().compareTo(b.pubKeyHex()));
+        return ring;
+    }
+
+    public static List<String> pubKeys(List<Member> ring) {
+        List<String> pubKeys = new ArrayList<>(ring.size());
+        for (Member member : ring) {
+            pubKeys.add(member.pubKeyHex());
+        }
+        return pubKeys;
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/RecoveryCoreTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/RecoveryCoreTest.java
@@ -1,0 +1,288 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.protocol.TransactionWitness;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The pieces coinjoin recovery is built from: the ring taken from the phase 2 inputs, the
+ * re-registration message, and the fee the rebuilt transaction pays.
+ */
+public class RecoveryCoreTest {
+
+    private static final String POOL_ID = "0123456789abcdef";
+
+    private ECKey key(int seed) {
+        return ECKey.fromPrivate(BigInteger.valueOf(3000017L + seed));
+    }
+
+    private String address(int seed) {
+        return ScriptType.P2WPKH.getAddress(key(seed + 400)).toString();
+    }
+
+    /** A signed single input registration, as a peer would publish it in phase 2. */
+    private String registration(int keySeed, int outpointSeed, List<String> outputs) throws Exception {
+        ECKey signingKey = key(keySeed);
+
+        Transaction tx = new Transaction();
+        tx.setVersion(2);
+        tx.addInput(Sha256Hash.wrap(String.format("%064x", 0xfeed0000L + outpointSeed)),
+                outpointSeed, new Script(new byte[0]));
+        for(String output : outputs) {
+            tx.addOutput(99_900L, Address.fromString(output).getOutputScript());
+        }
+
+        PSBT psbt = new PSBT(tx);
+        PSBTInput input = psbt.getPsbtInputs().get(0);
+        input.setSigHash(SigHash.ANYONECANPAY_ALL);
+        input.setWitnessUtxo(new TransactionOutput(tx, 100_200L,
+                ScriptType.P2WPKH.getOutputScript(signingKey)));
+        assertTrue(input.sign(signingKey), "test setup: signing failed");
+
+        var entry = input.getPartialSignatures().entrySet().iterator().next();
+        input.setFinalScriptWitness(new TransactionWitness(tx, entry.getKey(), entry.getValue()));
+
+        return Base64.toBase64String(psbt.serialize());
+    }
+
+    private List<String> outputs(int count) {
+        List<String> addresses = new ArrayList<>();
+        for(int i = 0; i < count; i++) {
+            addresses.add(address(i));
+        }
+        return addresses;
+    }
+
+    // --- the ring ---
+
+    @Test
+    public void theRingIsTheKeysBehindTheRegisteredInputs() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> registrations = List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs));
+
+        List<RingInput.Member> ring = RingInput.ring(registrations);
+
+        assertEquals(3, ring.size());
+        for(RingInput.Member member : ring) {
+            assertEquals(66, member.pubKeyHex().length());
+        }
+    }
+
+    /** Every peer has to build the same ring, so it is sorted rather than left in arrival order. */
+    @Test
+    public void theRingIsSortedSoEveryPeerBuildsTheSameOne() throws Exception {
+        List<String> outs = outputs(3);
+        String a = registration(1, 1, outs);
+        String b = registration(2, 2, outs);
+        String c = registration(3, 3, outs);
+
+        List<String> first = RingInput.pubKeys(RingInput.ring(List.of(a, b, c)));
+        List<String> second = RingInput.pubKeys(RingInput.ring(List.of(c, a, b)));
+
+        assertEquals(first, second);
+        assertEquals(first.stream().sorted().toList(), first);
+    }
+
+    /** A repeated key would inflate the ring, weakening every other member's cover. */
+    @Test
+    public void aRepeatedKeyIsNotAddedTwice() throws Exception {
+        List<String> outs = outputs(3);
+        List<RingInput.Member> ring = RingInput.ring(List.of(
+                registration(1, 1, outs), registration(1, 2, outs), registration(2, 3, outs)));
+
+        assertEquals(2, ring.size());
+    }
+
+    @Test
+    public void aRepeatedOutpointIsNotAddedTwice() throws Exception {
+        List<String> outs = outputs(3);
+        List<RingInput.Member> ring = RingInput.ring(List.of(
+                registration(1, 7, outs), registration(2, 7, outs)));
+
+        assertEquals(1, ring.size());
+    }
+
+    /** The key comes from the witness, so it has to be bound to the input it claims. */
+    @Test
+    public void aKeyThatDoesNotMatchTheScriptPubKeyIsRejected() throws Exception {
+        List<String> outs = outputs(3);
+        PSBT psbt = new PSBT(Base64.decode(registration(1, 1, outs)), false);
+        PSBTInput input = psbt.getPsbtInputs().get(0);
+
+        // keep the signature but claim a different key owns the input
+        input.setWitnessUtxo(new TransactionOutput(psbt.getTransaction(), 100_200L,
+                ScriptType.P2WPKH.getOutputScript(key(99))));
+
+        assertNull(RingInput.member(Base64.toBase64String(psbt.serialize())));
+    }
+
+    @Test
+    public void anUnsignedOrMalformedRegistrationIsNotARingMember() {
+        assertNull(RingInput.member("not base64"));
+        assertNull(RingInput.member(""));
+    }
+
+    // --- re-registration ---
+
+    private String signedReregister(int keySeed, String address, List<String> ring) {
+        int index = ring.indexOf(com.sparrowwallet.drongo.Utils.bytesToHex(key(keySeed).getPubKey()));
+        assertTrue(index >= 0, "test setup: signer is not in the ring");
+        Lsag.Signature signature = Lsag.sign(Reregister.message(address, POOL_ID), ring,
+                String.format("%064x", BigInteger.valueOf(3000017L + keySeed)), index);
+        return Reregister.build(address, POOL_ID, signature);
+    }
+
+    @Test
+    public void aValidReregisterIsAccepted() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> ring = RingInput.pubKeys(RingInput.ring(List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs))));
+
+        String claimed = address(10);
+        Reregister.Accepted accepted = Reregister.validate(signedReregister(2, claimed, ring),
+                POOL_ID, ring, List.of(), Set.of());
+
+        assertNotNull(accepted);
+        assertEquals(claimed, accepted.address());
+    }
+
+    @Test
+    public void aReregisterSignedByANonMemberIsRejected() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> ring = RingInput.pubKeys(RingInput.ring(List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs))));
+
+        List<String> outsiderRing = new ArrayList<>(ring);
+        outsiderRing.set(0, com.sparrowwallet.drongo.Utils.bytesToHex(key(77).getPubKey()));
+        String claimed = address(11);
+        Lsag.Signature outsider = Lsag.sign(Reregister.message(claimed, POOL_ID), outsiderRing,
+                String.format("%064x", BigInteger.valueOf(3000017L + 77)), 0);
+
+        assertNull(Reregister.validate(Reregister.build(claimed, POOL_ID, outsider),
+                POOL_ID, ring, List.of(), Set.of()));
+    }
+
+    /** One key claims one output. The second attempt shares a key image and is refused. */
+    @Test
+    public void oneKeyCannotClaimTwoOutputs() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> ring = RingInput.pubKeys(RingInput.ring(List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs))));
+
+        Reregister.Accepted first = Reregister.validate(signedReregister(2, address(10), ring),
+                POOL_ID, ring, List.of(), Set.of());
+        assertNotNull(first);
+
+        Set<String> seen = new HashSet<>(Set.of(first.keyImage()));
+        assertNull(Reregister.validate(signedReregister(2, address(11), ring),
+                POOL_ID, ring, List.of(first.address()), seen));
+    }
+
+    /**
+     * Dedup must use the key image inside the verified signature, not the field beside it, or a
+     * member varies that field and claims an output for every peer.
+     */
+    @Test
+    public void theKeyImageFieldCannotBeUsedToClaimASecondOutput() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> ring = RingInput.pubKeys(RingInput.ring(List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs))));
+
+        Reregister.Accepted first = Reregister.validate(signedReregister(2, address(10), ring),
+                POOL_ID, ring, List.of(), Set.of());
+        assertNotNull(first);
+
+        // same signer, second address, with the advertised key_image field altered
+        JsonObject tampered = new Gson().fromJson(signedReregister(2, address(12), ring), JsonObject.class);
+        tampered.addProperty("key_image", "02" + "11".repeat(32));
+
+        assertNull(Reregister.validate(new Gson().toJson(tampered), POOL_ID, ring,
+                List.of(first.address()), new HashSet<>(Set.of(first.keyImage()))));
+    }
+
+    @Test
+    public void aReregisterForAnotherPoolIsRejected() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> ring = RingInput.pubKeys(RingInput.ring(List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs))));
+
+        assertNull(Reregister.validate(signedReregister(2, address(10), ring),
+                "a-different-pool", ring, List.of(), Set.of()));
+    }
+
+    @Test
+    public void aReregisterWithAnInvalidAddressIsRejected() throws Exception {
+        List<String> outs = outputs(3);
+        List<String> ring = RingInput.pubKeys(RingInput.ring(List.of(
+                registration(1, 1, outs), registration(2, 2, outs), registration(3, 3, outs))));
+
+        JsonObject payload = new Gson().fromJson(signedReregister(2, address(10), ring), JsonObject.class);
+        payload.addProperty("address", "not-an-address");
+
+        assertNull(Reregister.validate(new Gson().toJson(payload), POOL_ID, ring, List.of(), Set.of()));
+    }
+
+    @Test
+    public void otherMessageTypesAndGarbageAreIgnored() {
+        assertNull(Reregister.validate("{\"type\":\"output\",\"address\":\"bc1q\"}",
+                POOL_ID, List.of(), List.of(), Set.of()));
+        assertNull(Reregister.validate("not json", POOL_ID, List.of(), List.of(), Set.of()));
+        assertNull(Reregister.validate(null, POOL_ID, List.of(), List.of(), Set.of()));
+    }
+
+    // --- the rebuilt transaction's fee ---
+
+    /**
+     * Values computed from the reference implementation's own formula,
+     * int(fee_rate * (100 * outputs + 68 * inputs + 100)) // outputs.
+     */
+    @Test
+    public void theRecoveryFeeMatchesTheReferenceImplementation() {
+        assertEquals(201L, CoinjoinMath.recoveryFeePerOutput(1, 3, 3));
+        assertEquals(503L, CoinjoinMath.recoveryFeePerOutput(2.5, 3, 3));
+        assertEquals(965L, CoinjoinMath.recoveryFeePerOutput(5, 4, 4));
+        assertEquals(320L, CoinjoinMath.recoveryFeePerOutput(1, 2, 5));
+        assertEquals(2369L, CoinjoinMath.recoveryFeePerOutput(13, 7, 7));
+    }
+
+    @Test
+    public void theRecoveryOutputAmountMatchesTheReferenceImplementation() {
+        assertEquals(99_799L, CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3));
+        assertEquals(99_497L, CoinjoinMath.recoveryOutputAmount(100_000L, 2.5, 3, 3));
+        assertEquals(97_631L, CoinjoinMath.recoveryOutputAmount(100_000L, 13, 7, 7));
+    }
+
+    /** Recovery pays for a real transaction, so it costs more than the phase 2 estimate. */
+    @Test
+    public void theRecoveryFeeIsLargerThanThePhaseTwoEstimate() {
+        assertTrue(CoinjoinMath.recoveryFeePerOutput(1, 3, 3) > CoinjoinMath.feePerOutput(1, 3));
+    }
+
+    @Test
+    public void theRecoveryFeeHandlesNoOutputs() {
+        assertEquals(0L, CoinjoinMath.recoveryFeePerOutput(5, 0, 3));
+    }
+}


### PR DESCRIPTION
Part of #65, on top of #87. The remaining piece is the async flow that drives these; see the note at the end.

Phase 3 and 4 recovery has three parts that have to agree with the plugin exactly, and one part that is orchestration. This is the three.

## Changes

`recovery: add the ring, the reregister message and the recovery fee`

**`RingInput`** builds the ring from the phase 2 registrations. Registration PSBTs carry no derivation paths, deliberately, so the key has to come from the witness; taking it from there alone would let a peer name any key, so it is bound to the input by checking the scriptPubKey is `hash160` of that key. P2WPKH only, matching `_validated_ring_input` (`plugin/joinstr.py:1391-1420`). A registration repeating a key or an outpoint already in the ring is dropped: without that a peer inflates the ring, which weakens every other member's cover, or displaces another member's input. The ring is sorted so every peer builds the same one.

**`Reregister`** builds and checks the phase 3 message. It signs `SHA256(address + pool_id)` and carries the signature base64 encoded, matching the plugin's payload.

The dedup uses the key image **inside the verified signature**, never the `key_image` field beside it. That field is the sender's claim; Y0 is bound to the signing key. Using the field would let one ring member vary it and claim an output for every peer, which is the whole thing phase 3 exists to prevent.

**`CoinjoinMath.recoveryFeePerOutput`** is the fee for the rebuilt transaction. Recovery knows every input and output up front, so the plugin sizes it properly rather than at a flat rate per peer: `100 * outputs + 68 * inputs + 100`. Both clients have to use it or they compute different output amounts and reject each other's re-signed PSBTs.

`test: cover the coinjoin recovery core`

Seventeen cases building real signed registration PSBTs with drongo:

- the ring is the keys behind the registered inputs, sorted so two peers seeing them in different orders agree
- a repeated key and a repeated outpoint are each admitted only once
- a key that does not match its scriptPubKey is rejected, so a peer cannot claim an input it does not own
- a valid re-registration is accepted, one signed by a non-member is rejected, one for another pool is rejected, one with an invalid address is rejected
- one key cannot claim two outputs
- altering the `key_image` field does not buy a second output
- other message types, unparseable input and null are ignored
- the fee and output amount match values computed from the reference formula, at five fee rate and size combinations
- recovery costs more per output than the phase 2 estimate, and zero outputs does not divide by zero

## Verification

`./gradlew :test` green, 196 tests.

Removing the `hash160` binding and switching the dedup to the advertised `key_image` field fails exactly the two tests that cover them, so both are load bearing rather than decorative.

## What is left in #65

The async orchestration: entering phase 3 when input registration times out with some inputs collected, publishing and collecting for the 120 second windows the plugin uses, requiring every ring member to re-register before proceeding, then rebuilding the transaction with `SIGHASH_ALL`, collecting the re-signed PSBTs and broadcasting. That is a state machine on top of these pieces and it needs wallet signing and relay polling, so it is the part that cannot be unit tested the way this can. I would rather land it separately than bury it under crypto that is already verifiable.
