### PR TITLE
fix: publish through the tor proxy

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/CoinjoinHandler.java
@@ -182,7 +182,7 @@ public class CoinjoinHandler {
                 nip04.setEvent(outputEvent);
                 nip04.sign();
 
-                publish(nip04, poolIdentity);
+                publish(outputEvent, poolIdentity);
 
                 Long createdAt = outputEvent.getCreatedAt();
                 recordOutput(address, createdAt == null ? Instant.now().getEpochSecond() : createdAt);
@@ -572,7 +572,7 @@ public class CoinjoinHandler {
             nip04.setEvent(inputEvent);
             nip04.sign();
 
-            publish(nip04, poolIdentity);
+            publish(inputEvent, poolIdentity);
 
             logger.info("Signed input sent to pool");
         } catch (Exception e) {
@@ -853,31 +853,17 @@ public class CoinjoinHandler {
             nip04.setEvent(event);
             nip04.sign();
 
-            publish(nip04, poolIdentity);
-            return true;
+            return JoinstrPublisher.publish(poolIdentity, relay, event);
         } catch (Exception e) {
             logger.severe("Failed to publish a pool message: " + e.getMessage());
             return false;
         }
     }
 
-    /** Send on a connection of its own, so this publish cannot disturb our subscription. */
-    private void publish(NIP04 nip04, Identity as) throws Exception {
-        Client client = new Client();
-        try {
-            DefaultRequestContext context = new DefaultRequestContext();
-            context.setPrivateKey(as.getPrivateKey().getRawData());
-            context.setRelays(new java.util.LinkedHashMap<>(Map.of("default", relay)));
-            context.setProxy(JoinstrTransport.proxy());
-            client.connect(context);
-
-            nip04.send(Map.of("default", relay));
-        } finally {
-            try {
-                client.disconnect();
-            } catch (Exception e) {
-                logger.fine("Error closing a publish connection: " + e.getMessage());
-            }
+    /** Send on a connection of its own, keeping the proxy and leaving our subscription alone. */
+    private void publish(GenericEvent signedEvent, Identity as) {
+        if (!JoinstrPublisher.publish(as, relay, signedEvent)) {
+            throw new IllegalStateException("could not publish to the pool");
         }
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPublisher.java
@@ -1,0 +1,75 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.client.Client;
+import nostr.context.impl.DefaultRequestContext;
+import nostr.event.impl.GenericEvent;
+import nostr.event.message.EventMessage;
+import nostr.id.Identity;
+
+import java.net.Proxy;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Sends one signed event on a connection of its own.
+ *
+ * The nostr api's own {@code send} builds a request context internally, carrying only the private
+ * key and the relay, and pushes it through the shared client. That context has no proxy, so
+ * publishing that way leaves through whatever route the JVM defaults to rather than through Tor.
+ * Building the context here keeps the proxy, and the private connection keeps a publish from
+ * disturbing a subscription.
+ */
+public final class JoinstrPublisher {
+
+    private static final Logger logger = Logger.getLogger(JoinstrPublisher.class.getName());
+
+    /**
+     * How long to let a send drain before closing the connection.
+     *
+     * {@code Client.send} is fire and forget with no completion signal, so closing immediately can
+     * drop the message on the floor.
+     */
+    private static final long FLUSH_MILLIS = 750;
+
+    private JoinstrPublisher() {
+    }
+
+    /** The context a joinstr connection uses, carrying the proxy so the traffic goes over Tor. */
+    static DefaultRequestContext context(Identity as, String relay, Proxy proxy) {
+        DefaultRequestContext context = new DefaultRequestContext();
+        context.setPrivateKey(as.getPrivateKey().getRawData());
+        context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
+        context.setProxy(proxy);
+        return context;
+    }
+
+    /** Publish a signed event. Returns false if it could not be sent. */
+    public static boolean publish(Identity as, String relay, GenericEvent signedEvent) {
+        if (!JoinstrTransport.newCircuit()) {
+            logger.warning("Not publishing: tor is not running");
+            return false;
+        }
+
+        Client client = new Client();
+        try {
+            client.connect(context(as, relay, JoinstrTransport.proxy()));
+            client.send(new EventMessage(signedEvent));
+
+            Thread.sleep(FLUSH_MILLIS);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (Exception e) {
+            logger.severe("Failed to publish an event: " + e.getMessage());
+            return false;
+        } finally {
+            try {
+                client.disconnect();
+            } catch (Exception e) {
+                logger.fine("Error closing a publish connection: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -141,21 +141,9 @@ public class NostrListener implements AutoCloseable {
             nip04.setEvent(credentialsEvent);
             nip04.sign();
 
-            // a connection of its own: answering a join request must not close our subscription
-            Client publisher = new Client();
-            try {
-                DefaultRequestContext context = new DefaultRequestContext();
-                context.setPrivateKey(identity.getPrivateKey().getRawData());
-                context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
-                context.setProxy(JoinstrTransport.proxy());
-                publisher.connect(context);
-                nip04.send(Map.of("default", relay));
-            } finally {
-                try {
-                    publisher.disconnect();
-                } catch (Exception e) {
-                    logger.fine("Error closing the credentials connection: " + e.getMessage());
-                }
+            if (!JoinstrPublisher.publish(identity, relay, credentialsEvent)) {
+                logger.severe("Failed to send pool credentials");
+                return;
             }
 
             logger.info("Sent pool credentials to a joiner");
@@ -172,10 +160,8 @@ public class NostrListener implements AutoCloseable {
 
             client = new Client();
 
-            DefaultRequestContext context = new DefaultRequestContext();
-            context.setPrivateKey(identity.getPrivateKey().getRawData());
-            context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
-            context.setProxy(JoinstrTransport.proxy());
+            DefaultRequestContext context = JoinstrPublisher.context(identity, relay,
+                    JoinstrTransport.proxy());
             context.setMessageListener((message, source) -> onRelayMessage(message));
 
             Filters filters = Filters.builder()

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -59,10 +59,6 @@ public class NostrPublisher implements AutoCloseable {
 
         Identity poolIdentity;
         try {
-            if (!JoinstrTransport.newCircuit()) {
-                AppServices.showErrorDialog("Tor Not Running", JoinstrTransport.NOT_READY);
-                return null;
-            }
 
             poolIdentity = Identity.generateRandomIdentity();
             poolPrivateKey = poolIdentity.getPrivateKey().toString();
@@ -75,7 +71,6 @@ public class NostrPublisher implements AutoCloseable {
             String network = com.sparrowwallet.drongo.Network.get().getName();
 
             NIP01 nip01 = new NIP01(poolIdentity);
-            Client publisher = new Client();
 
             GenericEvent event = buildPoolEvent(poolIdentity, poolId, network, denomination, peers, timeout,
                     relayUrl, feeRate);
@@ -83,20 +78,10 @@ public class NostrPublisher implements AutoCloseable {
             nip01.setEvent(event);
             nip01.sign();
 
-            {
-                DefaultRequestContext context = new DefaultRequestContext();
-                context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
-                context.setRelays(relays);
-                context.setProxy(JoinstrTransport.proxy());
-                publisher.connect(context);
-            }
 
-            nip01.send(relays);
-
-            try {
-                publisher.disconnect();
-            } catch (Exception e) {
-                logger.fine("Error closing the announcement connection: " + e.getMessage());
+            if (!JoinstrPublisher.publish(poolIdentity, relayUrl, event)) {
+                AppServices.showErrorDialog("Pool Not Created", JoinstrTransport.NOT_READY);
+                return null;
             }
 
             logger.info("Event ID: " + event.getId());

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -2,6 +2,7 @@ package com.sparrowwallet.sparrow.joinstr.control;
 
 import com.sparrowwallet.sparrow.joinstr.JoinstrMessage;
 import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
+import com.sparrowwallet.sparrow.joinstr.JoinstrPublisher;
 import com.sparrowwallet.sparrow.joinstr.JoinstrTransport;
 import com.sparrowwallet.sparrow.control.QRDisplayDialog;
 
@@ -184,10 +185,6 @@ public class JoinstrPoolList extends VBox {
 
                         joinButton.setOnAction(event -> {
                             JoinstrPool pool = getTableView().getItems().get(getIndex());
-                            if(!pool.isJoinable()) {
-                                AppServices.showErrorDialog("Pool Not Supported", pool.getUnsupportedReason());
-                                return;
-                            }
                             Identity identity = Identity.generateRandomIdentity();
                             String pubkey = identity.getPublicKey().toString();
                             QRDisplayDialog qrDialog = new QRDisplayDialog(pubkey);
@@ -195,12 +192,6 @@ public class JoinstrPoolList extends VBox {
 
                             new Thread(() -> {
                                 try {
-                                    if(!JoinstrTransport.newCircuit()) {
-                                        javafx.application.Platform.runLater(() ->
-                                                AppServices.showErrorDialog("Tor Not Running",
-                                                        JoinstrTransport.NOT_READY));
-                                        return;
-                                    }
 
                                     PublicKey poolPubKey = new PublicKey(pool.getPubkey());
                                     String requestContent = JoinstrMessage.of("join_pool").toJson();
@@ -216,25 +207,15 @@ public class JoinstrPoolList extends VBox {
                                             tags,
                                             encryptedContent);
 
-                                    Client joinClient = new Client();
                                     nip04.setEvent(encrypted_event);
                                     nip04.sign();
 
-                                    {
-                                        DefaultRequestContext context = new DefaultRequestContext();
-                                        context.setPrivateKey(identity.getPrivateKey().getRawData());
-                                        context.setRelays(new java.util.LinkedHashMap<>(
-                                                Map.of("default", pool.getRelay())));
-                                        context.setProxy(JoinstrTransport.proxy());
-                                        joinClient.connect(context);
-                                    }
 
-                                    nip04.send(Map.of("default", pool.getRelay()));
-
-                                    try {
-                                        joinClient.disconnect();
-                                    } catch (Exception e) {
-                                        // nothing to close
+                                    if(!JoinstrPublisher.publish(identity, pool.getRelay(), encrypted_event)) {
+                                        javafx.application.Platform.runLater(() ->
+                                                AppServices.showErrorDialog("Join Request Not Sent",
+                                                        JoinstrTransport.NOT_READY));
+                                        return;
                                     }
 
                                     Logger.getLogger(JoinstrPoolList.class.getName())

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PublishProxyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PublishProxyTest.java
@@ -1,0 +1,54 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import nostr.context.impl.DefaultRequestContext;
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Publishing must carry the proxy. The nostr api's own send builds a context internally with only
+ * the private key and the relay, so an event sent that way leaves by whatever route the JVM
+ * defaults to. Since the JVM wide socks property was removed, that is not Tor.
+ */
+public class PublishProxyTest {
+
+    private static final String RELAY = "wss://nos.lol";
+
+    @Test
+    public void thePublishContextCarriesTheProxy() {
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("127.0.0.1", 9050));
+
+        DefaultRequestContext context = JoinstrPublisher.context(
+                Identity.generateRandomIdentity(), RELAY, proxy);
+
+        assertSame(proxy, context.getProxy(), "a publish would not go through Tor");
+    }
+
+    @Test
+    public void thePublishContextCarriesTheRelayAndKey() {
+        Identity identity = Identity.generateRandomIdentity();
+
+        DefaultRequestContext context = JoinstrPublisher.context(identity, RELAY, null);
+
+        assertTrue(context.getRelays().containsValue(RELAY));
+        assertArrayEquals(identity.getPrivateKey().getRawData(), context.getPrivateKey());
+        assertNull(context.getProxy());
+    }
+
+    /** Without Tor there is no proxy, and publishing is refused rather than going out in clear. */
+    @Test
+    public void nothingIsPublishedWithoutTor() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+        try {
+            assertNull(JoinstrTransport.proxy());
+            assertFalse(JoinstrPublisher.publish(Identity.generateRandomIdentity(), RELAY, null));
+        } finally {
+            JoinstrTransport.setTorRunningForTesting(null);
+        }
+    }
+}


### PR DESCRIPTION
Regression from #90. Publishes have not been going through Tor since that merged.

## The bug

`Nostr.send(IEvent, relays)` in the nostr api builds its **own** `DefaultRequestContext`, carrying only the private key and the relay, and pushes it through the shared client:

```java
public void send(@NonNull IEvent event, Map<String, String> relays) {
    var context = new DefaultRequestContext();
    context.setPrivateKey(getSender().getPrivateKey().getRawData());
    context.setRelays(relays);
    send(new EventMessage(event), context);
}
```

No proxy. Before #90 that did not matter, because the JVM wide `socksProxyHost` property routed everything through Tor. #90 removed that property and set the proxy per connection instead, but every publish went through `nip04.send` / `nip01.send`, which discards the context we built.

So since #90: the pool announcement, the join request, the credentials, the output registration and the input registration all left over clearnet. Circuit rotation still ran, rotating a circuit nothing was using.

## Changes

- New `JoinstrPublisher.publish`, which builds the context with the proxy, connects its own client, sends the `EventMessage` itself, and closes.
- All five publish sites use it. No `nip04.send` or `nip01.send` remains in the joinstr package.
- `NostrListener` builds its subscription context through the same helper.
- Removed an unreachable branch in `JoinstrPoolList`: the Join button is disabled for unsupported pools, so the guard inside its action handler could never run.

`Client.send` is fire and forget with no completion signal, so the publisher waits briefly before closing the connection or the message can be dropped. Not elegant; the api gives nothing better to wait on.

## Tests

- the publish context carries the proxy, the relay and the key
- with Tor down there is no proxy and nothing is published

243 unit tests green, and the three peer integration tests still pass against a local relay.

## Note

Worth checking on regtest that publishes still arrive with a real Tor proxy in the path. The integration test uses a plain ws relay with no proxy, so it exercises the send path but not the proxy itself.
