### PR TITLE
fix: receive relay events directly instead of scraping log lines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ java {
 
 dependencies {
     //Any changes to the dependencies must be reflected in the module definitions below!
-    implementation('com.github.1440000bytes:nostr-java:v0.007.2-alpha') {
+    implementation('com.github.1440000bytes:nostr-java:v0.007.5-alpha') {
         exclude module: 'nostr-java-test'
     }
     implementation(project(':drongo'))

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
@@ -67,7 +67,7 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
         // Ensure Tor is running for Joinstr circuit isolation
         AppServices.get().startTor();
         // Route nostr-java WebSocket connections through Tor SOCKS proxy
-        applyTorSocksProxy();
+        awaitTor();
 
         joinstrMenu.selectedToggleProperty().addListener((observable, oldValue, selectedToggle) -> {
             if(selectedToggle == null) {
@@ -189,10 +189,12 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
     }
 
     /**
-     * Sets JVM-wide SOCKS proxy properties so nostr-java WebSocket connections
-     * are routed through Tor. Polls until Tor is ready (up to 90s).
+     * Wait for Tor before any joinstr traffic is possible, and say so if it never arrives.
+     *
+     * The proxy itself is applied per nostr connection by JoinstrTransport, so no JVM wide system
+     * property is set and the rest of Sparrow's traffic is unaffected.
      */
-    private void applyTorSocksProxy() {
+    private void awaitTor() {
         Thread t = new Thread(() -> {
             try {
                 int waited = 0;
@@ -201,11 +203,7 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
                     waited += 2;
                 }
                 if (AppServices.isTorRunning()) {
-                    HostAndPort proxy = AppServices.getTorProxy();
-                    System.setProperty("socksProxyHost", proxy.getHost());
-                    System.setProperty("socksProxyPort", String.valueOf(proxy.getPort()));
-                    log.info("[Joinstr] Nostr connections routed through Tor SOCKS proxy {}:{}",
-                            proxy.getHost(), proxy.getPort());
+                    log.info("[Joinstr] Tor is running, joinstr requests will use it");
                 } else {
                     log.warn("[Joinstr] Tor not ready after 90s, joinstr requests will be refused");
                     javafx.application.Platform.runLater(() -> AppServices.showErrorDialog(
@@ -216,7 +214,7 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
             }
         });
         t.setDaemon(true);
-        t.setName("TorProxyApplier");
+        t.setName("TorReadinessWatcher");
         t.start();
     }
 
@@ -228,10 +226,6 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
                 formController.close();
             }
             controllerCache.clear();
-
-            // Clear the JVM SOCKS proxy so normal Sparrow traffic is unaffected
-            System.clearProperty("socksProxyHost");
-            System.clearProperty("socksProxyPort");
 
             shutdownThreads();
             stage.close();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
@@ -6,6 +6,8 @@ import com.sparrowwallet.sparrow.net.TorUtils;
 
 import nostr.client.Client;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
 
@@ -33,6 +35,25 @@ public final class JoinstrTransport {
 
     public static boolean isReady() {
         return torRunning.getAsBoolean();
+    }
+
+    /**
+     * The proxy joinstr connections go through, or null when there is none.
+     *
+     * This is handed to each nostr connection rather than set as a JVM wide system property, so
+     * unrelated Sparrow traffic is unaffected.
+     */
+    public static Proxy proxy() {
+        if (!isReady()) {
+            return null;
+        }
+
+        HostAndPort torProxy = AppServices.getTorProxy();
+        if (torProxy == null) {
+            return null;
+        }
+
+        return new Proxy(Proxy.Type.SOCKS, new InetSocketAddress(torProxy.getHost(), torProxy.getPort()));
     }
 
     /** Why this request must not be sent, or null if it may be. */

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -1,140 +1,118 @@
 package com.sparrowwallet.sparrow.joinstr;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+
 import nostr.api.NIP04;
 import nostr.base.PublicKey;
 import nostr.client.Client;
 import nostr.context.impl.DefaultRequestContext;
+import nostr.event.BaseMessage;
 import nostr.event.BaseTag;
 import nostr.event.Kind;
 import nostr.event.impl.Filters;
 import nostr.event.impl.GenericEvent;
+import nostr.event.message.EventMessage;
 import nostr.event.message.ReqMessage;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
-import com.sparrowwallet.sparrow.AppServices;
-import com.sparrowwallet.sparrow.net.TorUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.logging.Handler;
 import java.util.function.BiConsumer;
+import java.util.logging.Logger;
 
+/**
+ * Receives the encrypted messages addressed to one key on a pool's relay.
+ *
+ * Events arrive through the nostr client's message listener. This used to work by attaching a
+ * handler to the library's own logger and parsing the log lines, which needed every message
+ * logged at INFO and broke on any change to the log format.
+ */
 public class NostrListener implements AutoCloseable {
+
     private static final Logger logger = Logger.getLogger(NostrListener.class.getName());
-    private static final Logger textLogger = Logger.getLogger("nostr.connection.impl.listeners.TextListener");
+
     private final Identity identity;
     private final String relay;
+    private final Map<String, Object> poolCredentials;
+
     private Client client;
     private BiConsumer<String, Long> messageHandler;
-    private final Map<String, Object> poolCredentials;
-    private static final ConsoleHandler consoleLogHandler = new ConsoleHandler();
-    private transient Handler eventMessageHandler = null;
 
     public NostrListener(Identity identity, String relay, Map<String, Object> poolCredentials) {
         this.identity = identity;
         this.relay = relay;
         this.poolCredentials = poolCredentials;
-        setupLogging();
-    }
-
-    private static void setupLogging() {
-        textLogger.setLevel(Level.INFO);
-        consoleLogHandler.setLevel(Level.INFO);
-        synchronized (textLogger) {
-            if (textLogger.getHandlers().length == 0)
-                textLogger.addHandler(consoleLogHandler);
-        }
     }
 
     public void startListening(BiConsumer<String, Long> messageHandler) {
         this.messageHandler = messageHandler;
-        setupEventHandler();
         connectAndSubscribe();
     }
 
-    private void setupEventHandler() {
-        eventMessageHandler = new Handler() {
-            @Override
-            public void publish(java.util.logging.LogRecord record) {
-                String message = record.getMessage();
-                if (message != null && message.contains("WebSocket received: [\"EVENT\"")) {
-                    handleEventMessage(message);
-                }
-            }
+    /** Called for every message the relay sends on this connection. */
+    private void onRelayMessage(BaseMessage message) {
+        if (!(message instanceof EventMessage eventMessage)) {
+            return;
+        }
 
-            @Override
-            public void flush() {
-            }
+        if (!(eventMessage.getEvent() instanceof GenericEvent event)) {
+            return;
+        }
 
-            @Override
-            public void close() {
-            }
-        };
-        textLogger.addHandler(eventMessageHandler);
-    }
+        if (event.getKind() == null || event.getKind() != Kind.ENCRYPTED_DIRECT_MESSAGE.getValue()) {
+            return;
+        }
 
-    private void handleEventMessage(String message) {
+        if (!isAddressedToUs(event)) {
+            return;
+        }
+
+        logger.fine("Received an encrypted DM addressed to this key");
+
+        String decryptedContent;
         try {
-            int startIndex = message.indexOf("{");
-            int endIndex = message.lastIndexOf("}") + 1;
-            String eventJson = message.substring(startIndex, endIndex);
+            decryptedContent = NIP04.decrypt(identity, event.getContent(), event.getPubKey());
+        } catch (Exception e) {
+            logger.fine("Could not decrypt a message addressed to this key");
+            return;
+        }
 
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode event = mapper.readTree(eventJson);
-
-            String encryptedContent = event.get("content").asText();
-            String senderPubkey = event.get("pubkey").asText();
-            long timestamp = event.get("created_at").asLong();
-
-            JsonNode tags = event.get("tags");
-            String recipientPubkey = null;
-            if (tags != null && tags.isArray()) {
-                for (JsonNode tag : tags) {
-                    if (tag.isArray() && !tag.isEmpty() && "p".equals(tag.get(0).asText())) {
-                        recipientPubkey = tag.get(1).asText();
-                        break;
-                    }
-                }
+        try {
+            if (poolCredentials != null && JoinstrMessage.isJoinRequest(decryptedContent)) {
+                handleJoinRequest(event.getPubKey());
             }
 
-            if (recipientPubkey == null || !recipientPubkey.equals(identity.getPublicKey().toString())) {
-                return;
-            }
-
-            logger.fine("Received an encrypted DM addressed to this key");
-
-            try {
-                String decryptedContent = NIP04.decrypt(
-                        identity,
-                        encryptedContent,
-                        new PublicKey(senderPubkey));
-
-                // matching the raw text depended on the sender's json whitespace, so a peer
-                // serialising compactly was never answered
-                if (poolCredentials != null && JoinstrMessage.isJoinRequest(decryptedContent)) {
-                    handleJoinRequest(senderPubkey);
-                }
-
-                if (messageHandler != null) {
-                    messageHandler.accept(decryptedContent, timestamp);
-                }
-
-                logger.info("Successfully decrypted message");
-            } catch (Exception e) {
-                logger.fine("Failed to decrypt message (may not be for us): " + e.getMessage());
+            if (messageHandler != null) {
+                long createdAt = event.getCreatedAt() == null
+                        ? java.time.Instant.now().getEpochSecond()
+                        : event.getCreatedAt();
+                messageHandler.accept(decryptedContent, createdAt);
             }
         } catch (Exception e) {
-            logger.severe("Error: " + e.getMessage());
+            logger.severe("Error handling a pool message: " + e.getMessage());
         }
     }
 
-    private void handleJoinRequest(String requesterPubkey) {
+    private boolean isAddressedToUs(GenericEvent event) {
+        if (event.getTags() == null) {
+            return false;
+        }
+
+        String ours = identity.getPublicKey().toString();
+        for (BaseTag tag : event.getTags()) {
+            if (tag instanceof PubKeyTag pubKeyTag && pubKeyTag.getPublicKey() != null
+                    && ours.equals(pubKeyTag.getPublicKey().toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void handleJoinRequest(PublicKey requester) {
         if (poolCredentials == null) {
             logger.warning("Received join request but poolCredentials is null - ignoring");
             return;
@@ -142,21 +120,17 @@ public class NostrListener implements AutoCloseable {
 
         try {
             if (!JoinstrTransport.newCircuit()) {
-                throw new IllegalStateException(JoinstrTransport.NOT_READY);
+                logger.warning("Not answering a join request: tor is not running");
+                return;
             }
 
-            // Send the payload as built. Re-picking keys here silently dropped any the caller
-            // had not supplied, and turned every value into a string.
             String credentialsJson = new Gson().toJson(poolCredentials);
 
             List<BaseTag> tags = new ArrayList<>();
-            tags.add(new PubKeyTag(new PublicKey(requesterPubkey)));
+            tags.add(new PubKeyTag(requester));
 
-            NIP04 nip04 = new NIP04(identity, new PublicKey(requesterPubkey));
-            String encryptedCredentials = nip04.encrypt(
-                    identity,
-                    credentialsJson,
-                    new PublicKey(requesterPubkey));
+            NIP04 nip04 = new NIP04(identity, requester);
+            String encryptedCredentials = nip04.encrypt(identity, credentialsJson, requester);
 
             GenericEvent credentialsEvent = new GenericEvent(
                     identity.getPublicKey(),
@@ -168,10 +142,9 @@ public class NostrListener implements AutoCloseable {
             nip04.sign();
             nip04.send(Map.of("default", relay));
 
-            logger.info("Sent pool credentials to: " + requesterPubkey);
+            logger.info("Sent pool credentials to a joiner");
         } catch (Exception e) {
-            logger.severe("Error: " + e.getMessage());
-            e.printStackTrace();
+            logger.severe("Failed to send pool credentials: " + e.getMessage());
         }
     }
 
@@ -182,35 +155,32 @@ public class NostrListener implements AutoCloseable {
             }
 
             client = Client.getInstance();
+
             DefaultRequestContext context = new DefaultRequestContext();
             context.setPrivateKey(identity.getPrivateKey().getRawData());
-            context.setRelays(Map.of("default", relay));
+            context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
+            context.setProxy(JoinstrTransport.proxy());
+            context.setMessageListener((message, source) -> onRelayMessage(message));
 
             Filters filters = Filters.builder()
                     .kinds(List.of(Kind.ENCRYPTED_DIRECT_MESSAGE))
                     .referencePubKeys(List.of(identity.getPublicKey()))
                     .build();
 
-            String subId = "joinstr-" + System.currentTimeMillis();
-            ReqMessage reqMessage = new ReqMessage(subId, filters);
+            ReqMessage reqMessage = new ReqMessage("joinstr-" + System.currentTimeMillis(), filters);
 
             client.connect(context);
             client.send(reqMessage);
 
-            logger.info("Started listening for encrypted messages on " + relay);
+            logger.info("Started listening for encrypted messages");
         } catch (Exception e) {
-            logger.severe("Error: " + e.getMessage());
+            logger.severe("Failed to start listener: " + e.getMessage());
             throw new RuntimeException("Failed to start listener", e);
         }
     }
 
     @Override
     public void close() throws TimeoutException {
-        if (eventMessageHandler != null) {
-            textLogger.removeHandler(eventMessageHandler);
-            eventMessageHandler = null;
-        }
-
         if (client != null) {
             client.disconnect();
             client = null;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -17,21 +17,22 @@ import nostr.client.Client;
 import nostr.context.impl.DefaultRequestContext;
 import nostr.event.Kind;
 import nostr.event.impl.Filters;
+import nostr.event.impl.GenericEvent;
+import nostr.event.message.EventMessage;
 import nostr.event.message.ReqMessage;
 import nostr.id.Identity;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.LinkedHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class OtherPoolsController extends JoinstrFormController {
 
     private static final int POOL_REFRESH_TIME = 30000;
     private static final Logger logger = Logger.getLogger(OtherPoolsController.class.getName());
-    private static final Logger textLogger = Logger.getLogger("nostr.connection.impl.listeners.TextListener");
 
     @FXML
     private VBox contentVBox;
@@ -46,7 +47,6 @@ public class OtherPoolsController extends JoinstrFormController {
 
     private ArrayList<JoinstrPool> myPools;
 
-    private java.util.logging.Handler currentEventHandler;
     private final AtomicBoolean isFetching = new AtomicBoolean(false);
 
     /**
@@ -133,6 +133,62 @@ public class OtherPoolsController extends JoinstrFormController {
         }, POOL_REFRESH_TIME, POOL_REFRESH_TIME); // Refresh every 30 seconds
     }
 
+    /**
+     * Build a pool from an announcement, or null if it is not one this client should list.
+     *
+     * The announcement must be signed by the pool key it advertises. Without that check anyone
+     * can announce a pool naming someone else's key, and a joiner sends its request to whoever
+     * that key belongs to.
+     */
+    static JoinstrPool parsePool(JsonNode poolData, String authorPubKey) {
+        if (poolData == null || !poolData.has("timeout")) {
+            return null;
+        }
+
+        long timeout = poolData.get("timeout").asLong();
+        if (timeout < Instant.now().getEpochSecond()) {
+            return null;
+        }
+
+        String relayUrl = extractRelay(poolData);
+        if (relayUrl == null || relayUrl.isEmpty()
+                || !networkMatches(poolData)
+                || !poolData.has("public_key")
+                || !poolData.has("denomination")
+                || !poolData.has("peers")) {
+            return null;
+        }
+
+        String poolKey = poolData.get("public_key").asText();
+        if (authorPubKey != null && !authorPubKey.equalsIgnoreCase(poolKey)) {
+            logger.warning("Ignoring a pool announcement that is not signed by the key it names");
+            return null;
+        }
+
+        JoinstrPool pool = new JoinstrPool(
+                relayUrl,
+                poolKey,
+                poolData.get("denomination").asText(),
+                poolData.get("peers").asText(),
+                String.valueOf(timeout));
+
+        if (poolData.has("fee_rate")) {
+            pool.setFeeRate(poolData.get("fee_rate").asText());
+        }
+
+        if (poolData.has("id")) {
+            pool.setPoolId(poolData.get("id").asText());
+        }
+
+        String unsupported = PoolSupport.unsupportedReason(poolData);
+        pool.setUnsupportedReason(unsupported);
+        if (unsupported != null) {
+            pool.setStatus("Unsupported");
+        }
+
+        return pool;
+    }
+
     private void fetchPools() {
         if (CoinjoinActivity.isActive()) {
             // discovery rotates the tor circuit, which disconnects the shared nostr client and
@@ -146,149 +202,83 @@ public class OtherPoolsController extends JoinstrFormController {
         }
 
         this.getJoinstrController().submitTask(() -> {
+            List<JoinstrPool> pools = new CopyOnWriteArrayList<>();
+            ObjectMapper mapper = new ObjectMapper();
+            Client client = Client.getInstance();
+
             try {
-                textLogger.setLevel(Level.INFO);
-
-                if (currentEventHandler != null) {
-                    textLogger.removeHandler(currentEventHandler);
+                if (!JoinstrTransport.newCircuit()) {
+                    Platform.runLater(() -> showError(JoinstrTransport.NOT_READY));
+                    return;
                 }
-
-                List<JoinstrPool> pools = new CopyOnWriteArrayList<>();
-                ObjectMapper mapper = new ObjectMapper();
-
-                currentEventHandler = new java.util.logging.Handler() {
-                    @Override
-                    public void publish(java.util.logging.LogRecord record) {
-                        String message = record.getMessage();
-                        if (message != null && message.contains("WebSocket received: [\"EVENT\"")) {
-                            try {
-                                int startIndex = message.indexOf("{");
-                                int endIndex = message.lastIndexOf("}") + 1;
-                                if (startIndex >= 0 && endIndex > startIndex) {
-                                    String eventJson = message.substring(startIndex, endIndex);
-                                    JsonNode event = mapper.readTree(eventJson);
-
-                                    if (event.has("content")) {
-                                        JsonNode poolData = mapper.readTree(event.get("content").asText());
-
-                                        if (poolData.has("timeout")) {
-                                            long timeout = poolData.get("timeout").asLong();
-                                            if (timeout < Instant.now().getEpochSecond()) {
-                                                return;
-                                            }
-
-                                            String relayUrl = extractRelay(poolData);
-                                            if (relayUrl == null || relayUrl.isEmpty()
-                                                    || !networkMatches(poolData)
-                                                    || !poolData.has("public_key")
-                                                    || !poolData.has("denomination")
-                                                    || !poolData.has("peers")) {
-                                                return;
-                                            }
-
-                                            JoinstrPool pool = new JoinstrPool(
-                                                    relayUrl,
-                                                    poolData.get("public_key").asText(),
-                                                    poolData.get("denomination").asText(),
-                                                    poolData.get("peers").asText(),
-                                                    String.valueOf(timeout));
-
-                                            if (poolData.has("fee_rate")) {
-                                                pool.setFeeRate(poolData.get("fee_rate").asText());
-                                            }
-
-                                            if (poolData.has("id")) {
-                                                pool.setPoolId(poolData.get("id").asText());
-                                            }
-
-                                            String unsupported = PoolSupport.unsupportedReason(poolData);
-                                            pool.setUnsupportedReason(unsupported);
-                                            if (unsupported != null) {
-                                                pool.setStatus("Unsupported");
-                                            }
-
-                                            if (pools.stream().noneMatch(
-                                                    (p) -> Objects.equals(p.getPubkey(), pool.getPubkey())) &&
-                                                    myPools.stream().noneMatch(
-                                                            (p) -> Objects.equals(p.getPubkey(), pool.getPubkey()))) {
-
-                                                pools.add(pool);
-                                                logger.info("Added pool: " + pool.getRelay() + " - "
-                                                        + pool.getDenomination());
-                                                Platform.runLater(() -> updateUIWithPools(new ArrayList<>(pools)));
-
-                                            }
-
-                                        }
-                                    }
-                                }
-                            } catch (Exception e) {
-                                logger.warning("Error processing pool event: " + e.getMessage());
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void flush() {
-                    }
-
-                    @Override
-                    public void close() {
-                    }
-                };
-
-                textLogger.addHandler(currentEventHandler);
 
                 Identity identity = Identity.generateRandomIdentity();
 
-                // Pools are dropped by their own timeout below, so do not also drop them by the
-                // age of the announcement. A pool open for longer than an hour was invisible.
+                DefaultRequestContext context = new DefaultRequestContext();
+                context.setPrivateKey(identity.getPrivateKey().getRawData());
+                context.setRelays(new LinkedHashMap<>(Map.of("default",
+                        JoinstrRelay.relayOrDefault(Config.get().getNostrRelay()))));
+                context.setProxy(JoinstrTransport.proxy());
+                context.setMessageListener((message, source) -> {
+                    if (!(message instanceof EventMessage eventMessage)
+                            || !(eventMessage.getEvent() instanceof GenericEvent event)) {
+                        return;
+                    }
+                    if (event.getKind() == null || event.getKind() != Kind.CONJOIN_POOL.getValue()) {
+                        return;
+                    }
+
+                    try {
+                        JsonNode poolData = mapper.readTree(event.getContent());
+                        String author = event.getPubKey() == null ? null : event.getPubKey().toString();
+                        JoinstrPool pool = parsePool(poolData, author);
+                        if (pool == null) {
+                            return;
+                        }
+
+                        if (pools.stream().noneMatch(p -> Objects.equals(p.getPubkey(), pool.getPubkey()))
+                                && myPools.stream().noneMatch(p -> Objects.equals(p.getPubkey(), pool.getPubkey()))) {
+                            pools.add(pool);
+                            logger.info("Added a discovered pool");
+                            Platform.runLater(() -> updateUIWithPools(new ArrayList<>(pools)));
+                        }
+                    } catch (Exception e) {
+                        logger.warning("Error processing pool event: " + e.getMessage());
+                    }
+                });
+
+                // Pools are dropped by their own timeout in parsePool, so do not also drop them
+                // by the age of the announcement. A pool open for longer than an hour was invisible.
                 Filters filters = Filters.builder()
                         .kinds(List.of(Kind.CONJOIN_POOL))
                         .build();
 
-                String subId = "pools-" + System.currentTimeMillis();
-                ReqMessage reqMessage = new ReqMessage(subId, filters);
+                ReqMessage reqMessage = new ReqMessage("pools-" + System.currentTimeMillis(), filters);
 
-                Client client = Client.getInstance();
-                DefaultRequestContext context = new DefaultRequestContext();
-                context.setPrivateKey(identity.getPrivateKey().getRawData());
-                context.setRelays(Map.of("default",
-                        JoinstrRelay.relayOrDefault(Config.get().getNostrRelay())));
+                client.connect(context);
+                client.send(reqMessage);
 
-                try {
-                    if (!JoinstrTransport.newCircuit()) {
-                        Platform.runLater(() -> showError(JoinstrTransport.NOT_READY));
-                        return;
-                    }
+                Thread.sleep(5000);
 
-                    client.connect(context);
-                    client.send(reqMessage);
+                Platform.runLater(() -> updateUIWithPools(new ArrayList<>(pools)));
 
-                    Thread.sleep(5000);
-
-                    textLogger.removeHandler(currentEventHandler);
-                    currentEventHandler = null;
-
-                    Platform.runLater(() -> updateUIWithPools(new ArrayList<>(pools)));
-
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    logger.warning("Sleep interrupted: " + e.getMessage());
-                } finally {
-                    if (!Thread.currentThread().isInterrupted())
-                        client.disconnect();
-                    isFetching.set(false);
-                }
-
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warning("Pool discovery interrupted");
             } catch (Exception e) {
                 logger.severe("Error fetching pools: " + e.getMessage());
-                e.printStackTrace();
                 Platform.runLater(() -> showError("Failed to fetch pools: " + e.getMessage()));
+            } finally {
+                try {
+                    if (!Thread.currentThread().isInterrupted()) {
+                        client.disconnect();
+                    }
+                } catch (Exception e) {
+                    logger.fine("Error disconnecting after discovery: " + e.getMessage());
+                }
                 isFetching.set(false);
             }
         });
-
     }
 
     private void updateUIWithPools(List<JoinstrPool> pools) {
@@ -319,11 +309,6 @@ public class OtherPoolsController extends JoinstrFormController {
 
     @Override
     public void close() throws Exception {
-        if (currentEventHandler != null) {
-            textLogger.removeHandler(currentEventHandler);
-            currentEventHandler = null;
-        }
-
         if (poolRefreshTimer != null) {
             poolRefreshTimer.cancel();
             poolRefreshTimer = null;

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolAnnouncementTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolAnnouncementTest.java
@@ -1,0 +1,114 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pool announcements now arrive as decoded events rather than being scraped out of log lines,
+ * which means the author of the event is known and can be checked against the key it advertises.
+ */
+public class PoolAnnouncementTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String POOL_KEY = "e37076afaf4a0054fd144f0b843c174173e7d0620a572572c0a34e6b78023afe";
+
+    private JsonNode announcement(String extra) throws Exception {
+        long timeout = Instant.now().getEpochSecond() + 3600;
+        return MAPPER.readTree("{"
+                + "\"id\":\"0123456789abcdef\","
+                + "\"public_key\":\"" + POOL_KEY + "\","
+                + "\"denomination\":0.001,"
+                + "\"peers\":3,"
+                + "\"timeout\":" + timeout + ","
+                + "\"relay\":\"wss://nos.lol\""
+                + extra + "}");
+    }
+
+    @Test
+    public void anAnnouncementSignedByItsPoolKeyIsListed() throws Exception {
+        JoinstrPool pool = OtherPoolsController.parsePool(announcement(""), POOL_KEY);
+
+        assertNotNull(pool);
+        assertEquals(POOL_KEY, pool.getPubkey());
+        assertEquals("0123456789abcdef", pool.getPoolId());
+        assertEquals("wss://nos.lol", pool.getRelay());
+        assertTrue(pool.isJoinable());
+    }
+
+    /**
+     * Without this anyone can announce a pool naming someone else's key, and a joiner then sends
+     * its request to whoever holds that key. The reference implementation drops these too.
+     */
+    @Test
+    public void anAnnouncementSignedByAnotherKeyIsIgnored() throws Exception {
+        String someoneElse = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+        assertNull(OtherPoolsController.parsePool(announcement(""), someoneElse));
+    }
+
+    @Test
+    public void theAuthorCheckIsCaseInsensitive() throws Exception {
+        assertNotNull(OtherPoolsController.parsePool(announcement(""), POOL_KEY.toUpperCase()));
+    }
+
+    @Test
+    public void anExpiredPoolIsNotListed() throws Exception {
+        JsonNode expired = MAPPER.readTree("{"
+                + "\"id\":\"abc\",\"public_key\":\"" + POOL_KEY + "\",\"denomination\":0.001,"
+                + "\"peers\":3,\"timeout\":" + (Instant.now().getEpochSecond() - 10) + ","
+                + "\"relay\":\"wss://nos.lol\"}");
+
+        assertNull(OtherPoolsController.parsePool(expired, POOL_KEY));
+    }
+
+    /** A pool open longer than an hour used to be filtered out by the announcement's age. */
+    @Test
+    public void aLongLivedPoolIsStillListed() throws Exception {
+        JsonNode longLived = MAPPER.readTree("{"
+                + "\"id\":\"abc\",\"public_key\":\"" + POOL_KEY + "\",\"denomination\":0.001,"
+                + "\"peers\":3,\"timeout\":" + (Instant.now().getEpochSecond() + 86400) + ","
+                + "\"relay\":\"wss://nos.lol\"}");
+
+        assertNotNull(OtherPoolsController.parsePool(longLived, POOL_KEY));
+    }
+
+    @Test
+    public void anAnnouncementMissingRequiredFieldsIsIgnored() throws Exception {
+        assertNull(OtherPoolsController.parsePool(MAPPER.readTree("{}"), POOL_KEY));
+        assertNull(OtherPoolsController.parsePool(null, POOL_KEY));
+        assertNull(OtherPoolsController.parsePool(MAPPER.readTree(
+                "{\"timeout\":" + (Instant.now().getEpochSecond() + 60) + "}"), POOL_KEY));
+    }
+
+    @Test
+    public void anUnsupportedPoolIsListedButNotJoinable() throws Exception {
+        JoinstrPool pool = OtherPoolsController.parsePool(
+                announcement(",\"transport\":\"vpn\""), POOL_KEY);
+
+        assertNotNull(pool, "an unsupported pool should still be listed with a reason");
+        assertFalse(pool.isJoinable());
+        assertEquals("Unsupported", pool.getStatus());
+        assertEquals(PoolSupport.REQUIRES_VPN, pool.getUnsupportedReason());
+    }
+
+    @Test
+    public void theFeeRateAndPoolIdAreCarriedThrough() throws Exception {
+        JoinstrPool pool = OtherPoolsController.parsePool(announcement(",\"fee_rate\":2.5"), POOL_KEY);
+
+        assertNotNull(pool);
+        assertEquals(2.5, pool.getParsedFeeRate());
+        assertEquals("0123456789abcdef", pool.getPoolId());
+    }
+
+    /** Announcements from before the author check are still parsed when no author is known. */
+    @Test
+    public void aMissingAuthorDoesNotRejectTheAnnouncement() throws Exception {
+        assertNotNull(OtherPoolsController.parsePool(announcement(""), null));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/TransportProxyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/TransportProxyTest.java
@@ -1,0 +1,36 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The Tor proxy is handed to each nostr connection rather than set as a JVM wide system property,
+ * so it no longer diverts the rest of Sparrow's traffic for as long as the joinstr window is open.
+ */
+public class TransportProxyTest {
+
+    @AfterEach
+    public void restoreRealTor() {
+        JoinstrTransport.setTorRunningForTesting(null);
+    }
+
+    @Test
+    public void thereIsNoProxyWhenTorIsDown() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        assertNull(JoinstrTransport.proxy());
+    }
+
+    @Test
+    public void askingForAProxyDoesNotTouchJvmWideProperties() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        JoinstrTransport.proxy();
+
+        assertNull(System.getProperty("socksProxyHost"),
+                "joinstr set a JVM wide proxy, which diverts unrelated Sparrow traffic");
+        assertNull(System.getProperty("socksProxyPort"));
+    }
+}


### PR DESCRIPTION
Closes #68. Closes #62.

Depends on the nostr-java change in 1440000bytes/nostr-java#1, released as `v0.007.5-alpha`.

Relay events were received by attaching a `java.util.logging.Handler` to the nostr library's internal `TextListener` logger, matching the literal string `WebSocket received: ["EVENT"` and slicing the JSON out between the first `{` and the last `}`. That broke on any change to the library's log format, forced INFO level logging of every relay message just to function, and raced when two handlers were attached to the same static logger.

Separately, the Tor proxy was applied by setting `socksProxyHost` and `socksProxyPort` as **JVM wide** system properties, so all of Sparrow's other traffic went through the joinstr Tor proxy for as long as the joinstr window was open.

## The library change

`nostr-java` now lets an application receive decoded messages and set a proxy per connection. Both are opt in and unset by default. See 1440000bytes/nostr-java#1.

That fork also had to move its compiler target from 22 to 17 so JitPack can build it again; its default JDK no longer supports 22 and the build was failing with `invalid target release: 22`. The library compiles unchanged at 17 and target 17 bytecode runs fine on Sparrow's Java 22. **Worth a look during review**, since it is a change to the library's own config rather than to Sparrow.

## Changes

`fix: receive relay events directly instead of scraping log lines`

- Dependency moves to `v0.007.5-alpha`.
- `NostrListener` sets a message listener on its request context and handles decoded `EventMessage`s: kind, recipient tag, decryption and dispatch, all from real objects. No logger handler, no string matching, no INFO logging requirement.
- `OtherPoolsController` does the same for pool discovery, and the parsing moves into a static `parsePool` that can be tested.
- **The pool announcement author is now checked against the key it advertises.** The scraper never did this. Without it anyone can announce a pool naming someone else's pool key, and a joiner then sends its join request to whoever holds that key. This is the same check the reference implementation applies (`plugin/joinstr.py:1093-1098`), and the same one #49 added to the publishing side; discovery was the other half and was missing.
- `JoinstrTransport.proxy()` returns a `Proxy` for the connection to use. `JoinstrController` no longer sets or clears any system property; it only waits for Tor and reports if it never arrives.

`test: cover announcement parsing and the per connection proxy`

Eleven cases: an announcement signed by its own pool key is listed; one signed by a different key is ignored; the check is case insensitive; expired pools are dropped while a pool open for a day is still listed; missing fields are ignored; an unsupported pool is listed but not joinable; fee rate and pool id carry through; a missing author does not reject. Plus: no proxy when Tor is down, and asking for one does not touch JVM wide properties.

## Verification

`./gradlew :test` green, 217 tests.

Removing the author check fails `anAnnouncementSignedByAnotherKeyIsIgnored`.

`grep` for `WebSocket received`, `TextListener` and `socksProxy` across the joinstr package returns nothing.

## Coverage boundary

The listener wiring itself, that a decoded `EventMessage` reaches `handleDecryptedMessage`, is not covered by a test: it needs a live relay. What is covered is everything that decides what to do with a message once it arrives. The wiring is verified by the code compiling against the new library API and by the parsing tests.
