### PR TITLE
fix: connect directly to a relay on this machine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,10 @@ if(System.getProperty("os.arch") == "aarch64") {
 def headless = "true".equals(System.getProperty("java.awt.headless"))
 
 group = 'com.sparrowwallet'
-version = '2.3.2-joinstr.0.1.1'
+version = '2.3.2-joinstr.0.2.0'
 // jpackage requires a numeric-only version (X.Y.Z) on Windows and macOS.
 // This is the version embedded into the installer/package metadata.
-def jpackageVersion = '0.1.1'
+def jpackageVersion = '0.2.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPublisher.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPublisher.java
@@ -52,7 +52,7 @@ public final class JoinstrPublisher {
      * relay's acknowledgement is delivered through the same message listener that carries events.
      */
     public static boolean publish(Identity as, String relay, GenericEvent signedEvent) {
-        if (!JoinstrTransport.newCircuit()) {
+        if (!JoinstrTransport.newCircuitFor(relay)) {
             logger.warning("Not publishing: tor is not running");
             return false;
         }
@@ -63,7 +63,7 @@ public final class JoinstrPublisher {
 
         Client client = new Client();
         try {
-            DefaultRequestContext context = context(as, relay, JoinstrTransport.proxy());
+            DefaultRequestContext context = context(as, relay, JoinstrTransport.proxy(relay));
             context.setMessageListener((message, source) -> {
                 if (message instanceof OkMessage ok
                         && (eventId == null || eventId.equals(ok.getEventId()))) {

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrTransport.java
@@ -41,6 +41,51 @@ public final class JoinstrTransport {
      * This is handed to each nostr connection rather than set as a JVM wide system property, so
      * unrelated Sparrow traffic is unaffected.
      */
+    /**
+     * Whether a relay is on this machine.
+     *
+     * A loopback address cannot be reached through Tor, so forcing the proxy makes a local relay
+     * unusable. Nothing leaves the machine for one, so there is no traffic to hide.
+     */
+    public static boolean isLoopback(String relay) {
+        if (relay == null) {
+            return false;
+        }
+
+        try {
+            String host = java.net.URI.create(relay.trim()).getHost();
+            if (host == null) {
+                return false;
+            }
+            host = host.toLowerCase(java.util.Locale.ROOT);
+            return host.equals("127.0.0.1") || host.equals("localhost") || host.equals("::1")
+                    || host.equals("[::1]");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** The proxy for a given relay, or null when it needs none. */
+    public static Proxy proxy(String relay) {
+        if (isLoopback(relay)) {
+            return null;
+        }
+        return proxy();
+    }
+
+    /** Whether joinstr may talk to this relay at all. A local one needs no tor. */
+    public static boolean isReadyFor(String relay) {
+        return isLoopback(relay) || isReady();
+    }
+
+    /** Take a fresh circuit unless the relay is local, in which case there is none to take. */
+    public static boolean newCircuitFor(String relay) {
+        if (isLoopback(relay)) {
+            return true;
+        }
+        return newCircuit();
+    }
+
     public static Proxy proxy() {
         if (directForTesting) {
             return null;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/NostrListener.java
@@ -202,14 +202,14 @@ public class NostrListener implements AutoCloseable {
 
     private void connectAndSubscribe() {
         try {
-            if (!JoinstrTransport.newCircuit()) {
+            if (!JoinstrTransport.newCircuitFor(relay)) {
                 throw new IllegalStateException(JoinstrTransport.NOT_READY);
             }
 
             client = new Client();
 
             DefaultRequestContext context = JoinstrPublisher.context(identity, relay,
-                    JoinstrTransport.proxy());
+                    JoinstrTransport.proxy(relay));
             context.setMessageListener((message, source) -> onRelayMessage(message));
 
             Filters filters = Filters.builder()

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/OtherPoolsController.java
@@ -216,7 +216,8 @@ public class OtherPoolsController extends JoinstrFormController {
             Client client = new Client();
 
             try {
-                if (!JoinstrTransport.newCircuit()) {
+                String discoveryRelay = JoinstrRelay.relayOrDefault(Config.get().getNostrRelay());
+                if (!JoinstrTransport.newCircuitFor(discoveryRelay)) {
                     Platform.runLater(() -> showError(JoinstrTransport.NOT_READY));
                     return;
                 }
@@ -225,9 +226,8 @@ public class OtherPoolsController extends JoinstrFormController {
 
                 DefaultRequestContext context = new DefaultRequestContext();
                 context.setPrivateKey(identity.getPrivateKey().getRawData());
-                context.setRelays(new LinkedHashMap<>(Map.of("default",
-                        JoinstrRelay.relayOrDefault(Config.get().getNostrRelay()))));
-                context.setProxy(JoinstrTransport.proxy());
+                context.setRelays(new LinkedHashMap<>(Map.of("default", discoveryRelay)));
+                context.setProxy(JoinstrTransport.proxy(discoveryRelay));
                 context.setMessageListener((message, source) -> {
                     if (!(message instanceof EventMessage eventMessage)
                             || !(eventMessage.getEvent() instanceof GenericEvent event)) {

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/TransportProxyTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/TransportProxyTest.java
@@ -16,6 +16,41 @@ public class TransportProxyTest {
         JoinstrTransport.setTorRunningForTesting(null);
     }
 
+    /**
+     * A loopback relay cannot be reached through Tor, so forcing the proxy makes a local relay
+     * unusable for testing. Nothing leaves the machine, so there is nothing to hide.
+     */
+    @Test
+    public void aLocalRelayNeedsNoTor() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        assertTrue(JoinstrTransport.isLoopback("ws://127.0.0.1:7777"));
+        assertTrue(JoinstrTransport.isLoopback("ws://localhost:7777"));
+        assertTrue(JoinstrTransport.isReadyFor("ws://127.0.0.1:7777"));
+        assertTrue(JoinstrTransport.newCircuitFor("ws://127.0.0.1:7777"));
+        assertNull(JoinstrTransport.proxy("ws://127.0.0.1:7777"));
+    }
+
+    /** Everything else still goes through Tor, and is refused when Tor is down. */
+    @Test
+    public void aRemoteRelayStillNeedsTor() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        assertFalse(JoinstrTransport.isLoopback("wss://nos.lol"));
+        assertFalse(JoinstrTransport.isReadyFor("wss://nos.lol"));
+        assertFalse(JoinstrTransport.newCircuitFor("wss://nos.lol"));
+    }
+
+    /** A host merely containing "localhost" is not loopback. */
+    @Test
+    public void aLookalikeHostIsNotTreatedAsLocal() {
+        JoinstrTransport.setTorRunningForTesting(() -> false);
+
+        assertFalse(JoinstrTransport.isLoopback("wss://localhost.evil.com"));
+        assertFalse(JoinstrTransport.isLoopback("wss://127.0.0.1.evil.com"));
+        assertFalse(JoinstrTransport.isReadyFor("wss://localhost.evil.com"));
+    }
+
     @Test
     public void thereIsNoProxyWhenTorIsDown() {
         JoinstrTransport.setTorRunningForTesting(() -> false);


### PR DESCRIPTION
Two things needed before a release build.

## A relay on this machine could not be used

Every relay connection was forced through the Tor proxy. A loopback address cannot be reached that way, so `ws://127.0.0.1:7777` simply failed, which makes local testing impossible. The reference implementation has `_relay_bypasses_proxy` for exactly this.

A relay on `127.0.0.1`, `localhost` or `::1` now connects directly and does not require Tor. Nothing leaves the machine for one, so there is no traffic to hide. Everything else is unchanged: still proxied, still refused when Tor is down.

Tested including lookalike hosts, so `wss://localhost.evil.com` is not treated as local.

## Version

`version` and `jpackageVersion` both move to `0.2.0`. `jpackageVersion` is separate and drives the installer metadata, so leaving it would have shipped an installer still calling itself 0.1.1.
