### PR TITLE
fix: do not rotate the tor circuit under a running coinjoin

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinActivity.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinActivity.java
@@ -1,0 +1,34 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracks whether a coinjoin is in flight.
+ *
+ * Pool discovery and a running coinjoin share one nostr client, and discovery takes a fresh Tor
+ * circuit by disconnecting it. Doing that while a coinjoin is waiting for peers tears down the
+ * subscription it depends on, so discovery stands aside until the coinjoin is finished.
+ */
+public final class CoinjoinActivity {
+
+    private static final AtomicInteger active = new AtomicInteger();
+
+    private CoinjoinActivity() {
+    }
+
+    public static void started() {
+        active.incrementAndGet();
+    }
+
+    public static void finished() {
+        active.updateAndGet(count -> count > 0 ? count - 1 : 0);
+    }
+
+    public static boolean isActive() {
+        return active.get() > 0;
+    }
+
+    static void resetForTesting() {
+        active.set(0);
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -63,6 +63,7 @@ public class CoinjoinHandler {
 
     private final Object stateLock = new Object();
     private final java.util.concurrent.atomic.AtomicBoolean finalizing = new java.util.concurrent.atomic.AtomicBoolean(false);
+    private final java.util.concurrent.atomic.AtomicBoolean holdingDiscovery = new java.util.concurrent.atomic.AtomicBoolean(false);
     private volatile boolean completed = false;
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -100,6 +101,9 @@ public class CoinjoinHandler {
 
         this.myOutputAddress = myOutputAddress;
 
+        if (holdingDiscovery.compareAndSet(false, true)) {
+            CoinjoinActivity.started();
+        }
         updateStatus("Output registered");
 
         scheduleTimeout();
@@ -812,6 +816,11 @@ public class CoinjoinHandler {
     }
 
     public void stopListening() {
+        // idempotent: a coinjoin that both completes and later times out must not release the
+        // hold twice, and one that never starts must not release a hold it never took
+        if (holdingDiscovery.compareAndSet(true, false)) {
+            CoinjoinActivity.finished();
+        }
         try {
             if (messageListener != null) {
                 messageListener.close();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -110,7 +110,15 @@ public class CoinjoinHandler {
 
         sendOutputToPool(myOutputAddress);
 
-        startListeningForMessages();
+        try {
+            startListeningForMessages();
+        } catch (Exception e) {
+            // without a subscription the coinjoin cannot progress, so end it here rather than
+            // leaving it holding off pool discovery for the rest of the session
+            logger.severe("Could not start listening for pool messages: " + e.getMessage());
+            updateStatus("Error: Check logs");
+            stopListening();
+        }
     }
 
     /**
@@ -812,6 +820,13 @@ public class CoinjoinHandler {
         } catch (Exception e) {
             logger.severe("Error broadcasting transaction: " + e.getMessage());
             updateStatus("Error: Check logs");
+        }
+    }
+
+    /** Take the discovery hold without needing a relay, for tests. */
+    void holdDiscoveryForTesting() {
+        if (holdingDiscovery.compareAndSet(false, true)) {
+            CoinjoinActivity.started();
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -134,6 +134,12 @@ public class OtherPoolsController extends JoinstrFormController {
     }
 
     private void fetchPools() {
+        if (CoinjoinActivity.isActive()) {
+            // discovery rotates the tor circuit, which disconnects the shared nostr client and
+            // would take the running coinjoin's subscription with it
+            logger.info("Skipping pool discovery while a coinjoin is in progress");
+            return;
+        }
 
         if (!isFetching.compareAndSet(false, true)) {
             return;

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinActivityTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/CoinjoinActivityTest.java
@@ -1,0 +1,138 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pool discovery and a running coinjoin share one nostr client, and discovery takes a fresh Tor
+ * circuit by disconnecting it. The refresh timer keeps firing every 30 seconds once the Other
+ * Pools tab has been opened, and is only cancelled when the whole joinstr window closes, so
+ * without this a coinjoin's subscription was torn down repeatedly while it waited for peers.
+ */
+public class CoinjoinActivityTest {
+
+    @BeforeEach
+    @AfterEach
+    public void reset() {
+        CoinjoinActivity.resetForTesting();
+    }
+
+    private CoinjoinHandler handler() {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", "1750000000");
+        return new CoinjoinHandler(null, pool, null, null, status -> {
+        });
+    }
+
+    @Test
+    public void nothingIsHeldWhenIdle() {
+        assertFalse(CoinjoinActivity.isActive());
+    }
+
+    @Test
+    public void aRunningCoinjoinHoldsOffDiscovery() {
+        CoinjoinActivity.started();
+
+        assertTrue(CoinjoinActivity.isActive());
+    }
+
+    @Test
+    public void discoveryResumesOnceTheCoinjoinFinishes() {
+        CoinjoinActivity.started();
+        CoinjoinActivity.finished();
+
+        assertFalse(CoinjoinActivity.isActive());
+    }
+
+    /** A stuck counter would disable discovery for the rest of the session. */
+    @Test
+    public void anExtraFinishCannotDriveTheCountNegative() {
+        CoinjoinActivity.finished();
+        CoinjoinActivity.finished();
+        CoinjoinActivity.started();
+
+        assertTrue(CoinjoinActivity.isActive());
+
+        CoinjoinActivity.finished();
+        assertFalse(CoinjoinActivity.isActive());
+    }
+
+    @Test
+    public void aSecondCoinjoinKeepsTheHoldUntilBothFinish() {
+        CoinjoinActivity.started();
+        CoinjoinActivity.started();
+        CoinjoinActivity.finished();
+
+        assertTrue(CoinjoinActivity.isActive());
+
+        CoinjoinActivity.finished();
+        assertFalse(CoinjoinActivity.isActive());
+    }
+
+    // --- the handler's own bookkeeping ---
+
+    /**
+     * With no relay reachable the subscription cannot start, and the coinjoin ends there. What
+     * matters is that it does not leave discovery held off for the rest of the session.
+     */
+    @Test
+    public void aCoinjoinThatCannotSubscribeDoesNotHoldDiscovery() {
+        CoinjoinHandler handler = handler();
+        assertFalse(CoinjoinActivity.isActive());
+
+        handler.startOutputPhase("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq");
+
+        assertFalse(CoinjoinActivity.isActive(),
+                "a coinjoin that failed to start left discovery blocked");
+    }
+
+    @Test
+    public void tearingDownReleasesTheHold() {
+        CoinjoinActivity.started();
+        assertTrue(CoinjoinActivity.isActive());
+
+        CoinjoinActivity.finished();
+
+        assertFalse(CoinjoinActivity.isActive());
+    }
+
+    /**
+     * A coinjoin that completes and is then hit by its own pool timeout tears down twice. The
+     * second must not release a hold taken by an unrelated coinjoin.
+     */
+    @Test
+    public void tearingDownTwiceReleasesTheHoldOnce() {
+        CoinjoinHandler handler = handler();
+        // stand in for a coinjoin that got as far as holding, without needing a relay
+        handler.holdDiscoveryForTesting();
+        CoinjoinActivity.started();
+
+        handler.stopListening();
+        handler.stopListening();
+        handler.stopListening();
+
+        assertTrue(CoinjoinActivity.isActive(), "another coinjoin's hold was released");
+        CoinjoinActivity.finished();
+        assertFalse(CoinjoinActivity.isActive());
+    }
+
+    /** A handler that never started must not release anything on teardown. */
+    @Test
+    public void tearingDownWithoutStartingReleasesNothing() {
+        CoinjoinActivity.started();
+
+        handler().stopListening();
+
+        assertTrue(CoinjoinActivity.isActive());
+    }
+
+    @Test
+    public void anInvalidOwnAddressDoesNotLeaveDiscoveryHeld() {
+        handler().startOutputPhase("not-an-address");
+
+        assertFalse(CoinjoinActivity.isActive(),
+                "a rejected address left discovery blocked for the session");
+    }
+}


### PR DESCRIPTION
Closes #67, as rescoped.

`OtherPoolsController` starts a 30 second refresh timer in `refreshView()` and only cancels it in `close()`, which runs when the whole joinstr window closes. Every tick calls `fetchPools`, which takes a fresh Tor circuit through `JoinstrTransport.newCircuit()` and so calls `Client.getInstance().disconnect()` on the shared nostr singleton, then disconnects again at the end.

An active coinjoin's subscription lives on that same singleton. Visit Other Pools, switch to My Pools, join a pool, and every 30 seconds something tears down the subscription the coinjoin depends on. For a pool that takes minutes to fill this happens repeatedly, and it is a plausible cause of joins that appear to hang for no reason.

## Changes

`fix: do not rotate the tor circuit under a running coinjoin`

- New `CoinjoinActivity`, a count of coinjoins in flight. `CoinjoinHandler` takes a hold when the output phase starts and releases it on teardown, guarded so the same handler cannot take or release twice.
- `fetchPools` stands aside while a hold is held.
- If the subscription cannot be started at all, the coinjoin now ends cleanly instead of letting the exception escape `startOutputPhase`. Previously that left the hold taken and the caller with a raw `RuntimeException`. A test caught this; it was not in the original plan.

The hold is bounded by the pool timeout in every case: the timeout task always runs `stopListening`, so even a coinjoin that dies in an unexpected way releases discovery when its pool expires rather than blocking it for the session.

`test: cover the discovery hold during a coinjoin`

Ten cases: idle holds nothing; a running coinjoin holds; finishing releases; an extra release cannot drive the count negative or free another coinjoin's hold; two coinjoins both have to finish; a coinjoin that cannot subscribe does not leave discovery held; tearing down three times releases once; tearing down without starting releases nothing; an invalid own address does not leave discovery blocked.

## Verification

`./gradlew :test` green, 206 tests.

**Coverage boundary, stated plainly:** these cover the mechanism and `CoinjoinHandler`'s bookkeeping, which is where the subtle failure modes are, in particular a stuck count silently disabling discovery for the rest of the session. They do **not** cover the single call site in `OtherPoolsController.fetchPools`; removing that one line guard leaves the suite green. That method needs JavaFX and a live relay to drive, so the guard itself is verified by reading rather than by test.
