### PR TITLE
fix: keep javafx properties out of the config file

### DIFF
--- a/src/main/java/com/sparrowwallet/sparrow/io/Config.java
+++ b/src/main/java/com/sparrowwallet/sparrow/io/Config.java
@@ -95,8 +95,11 @@ public class Config {
     // Joinstr settings
     private String nostrRelay;
     private String autctApiUrl;
-    private ArrayList<JoinstrPool> poolStore;
-    private ArrayList<JoinstrHistoryEntry> historyStore;
+    // Not serialised into the config: these hold JavaFX properties, and gson reflecting into
+    // javafx.beans.property throws InaccessibleObjectException in the packaged modular image.
+    // They live in their own files, written by JoinstrPool and JoinstrHistoryEntry.
+    private transient ArrayList<JoinstrPool> poolStore;
+    private transient ArrayList<JoinstrHistoryEntry> historyStore;
 
     // ================
 
@@ -767,8 +770,9 @@ public class Config {
     }
 
     public ArrayList<JoinstrPool> getPoolStore() {
-        if(poolStore == null)
-            poolStore = new ArrayList<JoinstrPool>();
+        if(poolStore == null) {
+            poolStore = JoinstrPool.loadPoolsFile(Storage.getJoinstrPoolsFile().getPath());
+        }
         return poolStore;
     }
 
@@ -778,8 +782,9 @@ public class Config {
     }
 
     public ArrayList<JoinstrHistoryEntry> getHistoryStore() {
-        if(historyStore == null)
-            historyStore = new ArrayList<JoinstrHistoryEntry>();
+        if(historyStore == null) {
+            historyStore = JoinstrHistoryEntry.loadHistoryFile(Storage.getJoinstrHistoryFile().getPath());
+        }
         return historyStore;
     }
 

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrHistoryEntry.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrHistoryEntry.java
@@ -97,6 +97,30 @@ public class JoinstrHistoryEntry {
         }
     }
 
+    /** Read the coinjoin history written by saveHistoryFile, or an empty list. */
+    public static ArrayList<JoinstrHistoryEntry> loadHistoryFile(String filePath) {
+        try {
+            java.io.File file = new java.io.File(filePath);
+            if (!file.exists()) {
+                return new ArrayList<>();
+            }
+
+            String text = new String(java.nio.file.Files.readAllBytes(file.toPath()),
+                    java.nio.charset.StandardCharsets.UTF_8);
+            if (text.isBlank()) {
+                return new ArrayList<>();
+            }
+
+            JoinstrHistoryStoreWrapper wrapper =
+                    new Gson().fromJson(text, JoinstrHistoryStoreWrapper.class);
+            return wrapper == null ? new ArrayList<>() : wrapper.getEntries();
+        } catch (Exception e) {
+            java.util.logging.Logger.getLogger(JoinstrHistoryEntry.class.getName())
+                    .warning("Could not read the coinjoin history: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
     public static void saveHistoryFile(String filePath) throws IOException {
         Gson gson = new Gson();
         ArrayList<JoinstrHistoryEntry> historyStore = Config.get().getHistoryStore();

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrPool.java
@@ -308,6 +308,30 @@ public class JoinstrPool {
         return status;
     }
 
+    /** Read the pools written by savePoolsFile, or an empty list when there are none. */
+    public static ArrayList<JoinstrPool> loadPoolsFile(String filePath) {
+        try {
+            File file = new File(filePath);
+            if (!file.exists()) {
+                return new ArrayList<>();
+            }
+
+            String text = new String(java.nio.file.Files.readAllBytes(file.toPath()),
+                    java.nio.charset.StandardCharsets.UTF_8);
+            if (text.isBlank()) {
+                return new ArrayList<>();
+            }
+
+            Type mapType = new TypeToken<JoinstrPoolStoreWrapper>() {
+            }.getType();
+            JoinstrPoolStoreWrapper wrapper = new Gson().fromJson(text, mapType);
+            return wrapper == null ? new ArrayList<>() : wrapper.getPools();
+        } catch (Exception e) {
+            logger.warning("Could not read the saved pools: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
     public static void importPoolsFile(String directoryPath) {
 
         FileChooser fileChooser = new FileChooser();

--- a/src/test/java/com/sparrowwallet/sparrow/joinstr/ConfigSerialisationTest.java
+++ b/src/test/java/com/sparrowwallet/sparrow/joinstr/ConfigSerialisationTest.java
@@ -1,0 +1,151 @@
+package com.sparrowwallet.sparrow.joinstr;
+
+import com.sparrowwallet.sparrow.io.Config;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The config file is written with gson, which reflects into every field it serialises.
+ *
+ * Reaching a JavaFX property that way throws InaccessibleObjectException in the packaged image,
+ * because javafx.base does not open javafx.beans.property to com.google.gson. It does not happen
+ * when running from Gradle or an IDE, where everything is on the classpath and module rules do
+ * not apply, so only a packaged build shows it. This walks the fields gson would touch and fails
+ * before that can ship.
+ */
+public class ConfigSerialisationTest {
+
+    /** Types gson will not reflect into, so recursion can stop there. */
+    private boolean isLeaf(Class<?> type) {
+        return type.isPrimitive() || type.isEnum() || type.getName().startsWith("java.");
+    }
+
+    private void collectReachable(Type type, Set<Class<?>> seen, List<String> javafxTypes,
+            String path) {
+        if (type instanceof ParameterizedType parameterized) {
+            collectReachable(parameterized.getRawType(), seen, javafxTypes, path);
+            for (Type argument : parameterized.getActualTypeArguments()) {
+                collectReachable(argument, seen, javafxTypes, path);
+            }
+            return;
+        }
+
+        if (!(type instanceof Class<?> clazz) || !seen.add(clazz)) {
+            return;
+        }
+
+        if (clazz.getName().startsWith("javafx.")) {
+            javafxTypes.add(path + " -> " + clazz.getName());
+            return;
+        }
+
+        if (isLeaf(clazz)) {
+            return;
+        }
+
+        for (Field field : clazz.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
+                continue;
+            }
+            collectReachable(field.getGenericType(), seen, javafxTypes,
+                    path + "." + field.getName());
+        }
+    }
+
+    @Test
+    public void noJavafxTypeIsReachableFromTheConfigFile() {
+        List<String> javafxTypes = new ArrayList<>();
+        Set<Class<?>> seen = new HashSet<>();
+
+        for (Field field : Config.class.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
+                continue;
+            }
+            collectReachable(field.getGenericType(), seen, javafxTypes, "Config." + field.getName());
+        }
+
+        assertTrue(javafxTypes.isEmpty(),
+                "gson would reflect into a JavaFX type writing the config, which throws "
+                        + "InaccessibleObjectException in the packaged build:\n  "
+                        + String.join("\n  ", javafxTypes));
+    }
+
+    /**
+     * The pool and history files are written with gson too, so the same rule applies to the
+     * wrappers they go through. Those convert to plain data classes precisely so gson never
+     * reaches a JavaFX property, and this keeps a field from being added straight to a wrapper.
+     */
+    @Test
+    public void noJavafxTypeIsReachableFromThePoolOrHistoryFiles() {
+        List<String> javafxTypes = new ArrayList<>();
+        Set<Class<?>> seen = new HashSet<>();
+
+        for (Class<?> nested : JoinstrPool.class.getDeclaredClasses()) {
+            if (nested.getSimpleName().equals("JoinstrPoolStoreWrapper")) {
+                collectReachable(nested, seen, javafxTypes, "pools.json");
+            }
+        }
+        for (Class<?> nested : JoinstrHistoryEntry.class.getDeclaredClasses()) {
+            if (nested.getSimpleName().equals("JoinstrHistoryStoreWrapper")) {
+                collectReachable(nested, seen, javafxTypes, "history.json");
+            }
+        }
+
+        assertFalse(seen.isEmpty(), "the store wrappers should have been found");
+        assertTrue(javafxTypes.isEmpty(),
+                "gson would reflect into a JavaFX type writing the joinstr files:\n  "
+                        + String.join("\n  ", javafxTypes));
+    }
+
+    /** The pool store holds JavaFX properties, so it must stay out of the config file. */
+    @Test
+    public void thePoolAndHistoryStoresAreNotSerialised() throws Exception {
+        assertTrue(Modifier.isTransient(Config.class.getDeclaredField("poolStore").getModifiers()),
+                "poolStore must be transient");
+        assertTrue(Modifier.isTransient(Config.class.getDeclaredField("historyStore").getModifiers()),
+                "historyStore must be transient");
+    }
+
+    /** They are kept in their own files instead, so nothing is lost by not serialising them. */
+    @Test
+    public void thePoolsAreReadBackFromTheirOwnFile() throws Exception {
+        java.nio.file.Path file = java.nio.file.Files.createTempFile("pools", ".json");
+        try {
+            java.nio.file.Files.writeString(file, "{\"poolsList\":[{\"relay\":\"wss://nos.lol\","
+                    + "\"pubkey\":\"pk\",\"denomination\":\"0.001\",\"peers\":\"3\","
+                    + "\"timeout\":\"1750000000\",\"privateKey\":\"aabb\",\"status\":\"\"}]}");
+
+            ArrayList<JoinstrPool> pools = JoinstrPool.loadPoolsFile(file.toString());
+
+            assertEquals(1, pools.size());
+            assertEquals("wss://nos.lol", pools.get(0).getRelay());
+            assertEquals("0.001", pools.get(0).getDenomination());
+        } finally {
+            java.nio.file.Files.deleteIfExists(file);
+        }
+    }
+
+    @Test
+    public void aMissingOrEmptyPoolsFileIsNotAnError() throws Exception {
+        assertTrue(JoinstrPool.loadPoolsFile("/nonexistent/pools.json").isEmpty());
+        assertTrue(JoinstrHistoryEntry.loadHistoryFile("/nonexistent/history.json").isEmpty());
+
+        java.nio.file.Path empty = java.nio.file.Files.createTempFile("pools", ".json");
+        try {
+            assertTrue(JoinstrPool.loadPoolsFile(empty.toString()).isEmpty());
+        } finally {
+            java.nio.file.Files.deleteIfExists(empty);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the crash in the packaged build when clicking "Configure Server" or "Offline" on the splash screen:

```
com.google.gson.JsonIOException: Failed making field 'javafx.beans.property.SimpleStringProperty#bean' accessible
Caused by: java.lang.reflect.InaccessibleObjectException:
  module javafx.base does not "opens javafx.beans.property" to module com.google.gson
```

`Config` held `poolStore` and `historyStore` as ordinary fields. Their elements hold JavaFX properties, so gson reflected into `javafx.beans.property` when reading and writing the config file. The packaged image is modular and javafx.base does not open that package to gson, so `Config.load` threw and `Config.flush` then made it fatal.

Both fields are now `transient`. They already live in their own files (`pools.json` and the history file) written through plain data classes, so nothing is lost by keeping them out of the config. There was no automatic load of those files before, only the manual import button, so `getPoolStore` and `getHistoryStore` now read them lazily on first use.

Present since v0.1.1. It does not reproduce from Gradle or an IDE, where everything is on the classpath and module rules do not apply, which is why only a packaged build shows it.

## Tests

`ConfigSerialisationTest` walks the fields gson would touch and fails if any reaches a JavaFX type. Checked both ways: it fails on the code before this change, naming the three fields, and passes after.

```
Config.poolStore.relay -> javafx.beans.property.SimpleStringProperty
Config.poolStore.connectedPeers -> javafx.beans.property.SimpleIntegerProperty
Config.historyStore.amountSats -> javafx.beans.property.SimpleLongProperty
```

The same walk covers the pool and history file wrappers, so a field added straight to one of those is caught as well. Also covers reading pools back from the file, and a missing or empty file.

Full suite: 328 tests, no failures.

I could not launch the packaged GUI headlessly on this machine to confirm the fix end to end, so the packaged build still needs a manual check.
