### PR TITLE
fix: show why a pool cannot be joined, stop reusing output addresses, confirm publishes

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -291,8 +291,10 @@ public class JoinPoolHandler {
             Storage storage = selectedWallet.getValue();
 
             WalletForm walletForm = new WalletForm(storage, wallet);
-            NodeEntry freshEntry = walletForm.getFreshNodeEntry(KeyPurpose.RECEIVE, null);
-            Address myOutputAddress = freshEntry.getAddress();
+            Address myOutputAddress = OutputAddress.fresh(walletForm);
+            if (myOutputAddress == null) {
+                throw new IllegalStateException("no receive address available for the coinjoin");
+            }
 
             coinjoinHandler = new CoinjoinHandler(poolIdentity, pool, wallet, storage, statusCallback);
             coinjoinHandler.setFeeRate(feeRate);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -29,6 +29,7 @@ public class JoinstrPool {
     private String privateKey;
     private String poolId = "";
     private String unsupportedReason;
+    private String requirement;
     private String feeRate = "1";
     private JoinPoolHandler handler;
 
@@ -87,6 +88,15 @@ public class JoinstrPool {
 
     public void setUnsupportedReason(String unsupportedReason) {
         this.unsupportedReason = unsupportedReason;
+    }
+
+    /** What this pool demands of a joiner, if anything. */
+    public String getRequirement() {
+        return requirement;
+    }
+
+    public void setRequirement(String requirement) {
+        this.requirement = requirement;
     }
 
     public boolean isJoinable() {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPublisher.java
@@ -6,9 +6,14 @@ import nostr.event.impl.GenericEvent;
 import nostr.event.message.EventMessage;
 import nostr.id.Identity;
 
+import nostr.event.message.OkMessage;
+
 import java.net.Proxy;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 /**
@@ -24,13 +29,8 @@ public final class JoinstrPublisher {
 
     private static final Logger logger = Logger.getLogger(JoinstrPublisher.class.getName());
 
-    /**
-     * How long to let a send drain before closing the connection.
-     *
-     * {@code Client.send} is fire and forget with no completion signal, so closing immediately can
-     * drop the message on the floor.
-     */
-    private static final long FLUSH_MILLIS = 750;
+    /** How long to wait for the relay to acknowledge an event. */
+    private static final long ACK_TIMEOUT_MILLIS = 10000;
 
     private JoinstrPublisher() {
     }
@@ -44,20 +44,47 @@ public final class JoinstrPublisher {
         return context;
     }
 
-    /** Publish a signed event. Returns false if it could not be sent. */
+    /**
+     * Publish a signed event and wait for the relay to accept it.
+     *
+     * {@code Client.send} is fire and forget, so without waiting for the relay's OK a publish that
+     * never arrived looks the same as one that did, and the pool stalls with no explanation. The
+     * relay's acknowledgement is delivered through the same message listener that carries events.
+     */
     public static boolean publish(Identity as, String relay, GenericEvent signedEvent) {
         if (!JoinstrTransport.newCircuit()) {
             logger.warning("Not publishing: tor is not running");
             return false;
         }
 
+        String eventId = signedEvent.getId();
+        CountDownLatch acknowledged = new CountDownLatch(1);
+        AtomicBoolean accepted = new AtomicBoolean(false);
+
         Client client = new Client();
         try {
-            client.connect(context(as, relay, JoinstrTransport.proxy()));
+            DefaultRequestContext context = context(as, relay, JoinstrTransport.proxy());
+            context.setMessageListener((message, source) -> {
+                if (message instanceof OkMessage ok
+                        && (eventId == null || eventId.equals(ok.getEventId()))) {
+                    accepted.set(Boolean.TRUE.equals(ok.getFlag()));
+                    if (!accepted.get()) {
+                        logger.warning("Relay rejected an event: " + ok.getMessage());
+                    }
+                    acknowledged.countDown();
+                }
+            });
+
+            client.connect(context);
             client.send(new EventMessage(signedEvent));
 
-            Thread.sleep(FLUSH_MILLIS);
-            return true;
+            if (!acknowledged.await(ACK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                logger.warning("Relay did not acknowledge an event within "
+                        + (ACK_TIMEOUT_MILLIS / 1000) + "s");
+                return false;
+            }
+
+            return accepted.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return false;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -45,8 +45,7 @@ public class NostrPublisher implements AutoCloseable {
     public Address getNewReceiveAddress(Storage storage, Wallet wallet) {
         WalletForm walletForm = new WalletForm(storage, wallet);
         EventManager.get().register(walletForm);
-        NodeEntry freshEntry = walletForm.getFreshNodeEntry(KeyPurpose.RECEIVE, null);
-        return freshEntry.getAddress();
+        return OutputAddress.fresh(walletForm);
     }
 
     public GenericEvent publishCustomEvent(String denomination, String peers, String bitcoinAddress,

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -186,6 +186,8 @@ public class OtherPoolsController extends JoinstrFormController {
             pool.setPoolId(poolData.get("id").asText());
         }
 
+        pool.setRequirement(PoolSupport.autctRequirement(poolData));
+
         String unsupported = PoolSupport.unsupportedReason(poolData);
         pool.setUnsupportedReason(unsupported);
         if (unsupported != null) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OutputAddress.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OutputAddress.java
@@ -1,0 +1,63 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.KeyPurpose;
+import com.sparrowwallet.drongo.address.Address;
+import com.sparrowwallet.sparrow.wallet.NodeEntry;
+import com.sparrowwallet.sparrow.wallet.WalletForm;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Picks the output address a pool pays to.
+ *
+ * A wallet hands out the first address it has not seen used, so two pools in a row get the same
+ * one whenever the first pool did not complete. Two coinjoins paying the same address is the
+ * reuse a coinjoin is meant to avoid, so an address handed to one pool is not offered again.
+ */
+public final class OutputAddress {
+
+    /** How far to look before giving up and taking whatever the wallet offers. */
+    private static final int MAX_LOOKAHEAD = 100;
+
+    private static final Set<String> reserved = ConcurrentHashMap.newKeySet();
+
+    private OutputAddress() {
+    }
+
+    /** The first candidate not already promised to a pool, reserving it. */
+    static String reserveFirstFree(Supplier<String> candidates) {
+        String last = null;
+        for (int i = 0; i < MAX_LOOKAHEAD; i++) {
+            String candidate = candidates.get();
+            if (candidate == null || candidate.equals(last)) {
+                // the wallet has stopped producing new addresses
+                break;
+            }
+            last = candidate;
+            if (reserved.add(candidate)) {
+                return candidate;
+            }
+        }
+        return last;
+    }
+
+    /** A receive address this session has not already given to a pool. */
+    public static Address fresh(WalletForm walletForm) {
+        NodeEntry[] cursor = new NodeEntry[1];
+
+        String address = reserveFirstFree(() -> {
+            cursor[0] = walletForm.getFreshNodeEntry(KeyPurpose.RECEIVE, cursor[0]);
+            return cursor[0] == null || cursor[0].getAddress() == null
+                    ? null
+                    : cursor[0].getAddress().toString();
+        });
+
+        return address == null || cursor[0] == null ? null : cursor[0].getAddress();
+    }
+
+    static void resetForTesting() {
+        reserved.clear();
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolSupport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolSupport.java
@@ -36,6 +36,30 @@ public final class PoolSupport {
         return transportReason(poolData.get("transport"));
     }
 
+    /**
+     * What an aut-ct pool demands of a joiner, or null if it demands nothing.
+     *
+     * Shown so a user can see what the pool wants even though this client cannot satisfy it. The
+     * reference implementation shows the same three fields in its pool list.
+     */
+    public static String autctRequirement(JsonNode poolData) {
+        if (poolData == null || !requiresAutct(poolData)) {
+            return null;
+        }
+
+        JsonNode autct = poolData.get("autct");
+        StringBuilder requirement = new StringBuilder();
+        requirement.append(autct.path("min_amount").asLong(0)).append(" sats");
+        requirement.append(", ").append(autct.path("min_confirmations").asInt(0)).append(" confs");
+
+        String scriptType = autct.path("script_type").asText("");
+        if (!scriptType.isEmpty()) {
+            requirement.append(", ").append(scriptType);
+        }
+
+        return requirement.toString();
+    }
+
     private static boolean requiresAutct(JsonNode poolData) {
         JsonNode autct = poolData.get("autct");
         if (autct == null || autct.isNull()) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -16,6 +16,8 @@ public class JoinstrInfoPane extends VBox {
     private Label denominationValueLabel;
     private Label feeRateValueLabel;
     private Label statusValueLabel;
+    private Label requirementLabel;
+    private Label requirementValueLabel;
     private Label unsupportedLabel;
     private Label unsupportedValueLabel;
 
@@ -62,6 +64,10 @@ public class JoinstrInfoPane extends VBox {
         statusLabel.getStyleClass().add("text-grey");
         statusValueLabel = new Label();
 
+        requirementLabel = new Label("Requirements:");
+        requirementLabel.getStyleClass().add("text-grey");
+        requirementValueLabel = new Label();
+
         unsupportedLabel = new Label("Not supported:");
         unsupportedLabel.getStyleClass().add("text-grey");
         unsupportedValueLabel = new Label();
@@ -73,6 +79,7 @@ public class JoinstrInfoPane extends VBox {
             denominationValueLabel.setStyle("-fx-text-fill: white;");
             feeRateValueLabel.setStyle("-fx-text-fill: white;");
             statusValueLabel.setStyle("-fx-text-fill: white;");
+            requirementValueLabel.setStyle("-fx-text-fill: white;");
             unsupportedValueLabel.setStyle("-fx-text-fill: white;");
         }
 
@@ -86,8 +93,13 @@ public class JoinstrInfoPane extends VBox {
         detailsGrid.add(feeRateValueLabel, 1, 3);
         detailsGrid.add(statusLabel, 0, 4);
         detailsGrid.add(statusValueLabel, 1, 4);
-        detailsGrid.add(unsupportedLabel, 0, 5);
-        detailsGrid.add(unsupportedValueLabel, 1, 5);
+        detailsGrid.add(requirementLabel, 0, 5);
+        detailsGrid.add(requirementValueLabel, 1, 5);
+        detailsGrid.add(unsupportedLabel, 0, 6);
+        detailsGrid.add(unsupportedValueLabel, 1, 6);
+
+        requirementLabel.managedProperty().bind(requirementLabel.visibleProperty());
+        requirementValueLabel.managedProperty().bind(requirementValueLabel.visibleProperty());
 
         // the row only appears for a pool this client cannot complete
         unsupportedLabel.managedProperty().bind(unsupportedLabel.visibleProperty());
@@ -105,9 +117,18 @@ public class JoinstrInfoPane extends VBox {
             feeRateValueLabel.setText(com.sparrowwallet.sparrow.joinstr.CoinjoinMath.formatFeeRate(pool.getParsedFeeRate()) + " sat/vB");
             statusValueLabel.textProperty().bind(pool.statusProperty());
             showUnsupported(pool.getUnsupportedReason());
+            showRequirement(pool.getRequirement());
         } else {
             clearPoolInfo();
         }
+    }
+
+    /** Show what a pool demands of a joiner, or hide the row when it demands nothing. */
+    private void showRequirement(String requirement) {
+        boolean show = requirement != null && !requirement.isEmpty();
+        requirementValueLabel.setText(show ? requirement : "");
+        requirementLabel.setVisible(show);
+        requirementValueLabel.setVisible(show);
     }
 
     /** Show why a pool cannot be joined, or hide the row when it can. */
@@ -126,5 +147,6 @@ public class JoinstrInfoPane extends VBox {
         statusValueLabel.textProperty().unbind();
         statusValueLabel.setText("");
         showUnsupported(null);
+        showRequirement(null);
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -16,6 +16,8 @@ public class JoinstrInfoPane extends VBox {
     private Label denominationValueLabel;
     private Label feeRateValueLabel;
     private Label statusValueLabel;
+    private Label unsupportedLabel;
+    private Label unsupportedValueLabel;
 
     public JoinstrInfoPane() {
         if(Config.get().getTheme() == Theme.DARK) {
@@ -60,12 +62,18 @@ public class JoinstrInfoPane extends VBox {
         statusLabel.getStyleClass().add("text-grey");
         statusValueLabel = new Label();
 
+        unsupportedLabel = new Label("Not supported:");
+        unsupportedLabel.getStyleClass().add("text-grey");
+        unsupportedValueLabel = new Label();
+        unsupportedValueLabel.setWrapText(true);
+
         if(Config.get().getTheme() == Theme.DARK) {
             relayValueLabel.setStyle("-fx-text-fill: white;");
             pubkeyValueLabel.setStyle("-fx-text-fill: white;");
             denominationValueLabel.setStyle("-fx-text-fill: white;");
             feeRateValueLabel.setStyle("-fx-text-fill: white;");
             statusValueLabel.setStyle("-fx-text-fill: white;");
+            unsupportedValueLabel.setStyle("-fx-text-fill: white;");
         }
 
         detailsGrid.add(relayLabel, 0, 0);
@@ -78,6 +86,13 @@ public class JoinstrInfoPane extends VBox {
         detailsGrid.add(feeRateValueLabel, 1, 3);
         detailsGrid.add(statusLabel, 0, 4);
         detailsGrid.add(statusValueLabel, 1, 4);
+        detailsGrid.add(unsupportedLabel, 0, 5);
+        detailsGrid.add(unsupportedValueLabel, 1, 5);
+
+        // the row only appears for a pool this client cannot complete
+        unsupportedLabel.managedProperty().bind(unsupportedLabel.visibleProperty());
+        unsupportedValueLabel.managedProperty().bind(unsupportedValueLabel.visibleProperty());
+        showUnsupported(null);
 
         getChildren().add(detailsGrid);
     }
@@ -89,9 +104,18 @@ public class JoinstrInfoPane extends VBox {
             denominationValueLabel.setText(pool.getDenomination());
             feeRateValueLabel.setText(com.sparrowwallet.sparrow.joinstr.CoinjoinMath.formatFeeRate(pool.getParsedFeeRate()) + " sat/vB");
             statusValueLabel.textProperty().bind(pool.statusProperty());
+            showUnsupported(pool.getUnsupportedReason());
         } else {
             clearPoolInfo();
         }
+    }
+
+    /** Show why a pool cannot be joined, or hide the row when it can. */
+    private void showUnsupported(String reason) {
+        boolean show = reason != null && !reason.isEmpty();
+        unsupportedValueLabel.setText(show ? reason : "");
+        unsupportedLabel.setVisible(show);
+        unsupportedValueLabel.setVisible(show);
     }
 
     public void clearPoolInfo() {
@@ -101,5 +125,6 @@ public class JoinstrInfoPane extends VBox {
         feeRateValueLabel.setText("");
         statusValueLabel.textProperty().unbind();
         statusValueLabel.setText("");
+        showUnsupported(null);
     }
 }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -27,6 +27,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 
@@ -177,6 +178,7 @@ public class JoinstrPoolList extends VBox {
             public TableCell<JoinstrPool, Void> call(final TableColumn<JoinstrPool, Void> param) {
                 return new TableCell<>() {
                     private final Button joinButton = new Button("Join");
+                    private final StackPane joinButtonHolder = new StackPane(joinButton);
                     {
                         joinButton.setStyle(
                                 "-fx-background-color: #2196F3; " +
@@ -265,12 +267,15 @@ public class JoinstrPoolList extends VBox {
                         // a pool this client cannot complete is still listed, so the reason is
                         // visible, but joining it would only wait for a reply that never comes
                         joinButton.setDisable(!joinable);
-                        joinButton.setTooltip(joinable ? null : new Tooltip(pool.getUnsupportedReason()));
+                        // a disabled node receives no mouse events, so the tooltip goes on the
+                        // wrapper, which stays enabled
+                        Tooltip.install(joinButtonHolder,
+                                joinable ? null : new Tooltip(pool.getUnsupportedReason()));
                         joinButton.setStyle(joinable
                                 ? "-fx-background-color: #2196F3; -fx-text-fill: white; -fx-cursor: hand;"
                                 : "-fx-background-color: #666666; -fx-text-fill: #cccccc;");
 
-                        setGraphic(joinButton);
+                        setGraphic(joinButtonHolder);
                     }
                 };
             }

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/OutputAddressTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/OutputAddressTest.java
@@ -1,0 +1,69 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A wallet hands out the first address it has not seen used on chain. A pool that never completes
+ * leaves its address unused, so the next pool is handed the same one and two coinjoins pay the
+ * same address.
+ */
+public class OutputAddressTest {
+
+    @BeforeEach
+    @AfterEach
+    public void reset() {
+        OutputAddress.resetForTesting();
+    }
+
+    /** Walks a fixed list the way the wallet walks its receive addresses. */
+    private java.util.function.Supplier<String> walletOffering(List<String> addresses) {
+        AtomicInteger index = new AtomicInteger();
+        return () -> {
+            int i = index.getAndIncrement();
+            return i < addresses.size() ? addresses.get(i) : addresses.get(addresses.size() - 1);
+        };
+    }
+
+    @Test
+    public void theFirstPoolGetsTheFirstAddress() {
+        assertEquals("a", OutputAddress.reserveFirstFree(walletOffering(List.of("a", "b", "c"))));
+    }
+
+    /** The case that matters: a pool that did not complete leaves its address unused. */
+    @Test
+    public void asecondPoolDoesNotGetTheSameAddress() {
+        assertEquals("a", OutputAddress.reserveFirstFree(walletOffering(List.of("a", "b", "c"))));
+        assertEquals("b", OutputAddress.reserveFirstFree(walletOffering(List.of("a", "b", "c"))));
+        assertEquals("c", OutputAddress.reserveFirstFree(walletOffering(List.of("a", "b", "c"))));
+    }
+
+    @Test
+    public void reservationsSurviveAcrossManyPools() {
+        List<String> wallet = List.of("a", "b", "c", "d", "e");
+        for(String expected : wallet) {
+            assertEquals(expected, OutputAddress.reserveFirstFree(walletOffering(wallet)));
+        }
+    }
+
+    /** When the wallet stops producing new addresses, take the last rather than loop. */
+    @Test
+    public void anExhaustedWalletStillReturnsAnAddress() {
+        assertEquals("a", OutputAddress.reserveFirstFree(walletOffering(List.of("a"))));
+
+        String again = OutputAddress.reserveFirstFree(walletOffering(List.of("a")));
+
+        assertEquals("a", again, "an exhausted wallet should still yield something to pay to");
+    }
+
+    @Test
+    public void anEmptyWalletYieldsNothing() {
+        assertNull(OutputAddress.reserveFirstFree(() -> null));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolSupportTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolSupportTest.java
@@ -90,6 +90,29 @@ public class PoolSupportTest {
         assertEquals(PoolSupport.REQUIRES_AUTCT, reason);
     }
 
+    /** Shown so a user can see what an aut-ct pool wants, even though we cannot satisfy it. */
+    @Test
+    public void theAutctRequirementIsDescribed() throws Exception {
+        String requirement = PoolSupport.autctRequirement(pool(
+                ",\"autct\":{\"keyset\":\"autct-830000-100000-6-2-1024.aks\",\"min_amount\":100000,"
+                + "\"min_confirmations\":6,\"script_type\":\"p2tr\"}"));
+
+        assertEquals("100000 sats, 6 confs, p2tr", requirement);
+    }
+
+    @Test
+    public void aRequirementWithoutAScriptTypeOmitsIt() throws Exception {
+        assertEquals("100000 sats, 0 confs", PoolSupport.autctRequirement(pool(
+                ",\"autct\":{\"keyset\":\"autct-1-2-3-4-5.aks\",\"min_amount\":100000}")));
+    }
+
+    @Test
+    public void aPoolWithNoAutctHasNoRequirement() throws Exception {
+        assertNull(PoolSupport.autctRequirement(pool("")));
+        assertNull(PoolSupport.autctRequirement(pool(",\"autct\":{}")));
+        assertNull(PoolSupport.autctRequirement(null));
+    }
+
     @Test
     public void aMissingAnnouncementIsNotRefused() {
         assertNull(PoolSupport.unsupportedReason(null));

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/TestPoolPublisher.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/TestPoolPublisher.java
@@ -21,7 +21,6 @@ final class TestPoolPublisher {
     }
 
     static boolean publish(Identity poolIdentity, String relay, String content) {
-        Client client = new Client();
         try {
             List<BaseTag> tags = new ArrayList<>();
             tags.add(new PubKeyTag(poolIdentity.getPublicKey()));
@@ -34,22 +33,10 @@ final class TestPoolPublisher {
             nip04.setEvent(event);
             nip04.sign();
 
-            DefaultRequestContext context = new DefaultRequestContext();
-            context.setPrivateKey(poolIdentity.getPrivateKey().getRawData());
-            context.setRelays(new LinkedHashMap<>(Map.of("default", relay)));
-            client.connect(context);
-
-            nip04.send(Map.of("default", relay));
-            Thread.sleep(400);
-            return true;
+            // the production publish path, so the test covers waiting for the relay's OK
+            return JoinstrPublisher.publish(poolIdentity, relay, event);
         } catch (Exception e) {
             return false;
-        } finally {
-            try {
-                client.disconnect();
-            } catch (Exception e) {
-                // nothing to close
-            }
         }
     }
 }


### PR DESCRIPTION
Three gaps found by reading the plugin and its merged MRs.

## 1. The unsupported reason was invisible

An aut-ct or non-Tor pool showed "Unsupported" in the status column with the reason in a tooltip on the **disabled** Join button. JavaFX does not deliver mouse events to disabled nodes, so that tooltip never appears.

- The info pane gains a "Not supported:" row, shown only for a pool that cannot be joined.
- The tooltip moves to a wrapper around the button, which stays enabled.
- The info pane also gains a "Requirements:" row showing an aut-ct pool's demands, `100000 sats, 6 confs, p2tr`, matching the Requirements column in the plugin's pool list (`qt.py:580-590`).

## 2. Output address reuse across pools (plugin MR !35)

`getFreshNodeEntry` returns the first address the wallet has not seen used on chain. A pool that never completes leaves its address unused, so the next pool is handed the same one and two coinjoins pay the same address.

The plugin reserves addresses for exactly this (`_get_fresh_address`, `joinstr.py:844`). `OutputAddress` does the same: an address given to one pool is not offered again this session.

Same limitation as the plugin: reservations are in memory, so a restart can hand out an address a previous session reserved.

## 3. Publishes were not confirmed (plugin MR !27)

`Client.send` is fire and forget. `JoinstrPublisher` slept 750ms and reported success, so an event that never reached the relay looked identical to one that did and the pool stalled with no explanation.

It now waits for the relay's `OK` for that event id, up to 10s, and reports failure if the relay rejects it or says nothing. The acknowledgement arrives through the same message listener that carries events.

## Checked and not affected

- **MR !23**, sorting pool outputs, only changed `gui/joinstr-web.py`. The plugin still does not sort in phase 2, so #86 stands.
- **MR !33**, wtxid logged instead of txid, does not apply: drongo has both and this uses `getTxId()`.
- **MRs !40 !41 !42 !44 !45 !46 !47 !48 !52 !56 !57 !58** are already covered.
- **MRs !43 !53** are aut-ct proof generation, not implemented here.
- **MR !50** is resume after restart, which this client does not do.

## Tests

251 unit tests green; the three peer integration tests pass, and now go through `JoinstrPublisher`, so they cover the relay acknowledgement too.
