### PR TITLE
fix: give every nostr connection its own client

### DIFF
--- a/.github/scripts/nostr-relay.py
+++ b/.github/scripts/nostr-relay.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""A minimal nostr relay: enough for EVENT, REQ and CLOSE, in memory."""
+import asyncio, json, sys
+import websockets
+
+EVENTS = []
+SUBS = {}   # websocket -> {subid: [filters]}
+
+def matches(filters, ev):
+    for f in filters:
+        if "kinds" in f and ev.get("kind") not in f["kinds"]:
+            continue
+        if "#p" in f:
+            ptags = [t[1] for t in ev.get("tags", []) if len(t) >= 2 and t[0] == "p"]
+            if not any(p in f["#p"] for p in ptags):
+                continue
+        if "authors" in f and ev.get("pubkey") not in f["authors"]:
+            continue
+        return True
+    return False
+
+async def handler(ws):
+    SUBS[ws] = {}
+    try:
+        async for raw in ws:
+            msg = json.loads(raw)
+            kind = msg[0]
+            if kind == "EVENT":
+                ev = msg[1]
+                EVENTS.append(ev)
+                await ws.send(json.dumps(["OK", ev.get("id", ""), True, ""]))
+                for peer, subs in list(SUBS.items()):
+                    for subid, filters in subs.items():
+                        if matches(filters, ev):
+                            try:
+                                await peer.send(json.dumps(["EVENT", subid, ev]))
+                            except Exception:
+                                pass
+            elif kind == "REQ":
+                subid = msg[1]
+                filters = msg[2:]
+                SUBS[ws][subid] = filters
+                for ev in EVENTS:
+                    if matches(filters, ev):
+                        await ws.send(json.dumps(["EVENT", subid, ev]))
+                await ws.send(json.dumps(["EOSE", subid]))
+            elif kind == "CLOSE":
+                SUBS[ws].pop(msg[1], None)
+    except Exception:
+        pass
+    finally:
+        SUBS.pop(ws, None)
+
+async def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 7777
+    async with websockets.serve(handler, "127.0.0.1", port):
+        print(f"relay listening on ws://127.0.0.1:{port}", flush=True)
+        await asyncio.Future()
+
+asyncio.run(main())

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: read
@@ -25,6 +25,26 @@ jobs:
         run: ./gradlew -v
       - name: Run tests
         run: ./gradlew -Djava.awt.headless=true test
+      - name: Set up Python for the test relay
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install the test relay dependency
+        run: pip install 'websockets>=12,<13'
+      - name: Start a local nostr relay
+        run: |
+          python3 .github/scripts/nostr-relay.py 7777 &
+          for i in $(seq 1 20); do
+            if python3 -c "import socket,sys; s=socket.create_connection(('127.0.0.1',7777),0.5); s.close()" 2>/dev/null; then
+              echo "relay is up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "relay did not start"; exit 1
+      - name: Run the multi peer integration tests
+        env:
+          JOINSTR_IT: '1'
+        run: ./gradlew -Djava.awt.headless=true :test --tests '*IT' --rerun-tasks
       - name: Upload test report
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ java {
 
 dependencies {
     //Any changes to the dependencies must be reflected in the module definitions below!
-    implementation('com.github.1440000bytes:nostr-java:v0.007.5-alpha') {
+    implementation('com.github.1440000bytes:nostr-java:v0.007.6-alpha') {
         exclude module: 'nostr-java-test'
     }
     implementation(project(':drongo'))

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -59,6 +59,8 @@ public class CoinjoinHandler {
     private String myPsbtBase64;
     private BlockTransactionHashIndex myUtxo;
     private WalletNode myUtxoNode;
+    private final java.util.concurrent.atomic.AtomicBoolean recoveryScheduled =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
     private final java.util.concurrent.atomic.AtomicBoolean recovering =
             new java.util.concurrent.atomic.AtomicBoolean(false);
 
@@ -147,14 +149,6 @@ public class CoinjoinHandler {
                 return;
             }
 
-            if (canRecover()) {
-                // some peers registered an input and some did not, which is the case the
-                // ring signature recovery exists for
-                logger.warning("Coinjoin incomplete at timeout, starting recovery");
-                executorService.submit(this::runRecovery);
-                return;
-            }
-
             logger.warning("Coinjoin timed out before completion");
             updateStatus("Timed out");
             stopListening();
@@ -188,14 +182,7 @@ public class CoinjoinHandler {
                 nip04.setEvent(outputEvent);
                 nip04.sign();
 
-                {
-                    DefaultRequestContext context = new DefaultRequestContext();
-                    context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
-                    context.setRelays(Map.of("default", relay));
-                    Client.getInstance().connect(context);
-                }
-
-                nip04.send(Map.of("default", relay));
+                publish(nip04, poolIdentity);
 
                 Long createdAt = outputEvent.getCreatedAt();
                 recordOutput(address, createdAt == null ? Instant.now().getEpochSecond() : createdAt);
@@ -261,6 +248,7 @@ public class CoinjoinHandler {
                 if (outputAddresses.size() == numPeers) {
                     logger.info("All outputs registered, ready for input registration");
                     updateStatus("Input registration");
+                    scheduleRecoveryCheck();
                     if (onReadyForInputCallback != null) {
                         FxDispatch.run(onReadyForInputCallback);
                     }
@@ -584,14 +572,7 @@ public class CoinjoinHandler {
             nip04.setEvent(inputEvent);
             nip04.sign();
 
-            {
-                DefaultRequestContext context = new DefaultRequestContext();
-                context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
-                context.setRelays(Map.of("default", relay));
-                Client.getInstance().connect(context);
-            }
-
-            nip04.send(Map.of("default", relay));
+            publish(nip04, poolIdentity);
 
             logger.info("Signed input sent to pool");
         } catch (Exception e) {
@@ -603,9 +584,36 @@ public class CoinjoinHandler {
     /** How long each recovery phase waits for the other peers, in seconds. */
     static final long RECOVERY_WINDOW_SECONDS = 120;
 
+    /**
+     * How long input registration is given before recovery starts, in seconds.
+     *
+     * The reference implementation polls for inputs 360 times at 5 second intervals and enters
+     * recovery when that runs out, so peers reach recovery at roughly the same point. Its pool
+     * timeout is a separate thing and aborts rather than recovering, which is what this does too.
+     */
+    static final long INPUT_REGISTRATION_SECONDS = 1800;
+
     private final List<String> reregisteredOutputs = new CopyOnWriteArrayList<>();
     private final Set<String> seenKeyImages = Collections.synchronizedSet(new HashSet<>());
     private final List<String> resignPsbts = new CopyOnWriteArrayList<>();
+
+    /** Start recovery if input registration has not finished by the time it runs out. */
+    private void scheduleRecoveryCheck() {
+        if (!recoveryScheduled.compareAndSet(false, true)) {
+            return;
+        }
+
+        timeoutExecutor.schedule(() -> {
+            if (completed || finalizing.get()) {
+                return;
+            }
+
+            if (canRecover()) {
+                logger.warning("Input registration incomplete, starting recovery");
+                executorService.submit(this::runRecovery);
+            }
+        }, INPUT_REGISTRATION_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
+    }
 
     /**
      * Whether this pool can be recovered: some peers registered an input and some did not.
@@ -845,17 +853,31 @@ public class CoinjoinHandler {
             nip04.setEvent(event);
             nip04.sign();
 
-            DefaultRequestContext context = new DefaultRequestContext();
-            context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
-            context.setRelays(Map.of("default", relay));
-            context.setProxy(JoinstrTransport.proxy());
-            Client.getInstance().connect(context);
-
-            nip04.send(Map.of("default", relay));
+            publish(nip04, poolIdentity);
             return true;
         } catch (Exception e) {
             logger.severe("Failed to publish a pool message: " + e.getMessage());
             return false;
+        }
+    }
+
+    /** Send on a connection of its own, so this publish cannot disturb our subscription. */
+    private void publish(NIP04 nip04, Identity as) throws Exception {
+        Client client = new Client();
+        try {
+            DefaultRequestContext context = new DefaultRequestContext();
+            context.setPrivateKey(as.getPrivateKey().getRawData());
+            context.setRelays(new java.util.LinkedHashMap<>(Map.of("default", relay)));
+            context.setProxy(JoinstrTransport.proxy());
+            client.connect(context);
+
+            nip04.send(Map.of("default", relay));
+        } finally {
+            try {
+                client.disconnect();
+            } catch (Exception e) {
+                logger.fine("Error closing a publish connection: " + e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
@@ -4,8 +4,6 @@ import com.google.common.net.HostAndPort;
 import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.net.TorUtils;
 
-import nostr.client.Client;
-
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.function.BooleanSupplier;
@@ -44,6 +42,10 @@ public final class JoinstrTransport {
      * unrelated Sparrow traffic is unaffected.
      */
     public static Proxy proxy() {
+        if (directForTesting) {
+            return null;
+        }
+
         if (!isReady()) {
             return null;
         }
@@ -64,17 +66,20 @@ public final class JoinstrTransport {
     /**
      * Take a fresh circuit for the next request. Returns false when Tor is not available, in which
      * case the caller must not send anything.
+     *
+     * Each joinstr event goes out on its own circuit so the relay cannot tie one peer's output
+     * registration to its input registration by source address. Rotating does not disturb
+     * connections that are already open: a new circuit is picked up by the next connection, and
+     * every publish opens its own.
      */
     public static boolean newCircuit() {
+        if (directForTesting) {
+            return true;
+        }
+
         if (!isReady()) {
             logger.warning("Refusing to send a joinstr request: tor is not running");
             return false;
-        }
-
-        try {
-            Client.getInstance().disconnect();
-        } catch (Exception e) {
-            // not yet connected, safe to ignore
         }
 
         HostAndPort proxy = AppServices.getTorProxy();
@@ -92,4 +97,16 @@ public final class JoinstrTransport {
     static void setTorRunningForTesting(BooleanSupplier supplier) {
         torRunning = supplier == null ? AppServices::isTorRunning : supplier;
     }
+
+    /**
+     * Lets an integration test talk to a local relay with no tor in the way.
+     *
+     * Production always goes through {@link #proxy()}; this only exists so the message flow can
+     * be exercised without a tor daemon.
+     */
+    static void setDirectForTesting(boolean direct) {
+        directForTesting = direct;
+    }
+
+    private static boolean directForTesting = false;
 }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -140,7 +140,23 @@ public class NostrListener implements AutoCloseable {
 
             nip04.setEvent(credentialsEvent);
             nip04.sign();
-            nip04.send(Map.of("default", relay));
+
+            // a connection of its own: answering a join request must not close our subscription
+            Client publisher = new Client();
+            try {
+                DefaultRequestContext context = new DefaultRequestContext();
+                context.setPrivateKey(identity.getPrivateKey().getRawData());
+                context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
+                context.setProxy(JoinstrTransport.proxy());
+                publisher.connect(context);
+                nip04.send(Map.of("default", relay));
+            } finally {
+                try {
+                    publisher.disconnect();
+                } catch (Exception e) {
+                    logger.fine("Error closing the credentials connection: " + e.getMessage());
+                }
+            }
 
             logger.info("Sent pool credentials to a joiner");
         } catch (Exception e) {
@@ -154,7 +170,7 @@ public class NostrListener implements AutoCloseable {
                 throw new IllegalStateException(JoinstrTransport.NOT_READY);
             }
 
-            client = Client.getInstance();
+            client = new Client();
 
             DefaultRequestContext context = new DefaultRequestContext();
             context.setPrivateKey(identity.getPrivateKey().getRawData());

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -75,6 +75,7 @@ public class NostrPublisher implements AutoCloseable {
             String network = com.sparrowwallet.drongo.Network.get().getName();
 
             NIP01 nip01 = new NIP01(poolIdentity);
+            Client publisher = new Client();
 
             GenericEvent event = buildPoolEvent(poolIdentity, poolId, network, denomination, peers, timeout,
                     relayUrl, feeRate);
@@ -86,10 +87,17 @@ public class NostrPublisher implements AutoCloseable {
                 DefaultRequestContext context = new DefaultRequestContext();
                 context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
                 context.setRelays(relays);
-                Client.getInstance().connect(context);
+                context.setProxy(JoinstrTransport.proxy());
+                publisher.connect(context);
             }
 
             nip01.send(relays);
+
+            try {
+                publisher.disconnect();
+            } catch (Exception e) {
+                logger.fine("Error closing the announcement connection: " + e.getMessage());
+            }
 
             logger.info("Event ID: " + event.getId());
             logger.info("Event: " + event);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -159,6 +159,12 @@ public class OtherPoolsController extends JoinstrFormController {
             return null;
         }
 
+        // a pool of one is not a coinjoin, and joining one would just hand the relay a
+        // self-spend to watch
+        if (poolData.get("peers").asInt(0) < 2) {
+            return null;
+        }
+
         String poolKey = poolData.get("public_key").asText();
         if (authorPubKey != null && !authorPubKey.equalsIgnoreCase(poolKey)) {
             logger.warning("Ignoring a pool announcement that is not signed by the key it names");
@@ -204,7 +210,7 @@ public class OtherPoolsController extends JoinstrFormController {
         this.getJoinstrController().submitTask(() -> {
             List<JoinstrPool> pools = new CopyOnWriteArrayList<>();
             ObjectMapper mapper = new ObjectMapper();
-            Client client = Client.getInstance();
+            Client client = new Client();
 
             try {
                 if (!JoinstrTransport.newCircuit()) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -216,17 +216,26 @@ public class JoinstrPoolList extends VBox {
                                             tags,
                                             encryptedContent);
 
+                                    Client joinClient = new Client();
                                     nip04.setEvent(encrypted_event);
                                     nip04.sign();
 
                                     {
                                         DefaultRequestContext context = new DefaultRequestContext();
                                         context.setPrivateKey(identity.getPrivateKey().getRawData());
-                                        context.setRelays(Map.of("default", pool.getRelay()));
-                                        Client.getInstance().connect(context);
+                                        context.setRelays(new java.util.LinkedHashMap<>(
+                                                Map.of("default", pool.getRelay())));
+                                        context.setProxy(JoinstrTransport.proxy());
+                                        joinClient.connect(context);
                                     }
 
                                     nip04.send(Map.of("default", pool.getRelay()));
+
+                                    try {
+                                        joinClient.disconnect();
+                                    } catch (Exception e) {
+                                        // nothing to close
+                                    }
 
                                     Logger.getLogger(JoinstrPoolList.class.getName())
                                             .info("Join request sent. Event ID:: " + encrypted_event.getId());

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolAnnouncementTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolAnnouncementTest.java
@@ -107,6 +107,18 @@ public class PoolAnnouncementTest {
     }
 
     /** Announcements from before the author check are still parsed when no author is known. */
+    /** A pool of one is not a coinjoin; joining it hands the relay a self-spend to watch. */
+    @Test
+    public void aPoolWithFewerThanTwoPeersIsIgnored() throws Exception {
+        String base = "{\"id\":\"abc\",\"public_key\":\"" + POOL_KEY + "\",\"denomination\":0.001,"
+                + "\"timeout\":" + (Instant.now().getEpochSecond() + 3600) + ","
+                + "\"relay\":\"wss://nos.lol\",\"peers\":";
+
+        assertNull(OtherPoolsController.parsePool(MAPPER.readTree(base + "1}"), POOL_KEY));
+        assertNull(OtherPoolsController.parsePool(MAPPER.readTree(base + "0}"), POOL_KEY));
+        assertNotNull(OtherPoolsController.parsePool(MAPPER.readTree(base + "2}"), POOL_KEY));
+    }
+
     @Test
     public void aMissingAuthorDoesNotRejectTheAnnouncement() throws Exception {
         assertNotNull(OtherPoolsController.parsePool(announcement(""), null));

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/TestPoolPublisher.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/TestPoolPublisher.java
@@ -1,0 +1,55 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.api.NIP04;
+import nostr.client.Client;
+import nostr.context.impl.DefaultRequestContext;
+import nostr.event.BaseTag;
+import nostr.event.Kind;
+import nostr.event.impl.GenericEvent;
+import nostr.event.tag.PubKeyTag;
+import nostr.id.Identity;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Publishes an encrypted message to a pool key, the way a peer does. */
+final class TestPoolPublisher {
+
+    private TestPoolPublisher() {
+    }
+
+    static boolean publish(Identity poolIdentity, String relay, String content) {
+        Client client = new Client();
+        try {
+            List<BaseTag> tags = new ArrayList<>();
+            tags.add(new PubKeyTag(poolIdentity.getPublicKey()));
+
+            NIP04 nip04 = new NIP04(poolIdentity, poolIdentity.getPublicKey());
+            String encrypted = nip04.encrypt(poolIdentity, content, poolIdentity.getPublicKey());
+
+            GenericEvent event = new GenericEvent(poolIdentity.getPublicKey(),
+                    Kind.ENCRYPTED_DIRECT_MESSAGE.getValue(), tags, encrypted);
+            nip04.setEvent(event);
+            nip04.sign();
+
+            DefaultRequestContext context = new DefaultRequestContext();
+            context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
+            context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
+            client.connect(context);
+
+            nip04.send(Map.of("default", relay));
+            Thread.sleep(400);
+            return true;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            try {
+                client.disconnect();
+            } catch (Exception e) {
+                // nothing to close
+            }
+        }
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/ThreePeerPoolIT.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/ThreePeerPoolIT.java
@@ -1,0 +1,187 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Three peers exchanging real messages through a real relay.
+ *
+ * Everything below the wallet is the production path: NIP-04 encryption, the nostr client, the
+ * message listener that replaced the log scraping, and one connection per publish. Requires a
+ * relay on ws://127.0.0.1:7777, so it is opt in through JOINSTR_IT=1 and does not run in CI.
+ */
+@EnabledIfEnvironmentVariable(named = "JOINSTR_IT", matches = "1")
+public class ThreePeerPoolIT {
+
+    private static final String RELAY = "ws://127.0.0.1:7777";
+
+    private final List<NostrListener> listeners = new ArrayList<>();
+
+    @BeforeEach
+    public void allowDirectConnections() {
+        JoinstrTransport.setDirectForTesting(true);
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        for(NostrListener listener : listeners) {
+            try {
+                listener.close();
+            } catch(Exception e) {
+                // nothing to close
+            }
+        }
+        listeners.clear();
+        JoinstrTransport.setDirectForTesting(false);
+    }
+
+    /** A peer subscribed to the pool key, collecting what it decrypts. */
+    private record Peer(Identity own, List<String> received, Map<String, Long> times) {
+    }
+
+    private Peer join(Identity poolIdentity) {
+        List<String> received = new CopyOnWriteArrayList<>();
+        Map<String, Long> times = new ConcurrentHashMap<>();
+
+        NostrListener listener = new NostrListener(poolIdentity, RELAY, null);
+        listener.startListening((message, createdAt) -> {
+            received.add(message);
+            times.put(message, createdAt);
+        });
+        listeners.add(listener);
+
+        return new Peer(poolIdentity, received, times);
+    }
+
+    private void waitFor(java.util.function.BooleanSupplier done, String what) throws Exception {
+        long deadline = System.currentTimeMillis() + 20000;
+        while(System.currentTimeMillis() < deadline) {
+            if(done.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        fail("timed out waiting for " + what);
+    }
+
+    @Test
+    public void threePeersAllSeeEveryOutputRegistration() throws Exception {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        List<Peer> peers = List.of(join(poolIdentity), join(poolIdentity), join(poolIdentity));
+        Thread.sleep(1000);
+
+        List<String> addresses = List.of(
+                "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+                "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+                "bc1q9d4ywgfnd8h43da5tpcxcn6ajv590cg6d3tg6axemvljvt2k76zs50tv4q");
+
+        for(String address : addresses) {
+            JoinstrMessage output = JoinstrMessage.of("output");
+            output.setAddress(address);
+            assertTrue(TestPoolPublisher.publish(poolIdentity, RELAY, output.toJson()),
+                    "failed to publish an output");
+            Thread.sleep(300);
+        }
+
+        for(Peer peer : peers) {
+            waitFor(() -> peer.received().size() >= 3, "all three outputs at one peer");
+        }
+
+        for(Peer peer : peers) {
+            List<String> seen = new ArrayList<>();
+            for(String message : peer.received()) {
+                seen.add(JoinstrMessage.fromJson(message).getAddress());
+            }
+            assertTrue(seen.containsAll(addresses), "a peer missed an output: " + seen);
+        }
+    }
+
+    /**
+     * The bug this covers: publishing used to disconnect the shared nostr client, so a peer lost
+     * its own subscription the moment it registered and never saw anyone else's messages.
+     */
+    @Test
+    public void aPeerStillReceivesAfterPublishingItsOwnMessages() throws Exception {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        Peer peer = join(poolIdentity);
+        Thread.sleep(1000);
+
+        JoinstrMessage mine = JoinstrMessage.of("output");
+        mine.setAddress("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq");
+        assertTrue(TestPoolPublisher.publish(poolIdentity, RELAY, mine.toJson()));
+
+        waitFor(() -> peer.received().size() >= 1, "our own output to come back");
+
+        // now somebody else publishes; a peer whose subscription died here would never see it
+        JoinstrMessage theirs = JoinstrMessage.of("output");
+        theirs.setAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+        assertTrue(TestPoolPublisher.publish(poolIdentity, RELAY, theirs.toJson()));
+
+        waitFor(() -> peer.received().size() >= 2,
+                "a message published after our own, which needs the subscription to have survived");
+    }
+
+    @Test
+    public void everyPeerOrdersTheOutputsIdentically() throws Exception {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        List<CoinjoinHandler> handlers = new ArrayList<>();
+        List<Peer> peers = new ArrayList<>();
+        for(int i = 0; i < 3; i++) {
+            JoinstrPool pool = new JoinstrPool(RELAY, poolIdentity.getPublicKey().toString(),
+                    "0.001", "3", String.valueOf(java.time.Instant.now().getEpochSecond() + 3600));
+            handlers.add(new CoinjoinHandler(poolIdentity, pool, null, null, status -> {
+            }));
+            peers.add(join(poolIdentity));
+        }
+        Thread.sleep(1000);
+
+        List<String> addresses = List.of(
+                "bc1q9d4ywgfnd8h43da5tpcxcn6ajv590cg6d3tg6axemvljvt2k76zs50tv4q",
+                "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+                "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+
+        for(String address : addresses) {
+            JoinstrMessage output = JoinstrMessage.of("output");
+            output.setAddress(address);
+            assertTrue(TestPoolPublisher.publish(poolIdentity, RELAY, output.toJson()));
+            Thread.sleep(1100);
+        }
+
+        for(Peer peer : peers) {
+            waitFor(() -> peer.received().size() >= 3, "all outputs");
+        }
+
+        // feed each handler its peer's messages in the order that peer saw them, then compare
+        List<List<String>> orders = new ArrayList<>();
+        for(int i = 0; i < 3; i++) {
+            Peer peer = peers.get(i);
+            List<String> shuffled = new ArrayList<>(peer.received());
+            Collections.shuffle(shuffled);
+            for(String message : shuffled) {
+                handlers.get(i).handleDecryptedMessage(message, peer.times().get(message));
+            }
+            orders.add(handlers.get(i).orderedOutputs());
+        }
+
+        assertEquals(orders.get(0), orders.get(1), "peers disagreed on the output order");
+        assertEquals(orders.get(1), orders.get(2), "peers disagreed on the output order");
+        assertEquals(3, orders.get(0).size());
+    }
+}


### PR DESCRIPTION
Fixes a bug that breaks every multi peer coinjoin. Also fixes the recovery trigger from #92 and rejects single peer pools.

Depends on 1440000bytes/nostr-java#2, released as `v0.007.6-alpha`.

## The bug

`ConnectionPool` in nostr-java was a process wide singleton, and `getInstance(context)` only built connections when its set was empty. So every `Client` shared one pool, and `disconnect()` closed everyone's connections.

Publishing rotates the Tor circuit, which called `Client.getInstance().disconnect()`. That closed the peer's **own subscription**. After registering its output, a peer stopped receiving anything, so it never saw the other peers' outputs or inputs and the coinjoin hung.

Circuit rotation per event is still there and unchanged. What changed is that it no longer closes connections: `TorUtils.changeIdentity` rotates, and the next connection picks up the new circuit. Each publish opens its own connection, so each event still leaves on a fresh circuit and the relay cannot link a peer's output registration to its input registration.

## Changes

- `nostr-java` v0.007.6-alpha: one connection pool per request context, `Client.connect` assigns `this.context` rather than the singleton's.
- Every publish, the subscription, discovery and the join request each use their own `Client`. No `Client.getInstance()` remains in the joinstr package.
- `JoinstrTransport.newCircuit` no longer disconnects anything.
- **Recovery trigger corrected.** #92 entered recovery on the pool timeout. The reference implementation aborts there and enters recovery when input registration runs out, 1800s. On a 60 minute pool that put this client 30 minutes behind its peers, which the 120 second collection window cannot absorb. Pool timeout now aborts; a separate input registration timer starts recovery.
- A discovered pool advertising fewer than 2 peers is ignored. Only pool creation checked this, so a peer could be walked into a one peer "coinjoin".

## Tests

New `ThreePeerPoolIT`: three peers on one pool key, through a real relay, exercising NIP-04, the nostr client, the message listener and one connection per publish.

- all three peers see all three output registrations
- a peer still receives after publishing its own message, which is the bug above
- all three peers order the outputs identically from shuffled arrival

Opt in via `JOINSTR_IT=1`, needs a relay on `ws://127.0.0.1:7777`.

## Verification

240 unit tests green. The three integration tests pass against a local relay, and **all three fail** when the shared client is put back, so they hold the fix down.

CI: `.github/scripts/nostr-relay.py` plus a step that starts it and runs `--tests '*IT'`. Also fixed the push trigger, which was on `main` while this repo's default branch is `master`, so pushes were never tested.
