### PR TITLE
fix: coinjoin window regressions found in testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -406,6 +406,8 @@ extraJavaModuleInfo {
         exports('okhttp3')
         requires('okio')
         requires('kotlin.stdlib')
+        // okhttp3.internal.concurrent.TaskRunner logs through java.util.logging
+        requires('java.logging')
     }
 
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -550,8 +550,16 @@ public class AppController implements Initializable {
     }
 
     public void showJoinstr(ActionEvent event) {
+        if(getSelectedWalletForm() == null) {
+            AppServices.showErrorDialog("No Wallet Open",
+                    "Open a wallet before starting a coinjoin.");
+            return;
+        }
+
         Stage joinstrStage = getJoinstrStage();
-        joinstrStage.show();
+        if(joinstrStage != null) {
+            joinstrStage.show();
+        }
     }
 
     private Stage getJoinstrStage() {
@@ -593,8 +601,11 @@ public class AppController implements Initializable {
             }
 
             return stage;
-        } catch(IOException e) {
+        } catch(Exception e) {
+            // Leaving a half built controller behind makes the next click open a broken window
+            joinstrController = null;
             log.error("Error loading Joinstr stage", e);
+            AppServices.showErrorDialog("Error Opening Coinjoin", e.getMessage() == null ? e.toString() : e.getMessage());
         }
 
         return null;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
@@ -16,13 +16,19 @@ import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Insets;
 import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
 import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 public class JoinstrController extends JoinstrFormController implements IThreadExecutor {
 
@@ -88,7 +94,7 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
         joinstrMenuBox.visibleProperty().bind(getJoinstrForm().lockedProperty().not());
 
         // Set theme CSS
-        String darkCss = getClass().getResource("../darktheme.css").toExternalForm();
+        String darkCss = AppServices.class.getResource("darktheme.css").toExternalForm();
         if(Config.get().getTheme() == Theme.DARK) {
             if(!stage.getScene().getStylesheets().contains(darkCss)) {
                 stage.getScene().getStylesheets().add(darkCss);
@@ -195,6 +201,13 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
      * property is set and the rest of Sparrow's traffic is unaffected.
      */
     private void awaitTor() {
+        if(AppServices.isTorRunning()) {
+            log.info("[Joinstr] Tor is already running, joinstr requests will use it");
+            return;
+        }
+
+        Stage progress = showTorProgress();
+
         Thread t = new Thread(() -> {
             try {
                 int waited = 0;
@@ -204,18 +217,52 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
                 }
                 if (AppServices.isTorRunning()) {
                     log.info("[Joinstr] Tor is running, joinstr requests will use it");
+                    javafx.application.Platform.runLater(progress::close);
                 } else {
                     log.warn("[Joinstr] Tor not ready after 90s, joinstr requests will be refused");
-                    javafx.application.Platform.runLater(() -> AppServices.showErrorDialog(
-                            "Tor Not Running", JoinstrTransport.NOT_READY));
+                    javafx.application.Platform.runLater(() -> {
+                        progress.close();
+                        AppServices.showErrorDialog("Tor Not Running", JoinstrTransport.NOT_READY);
+                    });
                 }
             } catch (InterruptedException e) {
+                javafx.application.Platform.runLater(progress::close);
                 Thread.currentThread().interrupt();
             }
         });
         t.setDaemon(true);
         t.setName("TorReadinessWatcher");
         t.start();
+    }
+
+    /**
+     * Tor can take a while on first start, and joinstr cannot send anything until it is up.
+     * Show that rather than leaving the window looking stuck.
+     */
+    private Stage showTorProgress() {
+        Label message = new Label("Starting Tor, this can take a minute on first run.");
+        ProgressBar progressBar = new ProgressBar();
+        progressBar.setProgress(ProgressBar.INDETERMINATE_PROGRESS);
+        progressBar.setMaxWidth(Double.MAX_VALUE);
+
+        VBox content = new VBox(12, message, progressBar);
+        content.setPadding(new Insets(20));
+        content.setPrefWidth(360);
+
+        Scene scene = new Scene(content);
+        if(Config.get().getTheme() == Theme.DARK) {
+            scene.getStylesheets().add(AppServices.class.getResource("darktheme.css").toExternalForm());
+        }
+
+        Stage progress = new Stage(StageStyle.UTILITY);
+        progress.setTitle("Coinjoin");
+        progress.initOwner(stage);
+        progress.initModality(Modality.NONE);
+        progress.setResizable(false);
+        progress.setScene(scene);
+        progress.show();
+
+        return progress;
     }
 
     @Override

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -1,5 +1,6 @@
 package com.sparrowwallet.sparrow.joinstr.control;
 
+import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.Theme;
 import com.sparrowwallet.sparrow.io.Config;
 import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
@@ -23,7 +24,7 @@ public class JoinstrInfoPane extends VBox {
 
     public JoinstrInfoPane() {
         if(Config.get().getTheme() == Theme.DARK) {
-            getStylesheets().add(getClass().getResource("../../darktheme.css").toExternalForm());
+            getStylesheets().add(AppServices.class.getResource("darktheme.css").toExternalForm());
         }
         getStyleClass().add("joinstr-infopane");
         setSpacing(10);

--- a/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
@@ -28,7 +28,7 @@
             </ImageView>
             <Label styleClass="title" text="Create a new pool"/>
             <Form style="-fx-max-width: 400px;">
-                <Fieldset inputGrow="ALWAYS">
+                <Fieldset inputGrow="ALWAYS" styleClass="wideLabelFieldSet">
                     <Field text="Denomination:" style="-fx-text-fill: #aaaaaa;">
                         <TextField fx:id="denominationField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
                             <tooltip>
@@ -53,7 +53,9 @@
                             </tooltip>
                         </TextField>
                     </Field>
-                    <Field text="Keyset (optional):" style="-fx-text-fill: #aaaaaa;">
+                </Fieldset>
+                <Fieldset inputGrow="ALWAYS" styleClass="wideLabelFieldSet" text="Sybil resistance (optional)">
+                    <Field text="aut-ct Keyset:" style="-fx-text-fill: #aaaaaa;">
                         <TextField fx:id="autctKeysetField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
                             <tooltip>
                                 <Tooltip text="aut-ct keyset, e.g. autct-830000-100000-1-2-1024.aks. Leave blank for no sybil resistance"/>
@@ -67,6 +69,8 @@
                             </tooltip>
                         </PasswordField>
                     </Field>
+                </Fieldset>
+                <Fieldset inputGrow="ALWAYS" styleClass="wideLabelFieldSet">
                     <Field>
                         <VBox alignment="CENTER">
                             <ToggleButton fx:id="createButton" text="Create" onAction="#handleCreateButton"


### PR DESCRIPTION
Fixes the problems found testing the coinjoin window in the IDE. Stacked on #100, so the diff here is only these commits until that merges.

## okhttp cannot reach java.util.logging

`build.gradle` declares okhttp's module descriptor by hand and it omitted `java.logging`:

```
module('com.squareup.okhttp3:okhttp', 'okhttp3') {
    exports('okhttp3')
    requires('okio')
    requires('kotlin.stdlib')
}
```

`okhttp3.internal.concurrent.TaskRunner` logs through `java.util.logging`, so it fails to initialise:

```
IllegalAccessError: class okhttp3.internal.concurrent.TaskRunner (in module okhttp3)
  cannot access class java.util.logging.Logger (in module java.logging)
  because module okhttp3 does not read module java.logging
```

After that the class stays failed and every later attempt is `NoClassDefFoundError: Could not initialize class TaskRunner`, which is the error that keeps reappearing.

This is not IDE only. okhttp is a separate module in the packaged image too, and its descriptor there has the same three requires, so nostr traffic is broken in the release binaries as well. The packaged build was never caught on it before because the config crash in #100 stopped the app before any relay call.

The declaration predates the joinstr work. Upstream used okhttp for Whirlpool and never hit this path; nostr-java uses it for websockets, which does.

## Theme stylesheet loaded through a relative path

`JoinstrController` and `JoinstrInfoPane` used `getClass().getResource("../darktheme.css")`. `Class.getResource` does not normalise `..`, so in a named module it returns null and `toExternalForm` throws. The rest of Sparrow already uses `AppServices.class.getResource("darktheme.css")` and these two now do the same.

That null was thrown in `initializeView` before `setJoinstrDisplay(NEW_POOL)` ran, which is why the window opened blank, stayed on the light theme, and threw on My Pools.

## Other fixes

- Opening coinjoin with no wallet open threw from `JoinstrForm.getWallet`. The menu now says to open a wallet first.
- A failure while building the stage left a half built controller behind, so the next click opened a broken window. The controller is reset and the error is shown.
- Tor start now shows a small progress window instead of leaving the window looking stuck.
- Pool form labels were cut off. The fieldset now uses Sparrow's existing `wideLabelFieldSet` (170px labels, default is 110px).
- The aut-ct keyset and proving key moved into their own "Sybil resistance (optional)" section. Both were already optional in `NewPoolController`; only the presentation changed.

## Tests

Full suite: 329 tests, no failures. The okhttp descriptor was checked directly: the regenerated module jar now reads `java.base, java.logging, kotlin.stdlib, okio`.
