### PR TITLE
fix: forget a pool's private key once the pool is finished

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -139,6 +139,43 @@ public class JoinstrPool {
         }
     }
 
+    /**
+     * Forget this pool's private key.
+     *
+     * The key is what reads the pool's encrypted channel and what answers its join requests. Once
+     * a pool is finished or expired it has no further use, so keeping it only widens the window
+     * in which it can leak.
+     */
+    public void clearPrivateKey() {
+        this.privateKey = "";
+    }
+
+    /** Whether this pool can still be worked on, and so still needs its key. */
+    public boolean isFinished() {
+        if ("Complete".equalsIgnoreCase(getStatus())) {
+            return true;
+        }
+
+        try {
+            return Long.parseLong(getTimeout().trim()) < java.time.Instant.now().getEpochSecond();
+        } catch (Exception e) {
+            // a pool with an unreadable timeout is left alone rather than silently disarmed
+            return false;
+        }
+    }
+
+    /** Drop the keys of pools that are finished. Returns how many were dropped. */
+    public static int purgeFinishedKeys(Collection<JoinstrPool> pools) {
+        int purged = 0;
+        for (JoinstrPool pool : pools) {
+            if (pool.isFinished() && pool.getPrivateKey() != null && !pool.getPrivateKey().isEmpty()) {
+                pool.clearPrivateKey();
+                purged++;
+            }
+        }
+        return purged;
+    }
+
     public void setPrivateKey(String privateKey) {
         this.privateKey = privateKey;
     }
@@ -303,6 +340,11 @@ public class JoinstrPool {
 
         Gson gson = new Gson();
         ArrayList<JoinstrPool> poolStore = Config.get().getPoolStore();
+
+        int purged = purgeFinishedKeys(poolStore);
+        if (purged > 0) {
+            logger.info("Dropped the keys of " + purged + " finished pool(s)");
+        }
         JoinstrPool[] pools = poolStore.toArray(new JoinstrPool[0]);
         String poolsJson = gson.toJson(new JoinstrPoolStoreWrapper(pools));
         // This file holds the private key of every pool, so it must not be world readable.

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolKeyLifetimeTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolKeyLifetimeTest.java
@@ -1,0 +1,99 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A pool's private key reads its encrypted channel and answers its join requests. Once the pool
+ * is finished the key has no further use, and keeping it only widens the window in which it can
+ * leak from the pool store.
+ */
+public class PoolKeyLifetimeTest {
+
+    private JoinstrPool pool(String timeout, String status) {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", "pk", "0.001", "3", timeout,
+                "aabbccddeeff", status);
+        return pool;
+    }
+
+    private String future() {
+        return String.valueOf(Instant.now().getEpochSecond() + 3600);
+    }
+
+    private String past() {
+        return String.valueOf(Instant.now().getEpochSecond() - 60);
+    }
+
+    @Test
+    public void aRunningPoolKeepsItsKey() {
+        JoinstrPool running = pool(future(), "Input registration");
+
+        assertFalse(running.isFinished());
+        assertEquals(0, JoinstrPool.purgeFinishedKeys(List.of(running)));
+        assertEquals("aabbccddeeff", running.getPrivateKey());
+    }
+
+    @Test
+    public void aCompletedPoolLosesItsKey() {
+        JoinstrPool complete = pool(future(), "Complete");
+
+        assertTrue(complete.isFinished());
+        assertEquals(1, JoinstrPool.purgeFinishedKeys(List.of(complete)));
+        assertEquals("", complete.getPrivateKey());
+    }
+
+    @Test
+    public void anExpiredPoolLosesItsKey() {
+        JoinstrPool expired = pool(past(), "Waiting for credentials");
+
+        assertTrue(expired.isFinished());
+        assertEquals(1, JoinstrPool.purgeFinishedKeys(List.of(expired)));
+        assertEquals("", expired.getPrivateKey());
+    }
+
+    /** Disarming a pool because its timeout could not be read would break a live coinjoin. */
+    @Test
+    public void aPoolWithAnUnreadableTimeoutKeepsItsKey() {
+        JoinstrPool odd = pool("not a timestamp", "Input registration");
+
+        assertFalse(odd.isFinished());
+        assertEquals(0, JoinstrPool.purgeFinishedKeys(List.of(odd)));
+        assertEquals("aabbccddeeff", odd.getPrivateKey());
+    }
+
+    @Test
+    public void purgingIsIdempotentAndCountsOnlyWhatItDropped() {
+        JoinstrPool complete = pool(future(), "Complete");
+
+        assertEquals(1, JoinstrPool.purgeFinishedKeys(List.of(complete)));
+        assertEquals(0, JoinstrPool.purgeFinishedKeys(List.of(complete)));
+    }
+
+    @Test
+    public void onlyTheFinishedPoolsInAStoreArePurged() {
+        JoinstrPool running = pool(future(), "Input registration");
+        JoinstrPool complete = pool(future(), "Complete");
+        JoinstrPool expired = pool(past(), "");
+
+        assertEquals(2, JoinstrPool.purgeFinishedKeys(List.of(running, complete, expired)));
+        assertEquals("aabbccddeeff", running.getPrivateKey());
+        assertEquals("", complete.getPrivateKey());
+        assertEquals("", expired.getPrivateKey());
+    }
+
+    /** Dropping the key must not remove the pool or its history from the list. */
+    @Test
+    public void purgingKeepsThePoolItself() {
+        JoinstrPool complete = pool(future(), "Complete");
+
+        JoinstrPool.purgeFinishedKeys(List.of(complete));
+
+        assertEquals("pk", complete.getPubkey());
+        assertEquals("0.001", complete.getDenomination());
+        assertEquals("Complete", complete.getStatus());
+    }
+}


### PR DESCRIPTION
Part of #34. Does the logging half and shortens the key's life; the encryption itself needs a decision from you, see below.

#34 asks for two things: stop logging private keys in plain text, and store them encrypted.

`grep` across the joinstr package for a logger call touching a private key returns nothing. The `logger.info("Public key: ...")` line went in #69 and the remaining identifier logging went in #75. Nothing prints a private key today, and `LogLinkageTest` fails the build if a logger call starts interpolating identifiers again.

## What this PR adds

`fix: forget a pool's private key once the pool is finished`

The pool key reads the pool's encrypted channel and answers its join requests. Once a pool is complete or its timeout has passed it has no further use, but it stayed in `pools.json` indefinitely. Most real exposure is that long tail: keys for pools that finished weeks ago sitting in a file, not the key of the coinjoin running right now.

`savePoolsFile` now drops the key of every finished pool before writing, so the store self cleans on each save. The pool itself stays, with its denomination, status and history intact.

A pool whose timeout cannot be parsed is left alone rather than being disarmed, since guessing wrong there would break a live coinjoin.

`test: cover the pool key lifetime`

Seven cases: a running pool keeps its key; a completed one and an expired one lose theirs; an unreadable timeout keeps its key; purging is idempotent and counts only what it dropped; a mixed store loses only the finished ones; and purging keeps the pool row itself.

## Verification

`./gradlew :test` green, 224 tests.
