### PR TITLE
autct: sybil resistance for pools

### DIFF
--- a/.github/scripts/make-autct-keyset.py
+++ b/.github/scripts/make-autct-keyset.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Build a small aut-ct keyset for testing, plus the WIF that can prove against it.
+
+A real keyset is a snapshot of the taproot UTXO set, produced with bitcoin-cli dumptxoutset,
+utxo_to_sqlite and aut-ct's filter_utxos.py. This makes an equivalent one from made up keys so a
+local autct server can be exercised without a synced node.
+
+Two details decide whether autct accepts it, and neither is written down:
+
+  1. The file is one line of space separated x-only hex, because filter_utxos.py writes
+     " ".join(scriptpubkey[4:]), stripping the 5120 prefix off each taproot output script.
+  2. The entries are taproot OUTPUT keys, not internal keys. The server applies BIP-341
+     tap_tweak to the proving key before looking it up (see lib.rs, tap_tweak(&secp, None)),
+     so an untweaked key gives error -8, "provided key is not in the keyset".
+
+Usage:
+    python3 make-autct-keyset.py            # writes keyset.aks and mywif.txt
+    autct -M serve -k mycontext:keyset.aks -n regtest -p 23333
+"""
+
+from coincurve import PrivateKey, PublicKey
+import hashlib
+
+N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+def wif(b):
+    payload = b'\xef' + b + b'\x01'
+    chk = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    alpha = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+    n = int.from_bytes(payload + chk, 'big'); out = ''
+    while n:
+        n, r = divmod(n, 58); out = alpha[r] + out
+    return out
+
+def tagged(tag, msg):
+    t = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(t + t + msg).digest()
+
+def taproot_output_xonly(k_int):
+    """BIP-341 key path tweak with no script tree, as bitcoin's tap_tweak(None) does."""
+    p = PrivateKey.from_int(k_int)
+    if p.public_key.format()[0] == 3:          # BIP-340: use the even-y internal key
+        k_int = N - k_int
+        p = PrivateKey.from_int(k_int)
+    xonly = p.public_key.format()[1:]
+    t = int.from_bytes(tagged("TapTweak", xonly), "big") % N
+    Q = PublicKey.combine_keys([p.public_key, PrivateKey.from_int(t).public_key])
+    return p, Q.format()[1:].hex()
+
+keys = []
+for i in range(60):
+    _, q = taproot_output_xonly(7000000 + i)
+    keys.append(q)
+
+p, q = taproot_output_xonly(9000003)
+keys.append(q)
+open("keyset.aks", "wb").write((" ".join(keys)).encode())
+open("mywif.txt", "w").write(wif(p.secret))
+print("taproot output key in keyset:", q)
+print("wrote", len(keys), "output keys")

--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -94,6 +94,7 @@ public class Config {
 
     // Joinstr settings
     private String nostrRelay;
+    private String autctApiUrl;
     private ArrayList<JoinstrPool> poolStore;
     private ArrayList<JoinstrHistoryEntry> historyStore;
 
@@ -789,6 +790,15 @@ public class Config {
 
     public String getNostrRelay() {
         return nostrRelay;
+    }
+
+    public String getAutctApiUrl() {
+        return autctApiUrl;
+    }
+
+    public void setAutctApiUrl(String autctApiUrl) {
+        this.autctApiUrl = autctApiUrl;
+        flush();
     }
 
     public void setNostrRelay(String nostrRelay) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctClient.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctClient.java
@@ -1,0 +1,248 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Talks to a local aut-ct server.
+ *
+ * aut-ct proves ownership of a UTXO in a published keyset without saying which one, so a pool can
+ * demand one proof per UTXO and make sybil peers expensive. The server speaks a websocket RPC of
+ * its own: two binary frames out, a header then the body, and two frames back, an ack then the
+ * response.
+ */
+public class AutctClient {
+
+    private static final Logger logger = Logger.getLogger(AutctClient.class.getName());
+    private static final Gson GSON = new Gson();
+
+    public static final String DEFAULT_API_URL = "ws://127.0.0.1:23333";
+
+    /** aut-ct answers prove with 0 and verify with 1 on success. */
+    private static final int PROVE_ACCEPTED = 0;
+    private static final int VERIFY_ACCEPTED = 1;
+
+    private static final long TIMEOUT_SECONDS = 180;
+
+    private final String apiUrl;
+
+    public AutctClient(String apiUrl) {
+        this.apiUrl = apiUrl == null || apiUrl.isBlank() ? DEFAULT_API_URL : apiUrl.trim();
+    }
+
+    /** A generated proof and the key image that identifies the UTXO behind it. */
+    public record Proof(String proof, String keyImage) {
+    }
+
+    /** A verification result. The key image comes from the verifier, never from the sender. */
+    public record Verification(boolean valid, String keyImage) {
+    }
+
+    /** Whether a server is listening. Opens a connection and closes it without a request. */
+    public boolean isReachable() {
+        try {
+            WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                    .connectTimeout(java.time.Duration.ofSeconds(5))
+                    .buildAsync(URI.create(apiUrl), new WebSocket.Listener() {
+                    }).get(10, TimeUnit.SECONDS);
+            socket.sendClose(WebSocket.NORMAL_CLOSURE, "health check");
+            return true;
+        } catch (Exception e) {
+            logger.fine("aut-ct server is not reachable: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Prove ownership of the UTXO behind {@code privateKeyWif}.
+     *
+     * The key is written to a temporary file in aut-ct's own encrypted format, because the server
+     * decrypts before parsing and rejects a plaintext WIF.
+     */
+    public Proof generateProof(String privateKeyWif, String keyset, String context) {
+        java.nio.file.Path keyFile = null;
+        try {
+            String password = AutctKeyFile.randomPassword();
+            keyFile = AutctKeyFile.write(privateKeyWif, password);
+
+            JsonObject request = new JsonObject();
+            request.addProperty("keyset", context + ":" + keyset);
+            request.addProperty("depth", 2);
+            request.addProperty("generators_length_log_2", 11);
+            request.addProperty("user_label", context);
+            request.addProperty("privkey_file_loc", keyFile.toString());
+            request.addProperty("bc_network", network());
+            request.addProperty("encryption_password", password);
+
+            JsonObject response = call("RPCProver.prove", request);
+            if (response == null || accepted(response) != PROVE_ACCEPTED) {
+                logger.severe("aut-ct proof generation failed with code " + accepted(response));
+                return null;
+            }
+
+            String proof = optString(response, "proof");
+            String keyImage = optString(response, "key_image");
+            if (proof == null || keyImage == null) {
+                logger.severe("aut-ct proof is missing its proof or key image");
+                return null;
+            }
+
+            return new Proof(proof, keyImage);
+        } catch (Exception e) {
+            logger.severe("aut-ct proof generation error: " + e.getMessage());
+            return null;
+        } finally {
+            AutctKeyFile.delete(keyFile);
+        }
+    }
+
+    /**
+     * Verify a peer's proof.
+     *
+     * The key image returned here is derived by the verifier. Callers must deduplicate on it and
+     * never on anything the peer supplied, or one proof buys every slot in the pool.
+     */
+    public Verification verifyProof(String proof, String keyset, String context) {
+        try {
+            JsonObject request = new JsonObject();
+            request.addProperty("keyset", context + ":" + keyset);
+            request.addProperty("user_label", context);
+            request.addProperty("context_label", context);
+            request.addProperty("application_label", "autct-v1.0");
+            request.addProperty("proof", proof);
+
+            JsonObject response = call("RPCProofVerifier.verify", request);
+            if (response == null || accepted(response) != VERIFY_ACCEPTED) {
+                logger.warning("aut-ct proof rejected with code " + accepted(response));
+                return new Verification(false, null);
+            }
+
+            String keyImage = optString(response, "key_image");
+            if (keyImage == null) {
+                logger.severe("aut-ct accepted a proof but returned no key image");
+                return new Verification(false, null);
+            }
+
+            return new Verification(true, keyImage);
+        } catch (Exception e) {
+            logger.severe("aut-ct verification error: " + e.getMessage());
+            return new Verification(false, null);
+        }
+    }
+
+    private static String network() {
+        return com.sparrowwallet.drongo.Network.get().getName();
+    }
+
+    private static int accepted(JsonObject response) {
+        if (response == null || !response.has("accepted") || response.get("accepted").isJsonNull()) {
+            return Integer.MIN_VALUE;
+        }
+        return response.get("accepted").getAsInt();
+    }
+
+    private static String optString(JsonObject response, String field) {
+        if (!response.has(field) || response.get(field).isJsonNull()) {
+            return null;
+        }
+        String value = response.get(field).getAsString();
+        return value.isEmpty() ? null : value;
+    }
+
+    /** One request: a header frame, then the body, then an ack frame and the response. */
+    JsonObject call(String method, JsonObject body) throws Exception {
+        List<String> received = new ArrayList<>();
+        CompletableFuture<Void>answered = new CompletableFuture<>();
+
+        WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                .connectTimeout(java.time.Duration.ofSeconds(15))
+                .buildAsync(URI.create(apiUrl), new WebSocket.Listener() {
+                    private final StringBuilder buffer = new StringBuilder();
+
+                    @Override
+                    public CompletionStage<?> onBinary(WebSocket ws, ByteBuffer data, boolean last) {
+                        buffer.append(StandardCharsets.UTF_8.decode(data));
+                        if (last) {
+                            received.add(buffer.toString());
+                            buffer.setLength(0);
+                            if (received.size() >= 2) {
+                                answered.complete(null);
+                            }
+                        }
+                        ws.request(1);
+                        return null;
+                    }
+
+                    @Override
+                    public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last) {
+                        buffer.append(data);
+                        if (last) {
+                            received.add(buffer.toString());
+                            buffer.setLength(0);
+                            if (received.size() >= 2) {
+                                answered.complete(null);
+                            }
+                        }
+                        ws.request(1);
+                        return null;
+                    }
+
+                    @Override
+                    public void onError(WebSocket ws, Throwable error) {
+                        answered.completeExceptionally(error);
+                    }
+
+                    @Override
+                    public CompletionStage<?> onClose(WebSocket ws, int status, String reason) {
+                        answered.completeExceptionally(new IllegalStateException("aut-ct closed the connection"));
+                        return null;
+                    }
+                }).get(20, TimeUnit.SECONDS);
+
+        try {
+            socket.sendBinary(ByteBuffer.wrap(header(method).getBytes(StandardCharsets.UTF_8)), true).get();
+            socket.sendBinary(ByteBuffer.wrap(GSON.toJson(body).getBytes(StandardCharsets.UTF_8)), true).get();
+
+            answered.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } finally {
+            try {
+                socket.sendClose(WebSocket.NORMAL_CLOSURE, "done");
+            } catch (Exception e) {
+                logger.fine("Error closing the aut-ct connection: " + e.getMessage());
+            }
+        }
+
+        // The first frame only acknowledges the request and the second carries the answer, but
+        // an error can arrive as a bare string, so take the last frame that is an object.
+        for (int i = received.size() - 1; i >= 0; i--) {
+            try {
+                JsonObject parsed = GSON.fromJson(received.get(i), JsonObject.class);
+                if (parsed != null && parsed.has("accepted")) {
+                    return parsed;
+                }
+            } catch (Exception e) {
+                // not this frame
+            }
+        }
+
+        logger.warning("aut-ct returned no recognisable response: " + received);
+        return null;
+    }
+
+    static String header(String method) {
+        return "{\"Request\": {\"id\": 0, \"service_method\": \"" + method
+                + "\",\"timeout\": {\"secs\": 120,\"nanos\": 0}}}\n";
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctJoin.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctJoin.java
@@ -1,0 +1,119 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.sparrow.AppServices;
+import com.sparrowwallet.sparrow.io.Config;
+import com.sparrowwallet.sparrow.io.Storage;
+
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
+import javafx.scene.layout.VBox;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/** Joining a pool that demands an aut-ct proof. */
+public final class AutctJoin {
+
+    private static final Logger logger = Logger.getLogger(AutctJoin.class.getName());
+
+    public static final String NO_PROOF =
+            "Could not generate the aut-ct proof this pool requires.\n\n"
+                    + "Check that an aut-ct server is running and that the key you gave owns a "
+                    + "Taproot output in the pool's keyset.";
+
+    /** Returned when the user wants the wallet to pick a coin rather than typing a key. */
+    static final String USE_WALLET = "";
+
+    private AutctJoin() {
+    }
+
+    /**
+     * Ask for the Taproot key to prove with.
+     *
+     * Blank means use a coin from the wallet, which only a Taproot wallet can do. Returns null if
+     * the user cancels.
+     */
+    public static String askForProvingKey(JoinstrPool pool) {
+        Dialog<String> dialog = new Dialog<>();
+        dialog.setTitle("aut-ct Proving Key");
+        DialogPane pane = dialog.getDialogPane();
+        AppServices.setStageIcon(pane.getScene().getWindow());
+        pane.getButtonTypes().addAll(ButtonType.CANCEL, ButtonType.OK);
+
+        Label explain = new Label("This pool requires an aut-ct proof"
+                + (pool.getRequirement() == null ? "" : " (" + pool.getRequirement() + ")") + ".\n\n"
+                + "Enter the WIF of a Taproot key whose output is in the keyset, or leave it blank "
+                + "to prove with a Taproot coin from this wallet.");
+        explain.setWrapText(true);
+
+        PasswordField wif = new PasswordField();
+        wif.setPromptText("Taproot WIF, or blank to use this wallet");
+
+        VBox content = new VBox(10, explain, wif);
+        content.setPrefWidth(460);
+        pane.setContent(content);
+
+        // the converter has to be in place before the dialog is shown
+        dialog.setResultConverter(button -> button == ButtonType.OK ? wif.getText() : null);
+
+        Optional<String> answer = dialog.showAndWait();
+        if (answer.isEmpty() || answer.get() == null) {
+            return null;
+        }
+
+        String typed = answer.get().trim();
+        if (!typed.isEmpty() && !ProvingKey.looksLikeWif(typed)) {
+            AppServices.showErrorDialog("Invalid Key", "That does not look like a WIF private key.");
+            return null;
+        }
+        return typed;
+    }
+
+    /**
+     * Generate the proof for a pool, from a typed key or a wallet coin.
+     *
+     * This talks to the aut-ct server and can take a while, so it must not run on the fx thread.
+     */
+    public static String proveFor(JoinstrPool pool, String typedProvingKey) {
+        String keyset = pool.getAutctKeyset();
+        if (keyset == null || keyset.isEmpty()) {
+            return null;
+        }
+
+        String wif = typedProvingKey != null && ProvingKey.looksLikeWif(typedProvingKey)
+                ? typedProvingKey.trim()
+                : walletProvingKey(pool);
+
+        if (wif == null) {
+            logger.severe("No Taproot key available for the aut-ct proof");
+            return null;
+        }
+
+        AutctClient client = new AutctClient(Config.get().getAutctApiUrl());
+        AutctClient.Proof proof = client.generateProof(wif, keyset,
+                AutctPool.context(pool.getPoolId(), pool.getPubkey()));
+
+        return proof == null ? null : proof.proof();
+    }
+
+    private static String walletProvingKey(JoinstrPool pool) {
+        try {
+            Map<Wallet, Storage> wallets = AppServices.get().getOpenWallets();
+            for (Wallet wallet : wallets.keySet()) {
+                String wif = ProvingKey.fromWallet(wallet, AppServices.getCurrentBlockHeight(),
+                        0, 0, "p2tr");
+                if (wif != null) {
+                    return wif;
+                }
+            }
+        } catch (Exception e) {
+            logger.severe("Could not take a proving key from the wallet: " + e.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctKeyFile.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctKeyFile.java
@@ -1,0 +1,115 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.bouncycastle.crypto.digests.Blake2bDigest;
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.modes.GCMSIVBlockCipher;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+
+/**
+ * Writes a proving key in the format aut-ct expects.
+ *
+ * aut-ct decrypts the key file before parsing it, so a plaintext WIF is refused. The format is
+ * from aut-ct's own encryption.rs: Argon2i derives the key, AES-256-GCM-SIV encrypts the WIF, and
+ * the pieces are laid out as a little endian u64 length, the ciphertext, a 12 byte nonce and a
+ * 32 byte salt.
+ */
+public final class AutctKeyFile {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private static final int SALT_LENGTH = 32;
+    private static final int NONCE_LENGTH = 12;
+    private static final int KEY_LENGTH = 32;
+    private static final int ITERATIONS = 3;
+    private static final int MEMORY_KB = 4096;
+    private static final int PARALLELISM = 1;
+
+    private AutctKeyFile() {
+    }
+
+    public static String randomPassword() {
+        byte[] password = new byte[16];
+        SECURE_RANDOM.nextBytes(password);
+        return HexFormat.of().formatHex(password);
+    }
+
+    /** The encrypted file body for a WIF. */
+    static byte[] encrypt(String wif, String password, byte[] salt, byte[] nonce) {
+        Argon2BytesGenerator argon2 = new Argon2BytesGenerator();
+        argon2.init(new Argon2Parameters.Builder(Argon2Parameters.ARGON2_i)
+                .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+                .withIterations(ITERATIONS)
+                .withMemoryAsKB(MEMORY_KB)
+                .withParallelism(PARALLELISM)
+                .withSalt(salt)
+                .build());
+
+        byte[] key = new byte[KEY_LENGTH];
+        argon2.generateBytes(password.getBytes(StandardCharsets.UTF_8), key);
+
+        GCMSIVBlockCipher cipher = new GCMSIVBlockCipher(AESEngine.newInstance());
+        cipher.init(true, new AEADParameters(new KeyParameter(key), 128, nonce));
+
+        byte[] plaintext = wif.getBytes(StandardCharsets.UTF_8);
+        byte[] ciphertext = new byte[cipher.getOutputSize(plaintext.length)];
+        int written = cipher.processBytes(plaintext, 0, plaintext.length, ciphertext, 0);
+        try {
+            written += cipher.doFinal(ciphertext, written);
+        } catch (Exception e) {
+            throw new IllegalStateException("could not encrypt the proving key", e);
+        }
+
+        ByteBuffer body = ByteBuffer.allocate(8 + written + NONCE_LENGTH + SALT_LENGTH)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        body.putLong(written);
+        body.put(ciphertext, 0, written);
+        body.put(nonce);
+        body.put(salt);
+        return body.array();
+    }
+
+    /** Write the proving key to a temporary file only this user can read. */
+    public static Path write(String wif, String password) throws IOException {
+        byte[] salt = new byte[SALT_LENGTH];
+        byte[] nonce = new byte[NONCE_LENGTH];
+        SECURE_RANDOM.nextBytes(salt);
+        SECURE_RANDOM.nextBytes(nonce);
+
+        Path file;
+        try {
+            file = Files.createTempFile("joinstr-proving", ".enc",
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+        } catch (UnsupportedOperationException e) {
+            file = Files.createTempFile("joinstr-proving", ".enc");
+        }
+
+        Files.write(file, encrypt(wif, password, salt, nonce));
+        return file;
+    }
+
+    public static void delete(Path file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            // a proving key left in the temp directory is worth a note but not a failure
+            java.util.logging.Logger.getLogger(AutctKeyFile.class.getName())
+                    .warning("Could not delete a temporary proving key file");
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctPool.java
@@ -1,0 +1,93 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The aut-ct requirement a pool can advertise.
+ *
+ * A keyset name carries the requirement in itself:
+ * {@code autct-<height>-<min amount>-<min confirmations>-<depth>-<branching>.aks}. The name also
+ * reaches an autct server as a command argument, so only that exact shape is accepted.
+ */
+public final class AutctPool {
+
+    private static final Pattern KEYSET = Pattern.compile("^autct-(\\d+)-(\\d+)-(\\d+)-(\\d+)-(\\d+)\\.aks$");
+
+    private AutctPool() {
+    }
+
+    /** Whether this is a keyset name an autct server will accept as an argument. */
+    public static boolean isValidKeyset(String keyset) {
+        return keyset != null && KEYSET.matcher(keyset.trim()).matches();
+    }
+
+    /** The announcement's autct object for a keyset, or null if the name is not one. */
+    public static String announcementJson(String keyset) {
+        if (!isValidKeyset(keyset)) {
+            return null;
+        }
+
+        Matcher matcher = KEYSET.matcher(keyset.trim());
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        long minAmount = Long.parseLong(matcher.group(2));
+        int minConfirmations = Integer.parseInt(matcher.group(3));
+
+        return "{\"keyset\": \"" + keyset.trim() + "\", \"min_amount\": " + minAmount
+                + ", \"min_confirmations\": " + minConfirmations + ", \"script_type\": \"p2tr\"}";
+    }
+
+    /** The keyset a pool demands, or null if it demands none. */
+    public static String keysetOf(JsonNode poolData) {
+        if (poolData == null) {
+            return null;
+        }
+
+        JsonNode autct = poolData.get("autct");
+        if (autct == null || autct.isNull()) {
+            return null;
+        }
+
+        String keyset = autct.path("keyset").asText("").trim();
+        return isValidKeyset(keyset) ? keyset : null;
+    }
+
+    public static long minAmount(JsonNode poolData) {
+        JsonNode autct = poolData == null ? null : poolData.get("autct");
+        return autct == null ? 0 : autct.path("min_amount").asLong(0);
+    }
+
+    public static int minConfirmations(JsonNode poolData) {
+        JsonNode autct = poolData == null ? null : poolData.get("autct");
+        return autct == null ? 0 : autct.path("min_confirmations").asInt(0);
+    }
+
+    /**
+     * The context a proof is bound to.
+     *
+     * It is the hash of the pool id together with the pool key, not the id alone, so a proof
+     * published in one pool cannot be reused by an announcement that copies its id. The value is
+     * hex because it reaches the autct server as a command argument.
+     */
+    public static String context(String poolId, String poolPublicKey) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(((poolId == null ? "" : poolId) + (poolPublicKey == null ? "" : poolPublicKey))
+                            .getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctVerifier.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/AutctVerifier.java
@@ -1,0 +1,75 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+/**
+ * Checks the aut-ct proofs joiners send, on behalf of a pool creator.
+ *
+ * One UTXO buys one slot. The key image that enforces that is the one the verifier derives from
+ * the proof, never anything the joiner supplied alongside it, or a peer varies its own field and
+ * takes every slot in the pool.
+ */
+public class AutctVerifier {
+
+    private static final Logger logger = Logger.getLogger(AutctVerifier.class.getName());
+
+    /** Reasons carried by a reject message, as the reference implementation names them. */
+    public static final String MISSING_PROOF = "missing_proof";
+    public static final String INVALID_PROOF = "invalid_proof";
+    public static final String DUPLICATE_TOKEN = "duplicate_token";
+
+    private final AutctClient client;
+    private final String keyset;
+    private final String context;
+    private final Set<String> usedKeyImages = ConcurrentHashMap.newKeySet();
+
+    public AutctVerifier(AutctClient client, String keyset, String context) {
+        this.client = client;
+        this.keyset = keyset;
+        this.context = context;
+    }
+
+    /**
+     * Reserve a key image before any joiner can present it.
+     *
+     * The creator's own proof is published with the pool, so without this the first peer to
+     * replay it takes a slot for free.
+     */
+    public void reserve(String keyImage) {
+        if (keyImage != null && !keyImage.isEmpty()) {
+            usedKeyImages.add(keyImage);
+        }
+    }
+
+    public boolean hasSeen(String keyImage) {
+        return usedKeyImages.contains(keyImage);
+    }
+
+    public int accepted() {
+        return usedKeyImages.size();
+    }
+
+    /** Why this join request must be refused, or null to accept it. */
+    public String rejectionReason(String autctProof) {
+        if (autctProof == null || autctProof.isBlank()) {
+            logger.warning("Join request carries no aut-ct proof");
+            return MISSING_PROOF;
+        }
+
+        AutctClient.Verification verification = client.verifyProof(autctProof, keyset, context);
+        if (verification == null || !verification.valid() || verification.keyImage() == null) {
+            logger.warning("Join request carries a proof that does not verify");
+            return INVALID_PROOF;
+        }
+
+        // dedup on the verified key image, never on anything the joiner sent
+        if (!usedKeyImages.add(verification.keyImage())) {
+            logger.warning("Join request reuses a key image already spent in this pool");
+            return DUPLICATE_TOKEN;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinPoolHandler.java
@@ -160,6 +160,14 @@ public class JoinPoolHandler {
             return "relay does not match the announcement";
         }
 
+        // a pool that advertised an aut-ct requirement cannot quietly drop or change it in the
+        // credentials, which would put the joiner in a pool with no sybil resistance at all
+        String advertised = pool.getAutctKeyset();
+        if (advertised != null && !advertised.isEmpty()
+                && !advertised.equals(credentials.getAutctKeyset())) {
+            return "aut-ct requirement does not match the announcement";
+        }
+
         return null;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrMessage.java
@@ -19,6 +19,8 @@ public class JoinstrMessage {
     private Long timeout;
     private String relay;
     private String reason;
+    private com.google.gson.JsonObject autct;
+    private String autct_proof;
 
     public String getVersion() {
         return version;
@@ -124,6 +126,28 @@ public class JoinstrMessage {
 
     public void setRelay(String relay) {
         this.relay = relay;
+    }
+
+    /** The aut-ct keyset named in these credentials, or null. */
+    public String getAutctKeyset() {
+        if (autct == null || !autct.has("keyset") || autct.get("keyset").isJsonNull()) {
+            return null;
+        }
+        return autct.get("keyset").getAsString();
+    }
+
+    public void setAutctKeyset(String keyset) {
+        com.google.gson.JsonObject object = new com.google.gson.JsonObject();
+        object.addProperty("keyset", keyset);
+        this.autct = object;
+    }
+
+    public String getAutctProof() {
+        return autct_proof;
+    }
+
+    public void setAutctProof(String autct_proof) {
+        this.autct_proof = autct_proof;
     }
 
     public String getReason() {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -30,6 +30,7 @@ public class JoinstrPool {
     private String poolId = "";
     private String unsupportedReason;
     private String requirement;
+    private String autctKeyset;
     private String feeRate = "1";
     private JoinPoolHandler handler;
 
@@ -90,6 +91,15 @@ public class JoinstrPool {
         this.unsupportedReason = unsupportedReason;
     }
 
+    /** The aut-ct keyset this pool demands, or null. */
+    public String getAutctKeyset() {
+        return autctKeyset;
+    }
+
+    public void setAutctKeyset(String autctKeyset) {
+        this.autctKeyset = autctKeyset;
+    }
+
     /** What this pool demands of a joiner, if anything. */
     public String getRequirement() {
         return requirement;
@@ -128,6 +138,9 @@ public class JoinstrPool {
         credentials.put("timeout", asLong(getTimeout()));
         credentials.put("relay", getRelay());
         credentials.put("fee_rate", getParsedFeeRate());
+        if (autctKeyset != null && !autctKeyset.isEmpty()) {
+            credentials.put("autct", Map.of("keyset", autctKeyset));
+        }
         credentials.put("private_key", privateKey);
         return credentials;
     }

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NewPoolController.java
@@ -43,6 +43,12 @@ public class NewPoolController extends JoinstrFormController {
     @FXML
     private TextField timeoutField;
 
+    @FXML
+    private TextField autctKeysetField;
+
+    @FXML
+    private javafx.scene.control.PasswordField autctProvingKeyField;
+
     @Override
     public void initializeView() {
         Double defaultFeeRate = AppServices.getDefaultFeeRate();
@@ -120,6 +126,12 @@ public class NewPoolController extends JoinstrFormController {
             long timeoutSeconds = PoolParameters.timeoutSeconds(timeoutText,
                     PoolParameters.DEFAULT_TIMEOUT_MINUTES);
 
+            String autctKeyset = autctKeysetField.getText().trim();
+            if(!autctKeyset.isEmpty() && !AutctPool.isValidKeyset(autctKeyset)) {
+                showError("Keyset must be named like autct-830000-100000-1-2-1024.aks");
+                return;
+            }
+
             Address bitcoinAddress;
             Wallet wallet;
 
@@ -155,7 +167,7 @@ public class NewPoolController extends JoinstrFormController {
                 }
 
                 event = nostrPublisher.publishCustomEvent(denomination, peers, bitcoinAddress.toString(),
-                        feeRate, timeoutSeconds);
+                        feeRate, timeoutSeconds, autctKeyset.isEmpty() ? null : autctKeyset);
 
                 if (event == null) {
                     showError("Failed to publish pool event");
@@ -168,6 +180,9 @@ public class NewPoolController extends JoinstrFormController {
                 JoinstrPool pool = new JoinstrPool(joinstrEvent.relay, joinstrEvent.public_key,
                         joinstrEvent.denomination, joinstrEvent.peers, joinstrEvent.timeout, poolPrivateKey);
                 pool.setPoolId(joinstrEvent.id);
+                if(!autctKeyset.isEmpty()) {
+                    pool.setAutctKeyset(autctKeyset);
+                }
                 if (joinstrEvent.fee_rate != null) {
                     pool.setFeeRate(joinstrEvent.fee_rate);
                 }
@@ -185,6 +200,8 @@ public class NewPoolController extends JoinstrFormController {
 
             denominationField.clear();
             peersField.clear();
+            autctKeysetField.clear();
+            autctProvingKeyField.clear();
             feeRateField.clear();
             timeoutField.clear();
 
@@ -220,7 +237,8 @@ public class NewPoolController extends JoinstrFormController {
             coinjoinHandler.startOutputPhase(myOutputAddress);
             logger.info("Pool creator started coinjoin flow");
 
-            shareCredentials(poolIdentity, pool.getRelay(), pool.toCredentials());
+            shareCredentials(poolIdentity, pool.getRelay(), pool.toCredentials(),
+                    autctVerifier(pool, wallet, autctProvingKeyField.getText()));
 
         } catch (Exception e) {
             logger.severe("Error starting creator coinjoin flow: " + e.getMessage());
@@ -277,9 +295,49 @@ public class NewPoolController extends JoinstrFormController {
 
     }
 
-    public static void shareCredentials(Identity poolIdentity, String relayUrl, Map<String, Object> poolCredentials) {
+    /**
+     * The verifier for a pool that demands a proof, or null when it demands none.
+     *
+     * The creator proves too, and reserves its own key image before publishing, so the first peer
+     * to replay the published proof cannot take a slot with it.
+     */
+    private AutctVerifier autctVerifier(JoinstrPool pool, Wallet wallet, String typedProvingKey) {
+        String keyset = pool.getAutctKeyset();
+        if(keyset == null || keyset.isEmpty()) {
+            return null;
+        }
+
+        AutctClient client = new AutctClient(Config.get().getAutctApiUrl());
+        String context = AutctPool.context(pool.getPoolId(), pool.getPubkey());
+        AutctVerifier verifier = new AutctVerifier(client, keyset, context);
+
+        String wif = ProvingKey.looksLikeWif(typedProvingKey)
+                ? typedProvingKey.trim()
+                : ProvingKey.fromWallet(wallet, AppServices.getCurrentBlockHeight(),
+                        0, 0, "p2tr");
+
+        if(wif == null) {
+            showError("This pool needs an aut-ct proof, but no Taproot key was given and this "
+                    + "wallet has no Taproot coin to prove with.");
+            return verifier;
+        }
+
+        AutctClient.Proof proof = client.generateProof(wif, keyset, context);
+        if(proof == null) {
+            showError("Could not generate the aut-ct proof for your own pool. Check the aut-ct "
+                    + "server and that the key is in the keyset.");
+            return verifier;
+        }
+
+        verifier.reserve(proof.keyImage());
+        return verifier;
+    }
+
+    public static void shareCredentials(Identity poolIdentity, String relayUrl,
+            Map<String, Object> poolCredentials, AutctVerifier verifier) {
 
         NostrListener listener = new NostrListener(poolIdentity, relayUrl, poolCredentials);
+        listener.setVerifier(verifier);
 
         listener.startListening((decryptedMessage, createdAt) -> {
             logger.info("Received message for credential sharing");

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -38,6 +38,7 @@ public class NostrListener implements AutoCloseable {
     private final Identity identity;
     private final String relay;
     private final Map<String, Object> poolCredentials;
+    private AutctVerifier verifier;
 
     private Client client;
     private BiConsumer<String, Long> messageHandler;
@@ -46,6 +47,11 @@ public class NostrListener implements AutoCloseable {
         this.identity = identity;
         this.relay = relay;
         this.poolCredentials = poolCredentials;
+    }
+
+    /** Set when the pool demands an aut-ct proof from every joiner. */
+    public void setVerifier(AutctVerifier verifier) {
+        this.verifier = verifier;
     }
 
     public void startListening(BiConsumer<String, Long> messageHandler) {
@@ -83,7 +89,12 @@ public class NostrListener implements AutoCloseable {
 
         try {
             if (poolCredentials != null && JoinstrMessage.isJoinRequest(decryptedContent)) {
-                handleJoinRequest(event.getPubKey());
+                String refusal = refuse(decryptedContent);
+                if (refusal != null) {
+                    sendReject(event.getPubKey(), refusal);
+                } else {
+                    handleJoinRequest(event.getPubKey());
+                }
             }
 
             if (messageHandler != null) {
@@ -110,6 +121,43 @@ public class NostrListener implements AutoCloseable {
             }
         }
         return false;
+    }
+
+    /** Why this join request must be refused, or null to answer it with credentials. */
+    private String refuse(String decryptedContent) {
+        if (verifier == null) {
+            return null;
+        }
+
+        try {
+            return verifier.rejectionReason(JoinstrMessage.fromJson(decryptedContent).getAutctProof());
+        } catch (Exception e) {
+            logger.warning("Could not read the aut-ct proof from a join request");
+            return AutctVerifier.INVALID_PROOF;
+        }
+    }
+
+    private void sendReject(PublicKey requester, String reason) {
+        try {
+            JoinstrMessage reject = JoinstrMessage.of("reject");
+            reject.setReason(reason);
+
+            List<BaseTag> tags = new ArrayList<>();
+            tags.add(new PubKeyTag(requester));
+
+            NIP04 nip04 = new NIP04(identity, requester);
+            String encrypted = nip04.encrypt(identity, reject.toJson(), requester);
+
+            GenericEvent event = new GenericEvent(identity.getPublicKey(),
+                    Kind.ENCRYPTED_DIRECT_MESSAGE.getValue(), tags, encrypted);
+            nip04.setEvent(event);
+            nip04.sign();
+
+            JoinstrPublisher.publish(identity, relay, event);
+            logger.info("Refused a join request: " + reason);
+        } catch (Exception e) {
+            logger.severe("Failed to send a reject: " + e.getMessage());
+        }
     }
 
     private void handleJoinRequest(PublicKey requester) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrPublisher.java
@@ -49,7 +49,7 @@ public class NostrPublisher implements AutoCloseable {
     }
 
     public GenericEvent publishCustomEvent(String denomination, String peers, String bitcoinAddress,
-            double feeRate, long timeoutSeconds) {
+            double feeRate, long timeoutSeconds, String autctKeyset) {
 
         if (bitcoinAddress.isEmpty()) {
             logger.warning("No Bitcoin Address found. Please open a wallet in Sparrow first.");
@@ -72,7 +72,7 @@ public class NostrPublisher implements AutoCloseable {
             NIP01 nip01 = new NIP01(poolIdentity);
 
             GenericEvent event = buildPoolEvent(poolIdentity, poolId, network, denomination, peers, timeout,
-                    relayUrl, feeRate);
+                    relayUrl, feeRate, autctKeyset);
 
             nip01.setEvent(event);
             nip01.sign();
@@ -101,6 +101,12 @@ public class NostrPublisher implements AutoCloseable {
      */
     static GenericEvent buildPoolEvent(Identity poolIdentity, String poolId, String network, String denomination,
             String peers, long timeout, String relayUrl, double feeRate) {
+        return buildPoolEvent(poolIdentity, poolId, network, denomination, peers, timeout, relayUrl,
+                feeRate, null);
+    }
+
+    static GenericEvent buildPoolEvent(Identity poolIdentity, String poolId, String network, String denomination,
+            String peers, long timeout, String relayUrl, double feeRate, String autctKeyset) {
 
         String content = String.format(
                 "{\n" +
@@ -115,7 +121,7 @@ public class NostrPublisher implements AutoCloseable {
                         "  \"relays\": [\"%s\"],\n" +
                         "  \"relay\": \"%s\",\n" +
                         "  \"fee_rate\": %s,\n" +
-                        "  \"transport\": { \"tor\": { \"enable\": true }, \"vpn\": { \"enable\": false, \"vpn_gateway\": null } }\n" +
+                        "  \"transport\": { \"tor\": { \"enable\": true }, \"vpn\": { \"enable\": false, \"vpn_gateway\": null } }%s\n" +
                         "}",
                 poolId,
                 network,
@@ -125,7 +131,10 @@ public class NostrPublisher implements AutoCloseable {
                 timeout,
                 relayUrl,
                 relayUrl,
-                CoinjoinMath.formatFeeRate(feeRate));
+                CoinjoinMath.formatFeeRate(feeRate),
+                AutctPool.announcementJson(autctKeyset) == null
+                        ? ""
+                        : ",\n  \"autct\": " + AutctPool.announcementJson(autctKeyset));
 
         List<BaseTag> tags = new ArrayList<>();
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -187,6 +187,7 @@ public class OtherPoolsController extends JoinstrFormController {
         }
 
         pool.setRequirement(PoolSupport.autctRequirement(poolData));
+        pool.setAutctKeyset(AutctPool.keysetOf(poolData));
 
         String unsupported = PoolSupport.unsupportedReason(poolData);
         pool.setUnsupportedReason(unsupported);

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolSupport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/PoolSupport.java
@@ -11,9 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public final class PoolSupport {
 
-    public static final String REQUIRES_AUTCT =
-            "This pool requires an aut-ct proof, which Sparrow cannot generate.";
-
     public static final String REQUIRES_VPN =
             "This pool requires a VPN transport. Sparrow is Tor only.";
 
@@ -27,10 +24,6 @@ public final class PoolSupport {
     public static String unsupportedReason(JsonNode poolData) {
         if (poolData == null) {
             return null;
-        }
-
-        if (requiresAutct(poolData)) {
-            return REQUIRES_AUTCT;
         }
 
         return transportReason(poolData.get("transport"));

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/ProvingKey.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/ProvingKey.java
@@ -1,0 +1,120 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.drongo.crypto.ECKey;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.wallet.BlockTransactionHashIndex;
+import com.sparrowwallet.drongo.wallet.Keystore;
+import com.sparrowwallet.drongo.wallet.Wallet;
+import com.sparrowwallet.drongo.wallet.WalletNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Finds the key an aut-ct proof is made with.
+ *
+ * Two ways in, because neither covers everyone. A Taproot wallet can prove with one of its own
+ * coins and never show a private key. A wallet with no Taproot coin, or whose coins are not in
+ * the pool's keyset, has to be given a key from elsewhere, which is what the reference
+ * implementation does for every pool because Electrum cannot export single sig Taproot keys.
+ */
+public final class ProvingKey {
+
+    private static final Logger logger = Logger.getLogger(ProvingKey.class.getName());
+
+    private ProvingKey() {
+    }
+
+    /** The candidates a wallet offers, judged on amount, confirmations and script type. */
+    public static List<ProvingUtxo.Candidate> candidates(Wallet wallet, int currentHeight) {
+        List<ProvingUtxo.Candidate> candidates = new ArrayList<>();
+        if (wallet == null) {
+            return candidates;
+        }
+
+        try {
+            for (Map.Entry<BlockTransactionHashIndex, WalletNode> entry
+                    : wallet.getSpendableUtxos().entrySet()) {
+                BlockTransactionHashIndex utxo = entry.getKey();
+                if (utxo.getHeight() <= 0) {
+                    continue;
+                }
+
+                String address = null;
+                try {
+                    address = entry.getValue().getAddress().toString();
+                } catch (Exception e) {
+                    continue;
+                }
+
+                int confirmations = currentHeight <= 0 ? 1 : (int) (currentHeight - utxo.getHeight() + 1);
+                candidates.add(new ProvingUtxo.Candidate(address, utxo.getValue(), confirmations));
+            }
+        } catch (Exception e) {
+            logger.warning("Could not read the wallet's coins for an aut-ct proof: " + e.getMessage());
+        }
+
+        return candidates;
+    }
+
+    /**
+     * A WIF from the wallet for a coin that meets the requirement, or null when it has none.
+     *
+     * Only a Taproot wallet can answer, since the keyset holds Taproot output keys.
+     */
+    public static String fromWallet(Wallet wallet, int currentHeight, long minAmount,
+            int minConfirmations, String scriptType) {
+        if (wallet == null || wallet.getScriptType() != ScriptType.P2TR) {
+            return null;
+        }
+
+        try {
+            for (Map.Entry<BlockTransactionHashIndex, WalletNode> entry
+                    : wallet.getSpendableUtxos().entrySet()) {
+                BlockTransactionHashIndex utxo = entry.getKey();
+                WalletNode node = entry.getValue();
+                if (utxo.getHeight() <= 0) {
+                    continue;
+                }
+
+                String address;
+                try {
+                    address = node.getAddress().toString();
+                } catch (Exception e) {
+                    continue;
+                }
+
+                int confirmations = currentHeight <= 0 ? 1 : (int) (currentHeight - utxo.getHeight() + 1);
+                ProvingUtxo.Candidate candidate =
+                        new ProvingUtxo.Candidate(address, utxo.getValue(), confirmations);
+                if (!ProvingUtxo.qualifies(candidate, minAmount, minConfirmations, scriptType)) {
+                    continue;
+                }
+
+                Keystore keystore = wallet.getKeystores().get(0);
+                ECKey key = keystore.getKey(node);
+                if (key == null || !key.hasPrivKey()) {
+                    continue;
+                }
+
+                return key.getPrivateKeyEncoded().toBase58();
+            }
+        } catch (Exception e) {
+            logger.severe("Could not export a proving key from the wallet: " + e.getMessage());
+        }
+
+        return null;
+    }
+
+    /** Whether a string looks like a WIF this client can hand to aut-ct. */
+    public static boolean looksLikeWif(String wif) {
+        if (wif == null) {
+            return false;
+        }
+        String trimmed = wif.trim();
+        return trimmed.length() >= 50 && trimmed.length() <= 53
+                && trimmed.matches("[1-9A-HJ-NP-Za-km-z]+");
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/ProvingUtxo.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/ProvingUtxo.java
@@ -1,0 +1,70 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import java.util.Collection;
+
+/**
+ * Chooses the UTXO an aut-ct proof is made against.
+ *
+ * It only proves membership of the keyset and is never spent, so it is deliberately a different
+ * coin from the one contributed to the coinjoin.
+ */
+public final class ProvingUtxo {
+
+    /** A candidate coin, reduced to what the requirement is judged on. */
+    public record Candidate(String address, long value, int confirmations) {
+    }
+
+    private ProvingUtxo() {
+    }
+
+    /** Whether an address is of the script type a pool demands. Empty means any. */
+    public static boolean matchesScriptType(String address, String scriptType) {
+        if (scriptType == null || scriptType.isBlank()) {
+            return true;
+        }
+        if (address == null) {
+            return false;
+        }
+
+        return switch (scriptType) {
+            case "p2tr" -> address.startsWith("bc1p") || address.startsWith("tb1p")
+                    || address.startsWith("bcrt1p");
+            case "p2wpkh" -> address.startsWith("bc1q") || address.startsWith("tb1q")
+                    || address.startsWith("bcrt1q");
+            case "p2pkh" -> address.startsWith("1") || address.startsWith("m")
+                    || address.startsWith("n");
+            case "p2sh" -> address.startsWith("3") || address.startsWith("2");
+            default -> false;
+        };
+    }
+
+    public static boolean qualifies(Candidate candidate, long minAmount, int minConfirmations,
+            String scriptType) {
+        if (candidate == null) {
+            return false;
+        }
+        if (candidate.value() < minAmount) {
+            return false;
+        }
+        // an unconfirmed coin may not be in the keyset snapshot at all
+        if (candidate.confirmations() <= 0 || candidate.confirmations() < minConfirmations) {
+            return false;
+        }
+        return matchesScriptType(candidate.address(), scriptType);
+    }
+
+    /** The first coin that meets the requirement, or null when the wallet has none. */
+    public static Candidate select(Collection<Candidate> candidates, long minAmount,
+            int minConfirmations, String scriptType) {
+        if (candidates == null) {
+            return null;
+        }
+
+        for (Candidate candidate : candidates) {
+            if (qualifies(candidate, minAmount, minConfirmations, scriptType)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/SettingsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/SettingsController.java
@@ -12,6 +12,9 @@ public class SettingsController extends JoinstrFormController {
     @FXML
     TextField nostrRelayTextField;
 
+    @FXML
+    TextField autctApiUrlTextField;
+
     @Override
     public void initializeView() {
 
@@ -27,6 +30,11 @@ public class SettingsController extends JoinstrFormController {
                 }
             });
             setDefaultNostrRelayIfEmpty();
+
+            autctApiUrlTextField.setPromptText(AutctClient.DEFAULT_API_URL);
+            autctApiUrlTextField.setText(Config.get().getAutctApiUrl());
+            autctApiUrlTextField.textProperty().addListener((observable, oldValue, newValue) ->
+                    Config.get().setAutctApiUrl(newValue == null ? null : newValue.trim()));
 
         } catch(Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrPoolList.java
@@ -1,5 +1,6 @@
 package com.sparrowwallet.sparrow.joinstr.control;
 
+import com.sparrowwallet.sparrow.joinstr.AutctJoin;
 import com.sparrowwallet.sparrow.joinstr.JoinstrMessage;
 import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
 import com.sparrowwallet.sparrow.joinstr.JoinstrPublisher;
@@ -187,6 +188,17 @@ public class JoinstrPoolList extends VBox {
 
                         joinButton.setOnAction(event -> {
                             JoinstrPool pool = getTableView().getItems().get(getIndex());
+
+                            // a gated pool needs a key before anything is published; asking here
+                            // keeps the dialog on the fx thread
+                            final String[] provingKey = new String[] {null};
+                            if(pool.getAutctKeyset() != null && !pool.getAutctKeyset().isEmpty()) {
+                                provingKey[0] = AutctJoin.askForProvingKey(pool);
+                                if(provingKey[0] == null) {
+                                    return;
+                                }
+                            }
+
                             Identity identity = Identity.generateRandomIdentity();
                             String pubkey = identity.getPublicKey().toString();
                             QRDisplayDialog qrDialog = new QRDisplayDialog(pubkey);
@@ -196,7 +208,20 @@ public class JoinstrPoolList extends VBox {
                                 try {
 
                                     PublicKey poolPubKey = new PublicKey(pool.getPubkey());
-                                    String requestContent = JoinstrMessage.of("join_pool").toJson();
+                                    JoinstrMessage request = JoinstrMessage.of("join_pool");
+
+                                    if(pool.getAutctKeyset() != null && !pool.getAutctKeyset().isEmpty()) {
+                                        String proof = AutctJoin.proveFor(pool, provingKey[0]);
+                                        if(proof == null) {
+                                            javafx.application.Platform.runLater(() ->
+                                                    AppServices.showErrorDialog("Proof Required",
+                                                            AutctJoin.NO_PROOF));
+                                            return;
+                                        }
+                                        request.setAutctProof(proof);
+                                    }
+
+                                    String requestContent = request.toJson();
                                     List<BaseTag> tags = new ArrayList<>();
                                     tags.add(new PubKeyTag(poolPubKey)); // Send to pool creator's pubkey
 

--- a/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
@@ -53,6 +53,20 @@
                             </tooltip>
                         </TextField>
                     </Field>
+                    <Field text="Keyset (optional):" style="-fx-text-fill: #aaaaaa;">
+                        <TextField fx:id="autctKeysetField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
+                            <tooltip>
+                                <Tooltip text="aut-ct keyset, e.g. autct-830000-100000-1-2-1024.aks. Leave blank for no sybil resistance"/>
+                            </tooltip>
+                        </TextField>
+                    </Field>
+                    <Field text="Proving Key:" style="-fx-text-fill: #aaaaaa;">
+                        <PasswordField fx:id="autctProvingKeyField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
+                            <tooltip>
+                                <Tooltip text="Taproot WIF for a UTXO in the keyset. Leave blank to use a coin from this wallet"/>
+                            </tooltip>
+                        </PasswordField>
+                    </Field>
                     <Field>
                         <VBox alignment="CENTER">
                             <ToggleButton fx:id="createButton" text="Create" onAction="#handleCreateButton"

--- a/src/main/resources/com/sparrowwallet/sparrow/joinstr/settings.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/joinstr/settings.fxml
@@ -24,6 +24,9 @@
                     <Label GridPane.rowIndex="4" GridPane.columnIndex="0">Nostr Relay:</Label>
                     <TextField prefWidth="100" maxWidth="150" GridPane.rowIndex="4" GridPane.columnIndex="1" fx:id="nostrRelayTextField">wss://nos.lol</TextField>
 
+                    <Label GridPane.rowIndex="5" GridPane.columnIndex="0">aut-ct Server:</Label>
+                    <TextField prefWidth="100" maxWidth="250" GridPane.rowIndex="5" GridPane.columnIndex="1" fx:id="autctApiUrlTextField"/>
+
                 </children>
             </GridPane>
         </VBox>

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/AutctKeyFileTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/AutctKeyFileTest.java
@@ -1,0 +1,96 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * aut-ct decrypts the proving key file before parsing it, so the layout has to match its
+ * encryption.rs exactly: a little endian u64 length, the ciphertext, a 12 byte nonce and a 32
+ * byte salt, with Argon2i deriving the key for AES-256-GCM-SIV.
+ *
+ * A wrong layout shows up as error -14 from the server rather than anything readable.
+ */
+public class AutctKeyFileTest {
+
+    private static final String WIF = "cW3AL8HXBSTonEeCkFhLxrLXmEXtnZfPsZBNSSpiVR9zZnkRJJmy";
+
+    private byte[] body() {
+        byte[] salt = new byte[32];
+        byte[] nonce = new byte[12];
+        for(int i = 0; i < salt.length; i++) {
+            salt[i] = (byte) i;
+        }
+        for(int i = 0; i < nonce.length; i++) {
+            nonce[i] = (byte) (0x40 + i);
+        }
+        return AutctKeyFile.encrypt(WIF, "hunter2", salt, nonce);
+    }
+
+    @Test
+    public void theLayoutIsLengthCiphertextNonceSalt() {
+        byte[] body = body();
+
+        long length = ByteBuffer.wrap(body, 0, 8).order(ByteOrder.LITTLE_ENDIAN).getLong();
+
+        assertEquals(WIF.length() + 16, length, "ciphertext is the wif plus a 16 byte tag");
+        assertEquals(8 + length + 12 + 32, body.length, "trailing nonce and salt are missing");
+    }
+
+    @Test
+    public void theNonceAndSaltAreCarriedVerbatim() {
+        byte[] body = body();
+        int ciphertextEnd = (int) (8 + ByteBuffer.wrap(body, 0, 8).order(ByteOrder.LITTLE_ENDIAN).getLong());
+
+        for(int i = 0; i < 12; i++) {
+            assertEquals((byte) (0x40 + i), body[ciphertextEnd + i], "nonce byte " + i);
+        }
+        for(int i = 0; i < 32; i++) {
+            assertEquals((byte) i, body[ciphertextEnd + 12 + i], "salt byte " + i);
+        }
+    }
+
+    /** The same key and nonce must give the same bytes, or the format is not deterministic. */
+    @Test
+    public void encryptionIsDeterministicForFixedSaltAndNonce() {
+        assertArrayEquals(body(), body());
+    }
+
+    @Test
+    public void adifferentPasswordGivesDifferentCiphertext() {
+        byte[] salt = new byte[32];
+        byte[] nonce = new byte[12];
+
+        assertFalse(java.util.Arrays.equals(
+                AutctKeyFile.encrypt(WIF, "one", salt, nonce),
+                AutctKeyFile.encrypt(WIF, "two", salt, nonce)));
+    }
+
+    @Test
+    public void theFileIsWrittenOwnerReadableOnly() throws Exception {
+        Path file = AutctKeyFile.write(WIF, "hunter2");
+        try {
+            assertTrue(Files.exists(file));
+            if(file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                assertEquals(PosixFilePermissions.fromString("rw-------"),
+                        Files.getPosixFilePermissions(file), "a proving key was left readable");
+            }
+            assertTrue(Files.size(file) > 40);
+        } finally {
+            AutctKeyFile.delete(file);
+            assertFalse(Files.exists(file), "the proving key file was left behind");
+        }
+    }
+
+    @Test
+    public void eachPasswordIsFresh() {
+        assertNotEquals(AutctKeyFile.randomPassword(), AutctKeyFile.randomPassword());
+        assertEquals(32, AutctKeyFile.randomPassword().length());
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/AutctPoolTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/AutctPoolTest.java
@@ -1,0 +1,224 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import nostr.id.Identity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Mirrors the behaviour the reference implementation pins in its own aut-ct tests: the keyset
+ * name carries the requirement, the proof context binds the pool id to the pool key, and the
+ * requirement a pool advertised cannot be dropped or swapped in its credentials.
+ */
+public class AutctPoolTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String KEYSET = "autct-830000-100000-6-2-1024.aks";
+
+    // --- keyset names ---
+
+    @Test
+    public void onlyTheCanonicalKeysetNameIsAccepted() {
+        assertTrue(AutctPool.isValidKeyset(KEYSET));
+        assertFalse(AutctPool.isValidKeyset("keyset.txt"));
+        assertFalse(AutctPool.isValidKeyset("../../etc/passwd"));
+        assertFalse(AutctPool.isValidKeyset("autct-830000-100000-6-2-1024.aks; rm -rf /"));
+        assertFalse(AutctPool.isValidKeyset(null));
+    }
+
+    /** The name reaches an autct server as a command argument, so nothing else may pass. */
+    @Test
+    public void aKeysetNameCannotCarryAPath() {
+        assertFalse(AutctPool.isValidKeyset("/keysets/autct-1-2-3-4-5.aks"));
+        assertFalse(AutctPool.isValidKeyset("sub/autct-1-2-3-4-5.aks"));
+    }
+
+    @Test
+    public void theRequirementComesOutOfTheKeysetName() throws Exception {
+        JsonNode autct = MAPPER.readTree(AutctPool.announcementJson(KEYSET));
+
+        assertEquals(KEYSET, autct.get("keyset").asText());
+        assertEquals(100000, autct.get("min_amount").asLong());
+        assertEquals(6, autct.get("min_confirmations").asInt());
+        assertEquals("p2tr", autct.get("script_type").asText());
+    }
+
+    @Test
+    public void anInvalidKeysetProducesNoAnnouncement() {
+        assertNull(AutctPool.announcementJson("nonsense"));
+        assertNull(AutctPool.announcementJson(""));
+    }
+
+    // --- reading a pool's requirement ---
+
+    private JsonNode pool(String autct) throws Exception {
+        return MAPPER.readTree("{\"id\":\"abc\",\"public_key\":\"pk\"" + autct + "}");
+    }
+
+    @Test
+    public void aPoolWithoutAutctDemandsNothing() throws Exception {
+        assertNull(AutctPool.keysetOf(pool("")));
+        assertNull(AutctPool.keysetOf(pool(",\"autct\":null")));
+        assertNull(AutctPool.keysetOf(null));
+    }
+
+    @Test
+    public void aPoolNamingAnInvalidKeysetIsTreatedAsNamingNone() throws Exception {
+        assertNull(AutctPool.keysetOf(pool(",\"autct\":{\"keyset\":\"../evil\"}")));
+    }
+
+    @Test
+    public void thePoolsRequirementIsRead() throws Exception {
+        JsonNode data = pool(",\"autct\":{\"keyset\":\"" + KEYSET
+                + "\",\"min_amount\":100000,\"min_confirmations\":6}");
+
+        assertEquals(KEYSET, AutctPool.keysetOf(data));
+        assertEquals(100000, AutctPool.minAmount(data));
+        assertEquals(6, AutctPool.minConfirmations(data));
+    }
+
+    // --- proof context ---
+
+    @Test
+    public void theContextIsHexAndFitsAServerArgument() {
+        String context = AutctPool.context("abc123", "pk");
+
+        assertEquals(64, context.length());
+        assertTrue(context.matches("[0-9a-f]{64}"));
+    }
+
+    /** A proof published in one pool must not be usable by one that copies its id. */
+    @Test
+    public void copyingTheIdAloneGivesADifferentContext() {
+        assertNotEquals(AutctPool.context("abc123", "poolkey"),
+                AutctPool.context("abc123", "another-poolkey"));
+    }
+
+    @Test
+    public void copyingThePoolKeyAloneGivesADifferentContext() {
+        assertNotEquals(AutctPool.context("abc123", "poolkey"),
+                AutctPool.context("different-id", "poolkey"));
+    }
+
+    @Test
+    public void theSamePoolAlwaysGivesTheSameContext() {
+        assertEquals(AutctPool.context("abc123", "poolkey"), AutctPool.context("abc123", "poolkey"));
+    }
+
+    // --- the advertised requirement survives into the credentials ---
+
+    private JoinstrPool advertised(Identity poolIdentity) {
+        JoinstrPool pool = new JoinstrPool("wss://nos.lol", poolIdentity.getPublicKey().toString(),
+                "0.001", "3", "1750000000");
+        pool.setPoolId("abc123");
+        pool.setAutctKeyset(KEYSET);
+        return pool;
+    }
+
+    private JoinstrMessage credentials(Identity poolIdentity, String keyset) {
+        JoinstrMessage message = new JoinstrMessage();
+        message.setType("credentials");
+        message.setPrivateKey(poolIdentity.getPrivateKey().toString());
+        message.setId("abc123");
+        message.setDenomination(0.001);
+        message.setPeers(3);
+        message.setTimeout(1750000000L);
+        message.setRelay("wss://nos.lol");
+        if(keyset != null) {
+            message.setAutctKeyset(keyset);
+        }
+        return message;
+    }
+
+    @Test
+    public void credentialsRepeatingTheRequirementAreAccepted() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        assertNull(JoinPoolHandler.credentialsRejectionReason(
+                credentials(poolIdentity, KEYSET), advertised(poolIdentity)));
+    }
+
+    /** Dropping it would put the joiner in a pool with no sybil resistance at all. */
+    @Test
+    public void credentialsDroppingTheRequirementAreRefused() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        String reason = JoinPoolHandler.credentialsRejectionReason(
+                credentials(poolIdentity, null), advertised(poolIdentity));
+
+        assertNotNull(reason);
+        assertTrue(reason.contains("aut-ct"), reason);
+    }
+
+    @Test
+    public void credentialsSwappingTheKeysetAreRefused() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+
+        assertNotNull(JoinPoolHandler.credentialsRejectionReason(
+                credentials(poolIdentity, "autct-830000-1-1-1-1.aks"), advertised(poolIdentity)));
+    }
+
+    @Test
+    public void aPoolWithoutARequirementDoesNotDemandOneInCredentials() {
+        Identity poolIdentity = Identity.generateRandomIdentity();
+        JoinstrPool plain = new JoinstrPool("wss://nos.lol", poolIdentity.getPublicKey().toString(),
+                "0.001", "3", "1750000000");
+        plain.setPoolId("abc123");
+
+        assertNull(JoinPoolHandler.credentialsRejectionReason(
+                credentials(poolIdentity, null), plain));
+    }
+
+    // --- choosing the proving utxo ---
+
+    @Test
+    public void theProvingUtxoMustBeBigEnoughAndConfirmed() {
+        ProvingUtxo.Candidate small = new ProvingUtxo.Candidate("bcrt1p" + "x".repeat(10), 50_000, 10);
+        ProvingUtxo.Candidate unconfirmed = new ProvingUtxo.Candidate("bcrt1p" + "x".repeat(10), 200_000, 0);
+        ProvingUtxo.Candidate tooNew = new ProvingUtxo.Candidate("bcrt1p" + "x".repeat(10), 200_000, 2);
+        ProvingUtxo.Candidate good = new ProvingUtxo.Candidate("bcrt1p" + "x".repeat(10), 200_000, 10);
+
+        assertFalse(ProvingUtxo.qualifies(small, 100_000, 6, "p2tr"));
+        assertFalse(ProvingUtxo.qualifies(unconfirmed, 100_000, 6, "p2tr"));
+        assertFalse(ProvingUtxo.qualifies(tooNew, 100_000, 6, "p2tr"));
+        assertTrue(ProvingUtxo.qualifies(good, 100_000, 6, "p2tr"));
+    }
+
+    @Test
+    public void theProvingUtxoMustBeTheRightScriptType() {
+        assertTrue(ProvingUtxo.matchesScriptType("bcrt1pabc", "p2tr"));
+        assertTrue(ProvingUtxo.matchesScriptType("bc1pabc", "p2tr"));
+        assertFalse(ProvingUtxo.matchesScriptType("bc1qabc", "p2tr"));
+        assertFalse(ProvingUtxo.matchesScriptType("1abc", "p2tr"));
+        // an empty script type means the pool does not care
+        assertTrue(ProvingUtxo.matchesScriptType("bc1qabc", ""));
+        assertTrue(ProvingUtxo.matchesScriptType("bc1qabc", null));
+    }
+
+    @Test
+    public void theFirstQualifyingCoinIsChosen() {
+        List<ProvingUtxo.Candidate> wallet = List.of(
+                new ProvingUtxo.Candidate("bc1qsegwit", 500_000, 20),
+                new ProvingUtxo.Candidate("bcrt1psmall", 1_000, 20),
+                new ProvingUtxo.Candidate("bcrt1pgood", 300_000, 20));
+
+        ProvingUtxo.Candidate chosen = ProvingUtxo.select(wallet, 100_000, 6, "p2tr");
+
+        assertNotNull(chosen);
+        assertEquals("bcrt1pgood", chosen.address());
+    }
+
+    @Test
+    public void aWalletWithNoQualifyingCoinYieldsNothing() {
+        assertNull(ProvingUtxo.select(List.of(
+                new ProvingUtxo.Candidate("bc1qsegwit", 500_000, 20)), 100_000, 6, "p2tr"));
+        assertNull(ProvingUtxo.select(List.of(), 100_000, 6, "p2tr"));
+        assertNull(ProvingUtxo.select(null, 100_000, 6, "p2tr"));
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/AutctVerifierTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/AutctVerifierTest.java
@@ -1,0 +1,124 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * One UTXO buys one slot. The key image that enforces it is the one the verifier derives, never
+ * anything the joiner sent, or a peer varies its own field and takes every slot in the pool.
+ */
+public class AutctVerifierTest {
+
+    /** Stands in for the aut-ct server, returning whatever verdict a test wants. */
+    private static class FakeClient extends AutctClient {
+        private final List<String> asked = new ArrayList<>();
+        private Verification next = new Verification(true, "keyimage-a");
+
+        FakeClient() {
+            super("ws://127.0.0.1:1");
+        }
+
+        @Override
+        public Verification verifyProof(String proof, String keyset, String context) {
+            asked.add(proof + "|" + keyset + "|" + context);
+            return next;
+        }
+    }
+
+    private AutctVerifier verifier(FakeClient client) {
+        return new AutctVerifier(client, "autct-830000-100000-1-2-1024.aks", "ctx");
+    }
+
+    @Test
+    public void aValidProofIsAccepted() {
+        FakeClient client = new FakeClient();
+
+        assertNull(verifier(client).rejectionReason("proof-a"));
+    }
+
+    @Test
+    public void aMissingProofIsRefused() {
+        AutctVerifier verifier = verifier(new FakeClient());
+
+        assertEquals(AutctVerifier.MISSING_PROOF, verifier.rejectionReason(null));
+        assertEquals(AutctVerifier.MISSING_PROOF, verifier.rejectionReason(""));
+        assertEquals(AutctVerifier.MISSING_PROOF, verifier.rejectionReason("   "));
+    }
+
+    @Test
+    public void aProofThatDoesNotVerifyIsRefused() {
+        FakeClient client = new FakeClient();
+        client.next = new AutctClient.Verification(false, null);
+
+        assertEquals(AutctVerifier.INVALID_PROOF, verifier(client).rejectionReason("proof-a"));
+    }
+
+    /** Accepted but with no key image is not something to trust either. */
+    @Test
+    public void anAcceptedProofWithoutAKeyImageIsRefused() {
+        FakeClient client = new FakeClient();
+        client.next = new AutctClient.Verification(true, null);
+
+        assertEquals(AutctVerifier.INVALID_PROOF, verifier(client).rejectionReason("proof-a"));
+    }
+
+    /** The same UTXO cannot take a second slot, even with a different looking proof. */
+    @Test
+    public void aRepeatedKeyImageIsRefused() {
+        FakeClient client = new FakeClient();
+        AutctVerifier verifier = verifier(client);
+
+        assertNull(verifier.rejectionReason("proof-a"));
+        assertEquals(AutctVerifier.DUPLICATE_TOKEN, verifier.rejectionReason("a-different-proof"));
+        assertEquals(1, verifier.accepted());
+    }
+
+    @Test
+    public void differentKeyImagesEachTakeASlot() {
+        FakeClient client = new FakeClient();
+        AutctVerifier verifier = verifier(client);
+
+        assertNull(verifier.rejectionReason("proof-a"));
+        client.next = new AutctClient.Verification(true, "keyimage-b");
+        assertNull(verifier.rejectionReason("proof-b"));
+
+        assertEquals(2, verifier.accepted());
+    }
+
+    /**
+     * The creator publishes its own proof with the pool, so the first peer to replay it would
+     * otherwise take a slot for free.
+     */
+    @Test
+    public void aReplayedCreatorProofTakesNoSlot() {
+        FakeClient client = new FakeClient();
+        AutctVerifier verifier = verifier(client);
+        verifier.reserve("keyimage-a");
+
+        assertEquals(AutctVerifier.DUPLICATE_TOKEN, verifier.rejectionReason("the-creators-proof"));
+        assertTrue(verifier.hasSeen("keyimage-a"));
+    }
+
+    @Test
+    public void reservingNothingIsHarmless() {
+        AutctVerifier verifier = verifier(new FakeClient());
+        verifier.reserve(null);
+        verifier.reserve("");
+
+        assertEquals(0, verifier.accepted());
+        assertNull(verifier.rejectionReason("proof-a"));
+    }
+
+    /** The proof is checked against this pool's own keyset and context, not any other. */
+    @Test
+    public void theProofIsCheckedAgainstThisPoolsKeysetAndContext() {
+        FakeClient client = new FakeClient();
+        verifier(client).rejectionReason("proof-a");
+
+        assertEquals(List.of("proof-a|autct-830000-100000-1-2-1024.aks|ctx"), client.asked);
+    }
+}

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolSupportTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/PoolSupportTest.java
@@ -65,29 +65,25 @@ public class PoolSupportTest {
                 ",\"transport\":\"i2p\"")));
     }
 
+    /** An aut-ct pool is joinable now that a proof can be generated for it. */
     @Test
-    public void anAutctPoolIsRefused() throws Exception {
-        String reason = PoolSupport.unsupportedReason(pool(
-                ",\"autct\":{\"keyset\":\"autct-830000-100000-1-2-1024.aks\",\"min_amount\":100000}"));
-
-        assertEquals(PoolSupport.REQUIRES_AUTCT, reason);
+    public void anAutctPoolIsJoinable() throws Exception {
+        assertNull(PoolSupport.unsupportedReason(pool(
+                ",\"autct\":{\"keyset\":\"autct-830000-100000-1-2-1024.aks\",\"min_amount\":100000}")));
     }
 
     /** The field only means anything with a keyset naming the requirement. */
     @Test
-    public void anEmptyAutctFieldDoesNotRefuseThePool() throws Exception {
+    public void anEmptyAutctFieldMeansNoRequirement() throws Exception {
         assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":{}")));
-        assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":{\"keyset\":\"\"}")));
-        assertNull(PoolSupport.unsupportedReason(pool(",\"autct\":{\"keyset\":\"   \"}")));
+        assertNull(PoolSupport.autctRequirement(pool(",\"autct\":{\"keyset\":\"\"}")));
     }
 
+    /** An aut-ct pool on a transport this client does not use is still refused, for transport. */
     @Test
-    public void autctIsReportedAheadOfTransport() throws Exception {
-        String reason = PoolSupport.unsupportedReason(pool(
-                ",\"autct\":{\"keyset\":\"autct-1-2-3-4-5.aks\"},\"transport\":\"vpn\""));
-
-        // both apply, but the proof requirement is the one the user can do nothing about
-        assertEquals(PoolSupport.REQUIRES_AUTCT, reason);
+    public void anAutctPoolOnVpnIsStillRefusedForItsTransport() throws Exception {
+        assertEquals(PoolSupport.REQUIRES_VPN, PoolSupport.unsupportedReason(pool(
+                ",\"autct\":{\"keyset\":\"autct-1-2-3-4-5.aks\"},\"transport\":\"vpn\"")));
     }
 
     /** Shown so a user can see what an aut-ct pool wants, even though we cannot satisfy it. */


### PR DESCRIPTION
Closes #96.

aut-ct sybil resistance: a pool can require each peer to prove it owns a Taproot UTXO in a published keyset, without revealing which. One UTXO buys one slot.

## Verified against the real autct binary

Two servers, so proving and verifying are separate parties as they are in a pool:

```
creator prove accepted = 0   keyimage = 75fb8b1568fb14a30427
joiner  prove accepted = 0   keyimage = ae7aae051839e6348984
VERIFY joiner proof     = 1   keyimage = ae7aae051839e6348984
verifier key image matches prover: True
VERIFY same proof again = -3  (replay refused)
```

The Java client also generated a proof directly: `accepted=0`, 3724 bytes, same key image as the reference Python client for the same key and context. A key file written by this code was decrypted back to the original WIF by the Python implementation.

## What is here

**Client** — `AutctClient` (websocket RPC), `AutctKeyFile` (Argon2i then AES-256-GCM-SIV, the layout aut-ct expects).

**Protocol** — `AutctPool` builds the `autct` object from the keyset name and derives the proof context as `SHA256(id || pool_key)`, so a proof cannot be recycled by an announcement copying the id. `AutctVerifier` checks joiners and refuses them with `missing_proof`, `invalid_proof` or `duplicate_token`. `NostrListener` sends the reject rather than staying silent.

Dedup uses the key image **the verifier derived**, never anything the joiner sent. The creator reserves its own key image before publishing, so the first peer to replay the published proof takes nothing.

**Joining** — `ProvingKey` resolves a key two ways. A Taproot wallet proves with one of its own coins and never shows a private key; anything else takes a typed WIF. Both are supported because neither covers everyone: a wallet with no Taproot coin, or whose coins are not in the keyset, has only the typed key.

**UI** — Settings gains the aut-ct server URL. Create gains Keyset and Proving Key, both optional. Joining a gated pool prompts for a WIF, with blank meaning "use a coin from this wallet". The pool list already shows the requirement (#95).

aut-ct pools are no longer marked unsupported.

## The keyset format, undocumented until now

`.github/scripts/make-autct-keyset.py` builds one a server accepts. Two details decide it:

1. **One line of space separated x-only hex.** `filter_utxos.py` writes `" ".join(scriptpubkey[4:])`, stripping the `5120` prefix. Newline separated is rejected.
2. **Taproot output keys, not internal keys.** `lib.rs` applies `tap_tweak(&secp, None)` before the lookup, so an untweaked key gives `-8`.

Codes: `-14` key file undecryptable, `-8` key not in keyset, `-5` wrong network, `-3` key image already used.

## Tests

285 unit tests. New ones follow the plugin's own aut-ct spec: keyset names cannot carry a path, the requirement comes from the name, the context changes with either the id or the pool key, credentials dropping or swapping the keyset are refused, the proving UTXO rules, and the verifier's reject reasons. Removing the key image dedup fails three of them.

## Not included

Managing a local `autct` binary as a child process. The server URL is configurable and an external server is expected. Worth its own issue if you want the managed mode the plugin has.
