### PR TITLE
recovery: run the ring signature phases when a pool loses a peer

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -2,7 +2,9 @@ package com.sparrowwallet.sparrow.joinstr;
 
 import com.google.gson.Gson;
 import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.Utils;
 import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.SigHash;
 import com.sparrowwallet.drongo.protocol.Transaction;
 import com.sparrowwallet.drongo.protocol.TransactionInput;
 import com.sparrowwallet.drongo.protocol.TransactionOutput;
@@ -55,6 +57,10 @@ public class CoinjoinHandler {
     private final Set<String> allInputs = Collections.synchronizedSet(new HashSet<>());
     private String myOutputAddress;
     private String myPsbtBase64;
+    private BlockTransactionHashIndex myUtxo;
+    private WalletNode myUtxoNode;
+    private final java.util.concurrent.atomic.AtomicBoolean recovering =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
 
     private Wallet wallet;
     private Storage storage;
@@ -137,11 +143,21 @@ public class CoinjoinHandler {
         }
 
         timeoutExecutor.schedule(() -> {
-            if (!completed) {
-                logger.warning("Coinjoin timed out before completion");
-                updateStatus("Timed out");
-                stopListening();
+            if (completed) {
+                return;
             }
+
+            if (canRecover()) {
+                // some peers registered an input and some did not, which is the case the
+                // ring signature recovery exists for
+                logger.warning("Coinjoin incomplete at timeout, starting recovery");
+                executorService.submit(this::runRecovery);
+                return;
+            }
+
+            logger.warning("Coinjoin timed out before completion");
+            updateStatus("Timed out");
+            stopListening();
         }, delaySeconds, java.util.concurrent.TimeUnit.SECONDS);
     }
 
@@ -210,6 +226,10 @@ public class CoinjoinHandler {
                 handleOutputReceived(message, createdAt);
             } else if ("input".equals(type)) {
                 handleInputReceived(message);
+            } else if ("reregister".equals(type)) {
+                handleReregisterReceived(decryptedMessage);
+            } else if ("resign".equals(type)) {
+                handleResignReceived(message);
             }
         } catch (Exception e) {
             logger.severe("Error handling message: " + e.getMessage());
@@ -255,6 +275,8 @@ public class CoinjoinHandler {
      * Start input phase - create and sign PSBT with selected UTXO.
      */
     public void startInputPhase(BlockTransactionHashIndex selectedUtxo, WalletNode utxoNode) {
+        this.myUtxo = selectedUtxo;
+        this.myUtxoNode = utxoNode;
         // The outpoint alongside the registered outputs is the input to output linkage this
         // coinjoin exists to break, so log shapes rather than values.
         logger.info("Starting input registration");
@@ -578,6 +600,265 @@ public class CoinjoinHandler {
         }
     }
 
+    /** How long each recovery phase waits for the other peers, in seconds. */
+    static final long RECOVERY_WINDOW_SECONDS = 120;
+
+    private final List<String> reregisteredOutputs = new CopyOnWriteArrayList<>();
+    private final Set<String> seenKeyImages = Collections.synchronizedSet(new HashSet<>());
+    private final List<String> resignPsbts = new CopyOnWriteArrayList<>();
+
+    /**
+     * Whether this pool can be recovered: some peers registered an input and some did not.
+     *
+     * With every input present there is nothing to recover, and with none there is no ring to
+     * sign against.
+     */
+    boolean canRecover() {
+        int registered = inputPSBTs.size();
+        return registered > 0 && registered < numPeers && myPsbtBase64 != null;
+    }
+
+    /**
+     * Recovery, phase 3.
+     *
+     * The peers that registered an input claim an output again, this time proving they are one of
+     * the ring of phase 2 keys rather than saying which. The pool keeps one output per key image,
+     * so a peer cannot take two, and the peer that never registered an input gets nothing.
+     */
+    private void runRecovery() {
+        if (!recovering.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            updateStatus("Recovering");
+
+            List<RingInput.Member> ring = RingInput.ring(new ArrayList<>(inputPSBTs));
+            List<String> ringPubKeys = RingInput.pubKeys(ring);
+            if (ringPubKeys.size() < 2) {
+                logger.severe("Not enough valid inputs to recover this coinjoin");
+                updateStatus("Timed out");
+                stopListening();
+                return;
+            }
+
+            String myPrivateKeyHex = myRingPrivateKey(ringPubKeys);
+            if (myPrivateKeyHex == null) {
+                logger.severe("Could not identify our own input among the ring");
+                updateStatus("Error: Check logs");
+                stopListening();
+                return;
+            }
+
+            String poolId = pool.getPoolId();
+            int myIndex = ringPubKeys.indexOf(Utils.bytesToHex(myKey(myUtxoNode).getPubKey()));
+            if (myIndex < 0) {
+                logger.severe("Our own key is not in the ring");
+                updateStatus("Error: Check logs");
+                stopListening();
+                return;
+            }
+
+            Lsag.Signature signature = Lsag.sign(
+                    Reregister.message(myOutputAddress, poolId), ringPubKeys, myPrivateKeyHex, myIndex);
+
+            reregisteredOutputs.add(myOutputAddress);
+            seenKeyImages.add(signature.getY0());
+
+            if (!publishToPool(Reregister.build(myOutputAddress, poolId, signature))) {
+                updateStatus("Error: Check logs");
+                stopListening();
+                return;
+            }
+
+            logger.info("Re-registered our output, waiting for the other ring members");
+
+            if (!awaitUntil(() -> reregisteredOutputs.size() >= ringPubKeys.size())) {
+                // the ring hides which input belongs to which output, so one missing peer cannot
+                // simply be dropped without unbalancing the transaction
+                logger.severe("Recovery incomplete: " + reregisteredOutputs.size() + "/"
+                        + ringPubKeys.size() + " outputs re-registered");
+                updateStatus("Timed out");
+                stopListening();
+                return;
+            }
+
+            runResign(ring);
+        } catch (Exception e) {
+            logger.severe("Recovery failed: " + e.getMessage());
+            updateStatus("Error: Check logs");
+            stopListening();
+        }
+    }
+
+    /**
+     * Recovery, phase 4.
+     *
+     * Every peer rebuilds the same transaction from the confirmed inputs and the re-registered
+     * outputs and signs it with SIGHASH_ALL, so nothing can be added to it afterwards.
+     */
+    private void runResign(List<RingInput.Member> ring) {
+        try {
+            List<String> outputs = new ArrayList<>(reregisteredOutputs);
+            Collections.sort(outputs);
+
+            long outputAmount = CoinjoinMath.recoveryOutputAmount(
+                    poolAmountSats, feeRate, outputs.size(), ring.size());
+
+            String rejection = RecoveryTransaction.rejectionReason(outputs, outputAmount, ring);
+            if (rejection != null) {
+                logger.severe("Refusing to re-sign: " + rejection);
+                updateStatus("Error: Check logs");
+                stopListening();
+                return;
+            }
+
+            PSBT psbt = RecoveryTransaction.build(outputs, outputAmount, ring);
+            signRecoveryInput(psbt);
+
+            String myResigned = Base64.toBase64String(psbt.serialize());
+            resignPsbts.add(myResigned);
+
+            JoinstrMessage message = JoinstrMessage.of("resign");
+            message.setPsbt(myResigned);
+            if (!publishToPool(message.toJson())) {
+                updateStatus("Error: Check logs");
+                stopListening();
+                return;
+            }
+
+            logger.info("Published our re-signed input, waiting for the other peers");
+
+            if (!awaitUntil(() -> resignPsbts.size() >= ring.size())) {
+                logger.severe("Recovery incomplete: " + resignPsbts.size() + "/" + ring.size()
+                        + " peers re-signed");
+                updateStatus("Timed out");
+                stopListening();
+                return;
+            }
+
+            Transaction finalTx = RecoveryTransaction.combine(new ArrayList<>(resignPsbts));
+            if (finalTx == null) {
+                logger.severe("Could not combine the re-signed inputs");
+                updateStatus("Error: Check logs");
+                stopListening();
+                return;
+            }
+
+            updateStatus("broadcast");
+            broadcastTransaction(finalTx, RecoveryTransaction.fee(outputs.size(), outputAmount, ring));
+        } catch (Exception e) {
+            logger.severe("Re-signing failed: " + e.getMessage());
+            updateStatus("Error: Check logs");
+            stopListening();
+        }
+    }
+
+    /** Wait for a condition, or give up when the recovery window closes. */
+    private boolean awaitUntil(java.util.function.BooleanSupplier done) {
+        long deadline = Instant.now().getEpochSecond() + RECOVERY_WINDOW_SECONDS;
+        while (Instant.now().getEpochSecond() < deadline) {
+            if (done.getAsBoolean()) {
+                return true;
+            }
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return done.getAsBoolean();
+    }
+
+    private com.sparrowwallet.drongo.crypto.ECKey myKey(WalletNode node) {
+        try {
+            return wallet.getKeystores().get(0).getKey(node);
+        } catch (Exception e) {
+            logger.severe("Could not derive our signing key: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /** Our own signing key, if our input is in the ring. */
+    private String myRingPrivateKey(List<String> ringPubKeys) {
+        try {
+            com.sparrowwallet.drongo.crypto.ECKey key = myKey(myUtxoNode);
+            if (key == null || !key.hasPrivKey()) {
+                return null;
+            }
+            if (!ringPubKeys.contains(Utils.bytesToHex(key.getPubKey()))) {
+                return null;
+            }
+            return String.format("%064x", key.getPrivKey());
+        } catch (Exception e) {
+            logger.severe("Could not read our own signing key: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void signRecoveryInput(PSBT psbt) {
+        com.sparrowwallet.drongo.crypto.ECKey key = myKey(myUtxoNode);
+        if (key == null) {
+            throw new IllegalStateException("no signing key for our recovery input");
+        }
+        String myPrevout = myUtxo.getHash().toString() + ":" + myUtxo.getIndex();
+
+        for (PSBTInput input : psbt.getPsbtInputs()) {
+            String prevout = input.getInput().getOutpoint().getHash().toString() + ":"
+                    + input.getInput().getOutpoint().getIndex();
+            if (!myPrevout.equals(prevout)) {
+                continue;
+            }
+
+            input.setSigHash(SigHash.ALL);
+            input.sign(key);
+
+            if (input.getPartialSignatures() != null && !input.getPartialSignatures().isEmpty()) {
+                var entry = input.getPartialSignatures().entrySet().iterator().next();
+                input.setFinalScriptWitness(new com.sparrowwallet.drongo.protocol.TransactionWitness(
+                        psbt.getTransaction(), entry.getKey(), entry.getValue()));
+            }
+        }
+    }
+
+    /** Publish an encrypted message to the pool's own key, which every peer reads. */
+    private boolean publishToPool(String content) {
+        try {
+            if (!JoinstrTransport.newCircuit()) {
+                updateStatus("Error: Tor not running");
+                return false;
+            }
+
+            List<BaseTag> tags = new ArrayList<>();
+            tags.add(new PubKeyTag(poolIdentity.getPublicKey()));
+
+            NIP04 nip04 = new NIP04(poolIdentity, poolIdentity.getPublicKey());
+            String encrypted = nip04.encrypt(poolIdentity, content, poolIdentity.getPublicKey());
+
+            GenericEvent event = new GenericEvent(
+                    poolIdentity.getPublicKey(),
+                    Kind.ENCRYPTED_DIRECT_MESSAGE.getValue(),
+                    tags,
+                    encrypted);
+
+            nip04.setEvent(event);
+            nip04.sign();
+
+            DefaultRequestContext context = new DefaultRequestContext();
+            context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
+            context.setRelays(Map.of("default", relay));
+            context.setProxy(JoinstrTransport.proxy());
+            Client.getInstance().connect(context);
+
+            nip04.send(Map.of("default", relay));
+            return true;
+        } catch (Exception e) {
+            logger.severe("Failed to publish a pool message: " + e.getMessage());
+            return false;
+        }
+    }
+
     private void handleInputReceived(JoinstrMessage message) {
         try {
             String psbtBase64 = message.getPsbt();
@@ -632,6 +913,44 @@ public class CoinjoinHandler {
             }
         } catch (Exception e) {
             logger.severe("Error handling input: " + e.getMessage());
+        }
+    }
+
+    private void handleReregisterReceived(String decrypted) {
+        if (!recovering.get()) {
+            return;
+        }
+
+        List<String> ringPubKeys = RingInput.pubKeys(RingInput.ring(new ArrayList<>(inputPSBTs)));
+        Reregister.Accepted accepted = Reregister.validate(decrypted, pool.getPoolId(), ringPubKeys,
+                new ArrayList<>(reregisteredOutputs), new HashSet<>(seenKeyImages));
+        if (accepted == null) {
+            return;
+        }
+
+        synchronized (stateLock) {
+            if (seenKeyImages.contains(accepted.keyImage())
+                    || reregisteredOutputs.contains(accepted.address())
+                    || reregisteredOutputs.size() >= ringPubKeys.size()) {
+                return;
+            }
+            seenKeyImages.add(accepted.keyImage());
+            reregisteredOutputs.add(accepted.address());
+            logger.info("Accepted a re-registered output " + reregisteredOutputs.size() + "/"
+                    + ringPubKeys.size());
+        }
+    }
+
+    private void handleResignReceived(JoinstrMessage message) {
+        if (!recovering.get() || message.getPsbt() == null) {
+            return;
+        }
+
+        synchronized (stateLock) {
+            if (!resignPsbts.contains(message.getPsbt())) {
+                resignPsbts.add(message.getPsbt());
+                logger.info("Received a re-signed input " + resignPsbts.size());
+            }
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/RecoveryTransaction.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/RecoveryTransaction.java
@@ -1,0 +1,211 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import org.bouncycastle.util.encoders.Base64;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * The transaction coinjoin recovery rebuilds.
+ *
+ * Every peer has to construct this identically from the confirmed phase 2 inputs and the
+ * re-registered outputs, or their signatures do not agree. Unlike a registration PSBT it is signed
+ * with SIGHASH_ALL, so nothing can be added to it afterwards.
+ */
+public final class RecoveryTransaction {
+
+    private RecoveryTransaction() {
+    }
+
+    /** Inputs go in outpoint order so every peer builds the same transaction. */
+    static List<RingInput.Member> orderedInputs(List<RingInput.Member> ring) {
+        List<RingInput.Member> ordered = new ArrayList<>(ring);
+        ordered.sort(Comparator.comparing(RingInput.Member::prevout));
+        return ordered;
+    }
+
+    /** Why this transaction must not be signed, or null if it may be. */
+    public static String rejectionReason(List<String> outputs, long outputAmount,
+            List<RingInput.Member> ring) {
+        if (outputs == null || outputs.isEmpty() || ring == null || ring.isEmpty()) {
+            return "recovery needs at least one input and one output";
+        }
+
+        if (outputAmount <= 0) {
+            return "output amount is not positive: " + outputAmount;
+        }
+
+        long dust = 0;
+        for (String address : outputs) {
+            try {
+                dust = Math.max(dust, com.sparrowwallet.sparrow.wallet.PaymentController
+                        .getRecipientDustThreshold(Address.fromString(address)));
+            } catch (Exception e) {
+                return "an output is not a valid address";
+            }
+        }
+
+        if (outputAmount < dust) {
+            return "output amount " + outputAmount + " is below the dust limit " + dust;
+        }
+
+        long totalIn = 0;
+        for (RingInput.Member member : ring) {
+            long value = inputValue(member);
+            if (value <= 0) {
+                return "an input value is missing or not positive";
+            }
+            totalIn += value;
+        }
+
+        long totalOut = outputAmount * outputs.size();
+        if (totalIn <= totalOut) {
+            return "inputs (" + totalIn + ") must exceed outputs (" + totalOut + ")";
+        }
+
+        long fee = totalIn - totalOut;
+        if (fee < 100L * ring.size() || fee > 10000L * ring.size()) {
+            return "fee of " + fee + " sats is outside the expected range for " + ring.size()
+                    + " inputs";
+        }
+
+        return null;
+    }
+
+    /** Build the unsigned recovery transaction. */
+    public static PSBT build(List<String> outputs, long outputAmount, List<RingInput.Member> ring) {
+        try {
+            Transaction tx = new Transaction();
+            tx.setVersion(2);
+
+            List<RingInput.Member> inputs = orderedInputs(ring);
+            for (RingInput.Member member : inputs) {
+                String[] parts = member.prevout().split(":");
+                tx.addInput(Sha256Hash.wrap(parts[0]), Integer.parseInt(parts[1]), new Script(new byte[0]));
+            }
+
+            for (String address : outputs) {
+                tx.addOutput(outputAmount, Address.fromString(address).getOutputScript());
+            }
+
+            PSBT psbt = new PSBT(tx);
+            for (int i = 0; i < inputs.size(); i++) {
+                TransactionOutput witnessUtxo = witnessUtxo(inputs.get(i));
+                if (witnessUtxo != null) {
+                    psbt.getPsbtInputs().get(i).setWitnessUtxo(witnessUtxo);
+                }
+            }
+
+            return psbt;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Merge the peers' re-signed transactions, or null if they do not agree. */
+    public static Transaction combine(List<String> signedPsbts) {
+        try {
+            if (signedPsbts.isEmpty()) {
+                return null;
+            }
+
+            PSBT combined = new PSBT(Base64.decode(signedPsbts.get(0)), false);
+
+            for (int i = 1; i < signedPsbts.size(); i++) {
+                PSBT other = new PSBT(Base64.decode(signedPsbts.get(i)), false);
+
+                if (!sameTransaction(combined, other)) {
+                    // a peer that re-signed a different transaction cannot be merged into this one
+                    return null;
+                }
+
+                for (int input = 0; input < combined.getPsbtInputs().size(); input++) {
+                    PSBTInput target = combined.getPsbtInputs().get(input);
+                    PSBTInput source = other.getPsbtInputs().get(input);
+
+                    if (target.getFinalScriptWitness() == null && source.getFinalScriptWitness() != null) {
+                        target.setFinalScriptWitness(source.getFinalScriptWitness());
+                    }
+                    if (target.getWitnessUtxo() == null && source.getWitnessUtxo() != null) {
+                        target.setWitnessUtxo(source.getWitnessUtxo());
+                    }
+                }
+            }
+
+            for (PSBTInput input : combined.getPsbtInputs()) {
+                if (input.getFinalScriptWitness() == null) {
+                    return null;
+                }
+            }
+
+            return combined.extractTransaction();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static long fee(int outputCount, long outputAmount, List<RingInput.Member> ring) {
+        long totalIn = 0;
+        for (RingInput.Member member : ring) {
+            totalIn += inputValue(member);
+        }
+        return totalIn - outputAmount * outputCount;
+    }
+
+    /** Whether two PSBTs describe the same transaction, signatures aside. */
+    static boolean sameTransaction(PSBT a, PSBT b) {
+        try {
+            Transaction first = a.getTransaction();
+            Transaction second = b.getTransaction();
+
+            if (first.getInputs().size() != second.getInputs().size()
+                    || first.getOutputs().size() != second.getOutputs().size()) {
+                return false;
+            }
+
+            for (int i = 0; i < first.getInputs().size(); i++) {
+                if (!first.getInputs().get(i).getOutpoint().toString()
+                        .equals(second.getInputs().get(i).getOutpoint().toString())) {
+                    return false;
+                }
+            }
+
+            for (int i = 0; i < first.getOutputs().size(); i++) {
+                TransactionOutput out = first.getOutputs().get(i);
+                TransactionOutput other = second.getOutputs().get(i);
+                if (out.getValue() != other.getValue()
+                        || !out.getScript().getToAddress().toString()
+                                .equals(other.getScript().getToAddress().toString())) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static TransactionOutput witnessUtxo(RingInput.Member member) {
+        try {
+            PSBT psbt = new PSBT(Base64.decode(member.psbtBase64()), false);
+            return psbt.getPsbtInputs().get(0).getWitnessUtxo();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static long inputValue(RingInput.Member member) {
+        TransactionOutput witnessUtxo = witnessUtxo(member);
+        return witnessUtxo == null ? 0 : witnessUtxo.getValue();
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/RecoveryTransactionTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/RecoveryTransactionTest.java
@@ -1,0 +1,234 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.protocol.Script;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.protocol.Sha256Hash;
+import com.sparrowwallet.drongo.protocol.SigHash;
+import com.sparrowwallet.drongo.protocol.Transaction;
+import com.sparrowwallet.drongo.protocol.TransactionOutput;
+import com.sparrowwallet.drongo.protocol.TransactionWitness;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTInput;
+
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The transaction recovery rebuilds. Every peer constructs it from the same confirmed inputs and
+ * re-registered outputs, so it has to come out identical for their signatures to agree.
+ */
+public class RecoveryTransactionTest {
+
+    private static final long INPUT_VALUE = 100_500L;
+
+    private ECKey key(int seed) {
+        return ECKey.fromPrivate(BigInteger.valueOf(4000037L + seed));
+    }
+
+    private String address(int seed) {
+        return ScriptType.P2WPKH.getAddress(key(seed + 700)).toString();
+    }
+
+    private RingInput.Member member(int keySeed, int outpointSeed) throws Exception {
+        Transaction tx = new Transaction();
+        tx.setVersion(2);
+        tx.addInput(Sha256Hash.wrap(String.format("%064x", 0xaa0000L + outpointSeed)),
+                outpointSeed, new Script(new byte[0]));
+        tx.addOutput(99_900L, Address.fromString(address(0)).getOutputScript());
+
+        PSBT psbt = new PSBT(tx);
+        PSBTInput input = psbt.getPsbtInputs().get(0);
+        input.setSigHash(SigHash.ANYONECANPAY_ALL);
+        input.setWitnessUtxo(new TransactionOutput(tx, INPUT_VALUE,
+                ScriptType.P2WPKH.getOutputScript(key(keySeed))));
+        assertTrue(input.sign(key(keySeed)));
+        var entry = input.getPartialSignatures().entrySet().iterator().next();
+        input.setFinalScriptWitness(new TransactionWitness(tx, entry.getKey(), entry.getValue()));
+
+        return RingInput.member(Base64.toBase64String(psbt.serialize()));
+    }
+
+    private List<RingInput.Member> ring(int size) throws Exception {
+        List<RingInput.Member> ring = new ArrayList<>();
+        for(int i = 0; i < size; i++) {
+            ring.add(member(i + 1, i + 1));
+        }
+        return ring;
+    }
+
+    private List<String> outputs(int count) {
+        List<String> outputs = new ArrayList<>();
+        for(int i = 0; i < count; i++) {
+            outputs.add(address(i));
+        }
+        Collections.sort(outputs);
+        return outputs;
+    }
+
+    /** Sign every input of a built recovery transaction, as all the peers together would. */
+    private String fullySigned(PSBT psbt) {
+        for(PSBTInput input : psbt.getPsbtInputs()) {
+            // member(i, i) was built with key seed == outpoint index
+            int seed = (int) input.getInput().getOutpoint().getIndex();
+            input.setSigHash(SigHash.ALL);
+            assertTrue(input.sign(key(seed)), "test setup: could not sign a recovery input");
+            var entry = input.getPartialSignatures().entrySet().iterator().next();
+            input.setFinalScriptWitness(
+                    new TransactionWitness(psbt.getTransaction(), entry.getKey(), entry.getValue()));
+        }
+        return Base64.toBase64String(psbt.serialize());
+    }
+
+    @Test
+    public void inputsGoInOutpointOrderWhateverOrderTheRingIsIn() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        List<RingInput.Member> shuffled = new ArrayList<>(ring);
+        Collections.reverse(shuffled);
+
+        assertEquals(RecoveryTransaction.orderedInputs(ring),
+                RecoveryTransaction.orderedInputs(shuffled));
+    }
+
+    /** Two peers must build byte identical transactions or their signatures cannot combine. */
+    @Test
+    public void twoPeersBuildTheSameTransaction() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        List<String> outputs = outputs(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+
+        List<RingInput.Member> reversed = new ArrayList<>(ring);
+        Collections.reverse(reversed);
+
+        PSBT first = RecoveryTransaction.build(outputs, amount, ring);
+        PSBT second = RecoveryTransaction.build(outputs, amount, reversed);
+
+        assertNotNull(first);
+        assertNotNull(second);
+        assertEquals(first.getTransaction().getTxId(), second.getTransaction().getTxId());
+    }
+
+    @Test
+    public void theBuiltTransactionCarriesEveryInputAndOutput() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        List<String> outputs = outputs(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+
+        PSBT psbt = RecoveryTransaction.build(outputs, amount, ring);
+
+        assertEquals(3, psbt.getTransaction().getInputs().size());
+        assertEquals(3, psbt.getTransaction().getOutputs().size());
+        for(PSBTInput input : psbt.getPsbtInputs()) {
+            assertNotNull(input.getWitnessUtxo(), "an input lost its value");
+        }
+    }
+
+    @Test
+    public void aWellFormedRecoveryIsAccepted() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+
+        assertNull(RecoveryTransaction.rejectionReason(outputs(3), amount, ring));
+    }
+
+    @Test
+    public void outputsExceedingInputsAreRejected() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+
+        String reason = RecoveryTransaction.rejectionReason(outputs(3), INPUT_VALUE + 1, ring);
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("must exceed outputs"), reason);
+    }
+
+    @Test
+    public void anAbsurdFeeIsRejected() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+
+        // 3 inputs of 100500 against 3 outputs of 50000 leaves a fee of 151500
+        String reason = RecoveryTransaction.rejectionReason(outputs(3), 50_000L, ring);
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("outside the expected range"), reason);
+    }
+
+    @Test
+    public void aDustOutputIsRejected() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+
+        String reason = RecoveryTransaction.rejectionReason(outputs(3), 100L, ring);
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("dust") || reason.contains("expected range"), reason);
+    }
+
+    @Test
+    public void emptyInputsOrOutputsAreRejected() throws Exception {
+        assertNotNull(RecoveryTransaction.rejectionReason(List.of(), 99_000L, ring(3)));
+        assertNotNull(RecoveryTransaction.rejectionReason(outputs(3), 99_000L, List.of()));
+        assertNotNull(RecoveryTransaction.rejectionReason(outputs(3), 0, ring(3)));
+    }
+
+    /** The happy path, so the rejection below cannot pass just because nothing ever combines. */
+    @Test
+    public void fullySignedPeersCombineIntoATransaction() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+
+        String signed = fullySigned(RecoveryTransaction.build(outputs(3), amount, ring));
+
+        Transaction combined = RecoveryTransaction.combine(List.of(signed, signed));
+
+        assertNotNull(combined, "signed peers should combine");
+        assertEquals(3, combined.getInputs().size());
+        assertEquals(3, combined.getOutputs().size());
+    }
+
+    /**
+     * Both sides are fully signed here, so only the transaction check can reject this. An
+     * earlier version of this test used unsigned PSBTs, which the witness check rejected anyway
+     * and so proved nothing.
+     */
+    @Test
+    public void psbtsForDifferentTransactionsAreNotCombined() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+
+        String mine = fullySigned(RecoveryTransaction.build(outputs(3), amount, ring));
+        String different = fullySigned(RecoveryTransaction.build(outputs(3), amount - 500, ring));
+
+        assertNull(RecoveryTransaction.combine(List.of(mine, different)),
+                "a peer re-signing a different transaction was merged in");
+    }
+
+    @Test
+    public void anUnsignedCombinationIsRefused() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+        PSBT unsigned = RecoveryTransaction.build(outputs(3), amount, ring);
+
+        assertNull(RecoveryTransaction.combine(List.of(Base64.toBase64String(unsigned.serialize()))),
+                "an unsigned transaction was treated as complete");
+    }
+
+    @Test
+    public void theSameTransactionCheckSpotsAChangedOutput() throws Exception {
+        List<RingInput.Member> ring = ring(3);
+        long amount = CoinjoinMath.recoveryOutputAmount(100_000L, 1, 3, 3);
+
+        PSBT a = RecoveryTransaction.build(outputs(3), amount, ring);
+        PSBT b = RecoveryTransaction.build(outputs(3), amount, ring);
+        PSBT c = RecoveryTransaction.build(outputs(3), amount - 1, ring);
+
+        assertTrue(RecoveryTransaction.sameTransaction(a, b));
+        assertFalse(RecoveryTransaction.sameTransaction(a, c));
+    }
+}


### PR DESCRIPTION
Closes #65. Completes the work started in #87 (the ring signature) and #88 (the ring, the reregister message and the recovery fee).

When a pool loses a peer during input registration, the peers that did register recover: they claim an output again under a ring signature, rebuild the transaction from the confirmed inputs, and re-sign it. Without this, one peer registering an output and never an input griefs the whole pool for free, and plugin peers move to recovery while this client sits until the pool expires.

## Changes

`recovery: run the ring signature phases when a pool loses a peer`

- The pool timeout now checks whether recovery applies before giving up. It does when some inputs were registered but not all, and this client registered one of them. With every input present there is nothing to recover; with none there is no ring.
- **Phase 3.** Build the ring from the phase 2 registrations, sign `SHA256(address + pool_id)` as our ring member, publish the re-registration, and collect the others for 120 seconds. Incoming re-registrations are verified and deduplicated on the key image inside the signature. If any ring member fails to re-register the coinjoin is abandoned: the ring hides which input belongs to which output, so a missing peer cannot be dropped without unbalancing the transaction.
- **Phase 4.** New `RecoveryTransaction` rebuilds the transaction from the confirmed inputs in outpoint order and the re-registered outputs sorted, checks it, signs our input with `SIGHASH_ALL` so nothing can be added afterwards, publishes it, and combines the peers' copies before broadcasting.
- `publishToPool` replaces three near identical copies of the encrypt, sign and send block.

`test: cover the rebuilt recovery transaction`

Twelve cases: inputs ordered by outpoint regardless of ring order; two peers building byte identical transactions; every input and output carried with its value; a well formed recovery accepted; outputs exceeding inputs, an absurd fee, a dust output, and empty inputs or outputs each rejected; fully signed peers combining; a peer that re-signed a different transaction refused; an unsigned combination refused; and the transaction comparison spotting a changed output.

## Verification

`./gradlew :test` green, 236 tests.

Removing the balance and fee checks and the transaction comparison fails 3 of the 12.