### PR TITLE
fix: coinjoin window regressions found in testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -406,6 +406,8 @@ extraJavaModuleInfo {
         exports('okhttp3')
         requires('okio')
         requires('kotlin.stdlib')
+        // okhttp3.internal.concurrent.TaskRunner logs through java.util.logging
+        requires('java.logging')
     }
 
 

--- a/src/main/java/com/sparrowwallet/sparrow/AppController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/AppController.java
@@ -550,8 +550,16 @@ public class AppController implements Initializable {
     }
 
     public void showJoinstr(ActionEvent event) {
+        if(getSelectedWalletForm() == null) {
+            AppServices.showErrorDialog("No Wallet Open",
+                    "Open a wallet before starting a coinjoin.");
+            return;
+        }
+
         Stage joinstrStage = getJoinstrStage();
-        joinstrStage.show();
+        if(joinstrStage != null) {
+            joinstrStage.show();
+        }
     }
 
     private Stage getJoinstrStage() {
@@ -593,8 +601,11 @@ public class AppController implements Initializable {
             }
 
             return stage;
-        } catch(IOException e) {
+        } catch(Exception e) {
+            // Leaving a half built controller behind makes the next click open a broken window
+            joinstrController = null;
             log.error("Error loading Joinstr stage", e);
+            AppServices.showErrorDialog("Error Opening Coinjoin", e.getMessage() == null ? e.toString() : e.getMessage());
         }
 
         return null;

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/JoinstrController.java
@@ -16,13 +16,19 @@ import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Insets;
 import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
 import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 public class JoinstrController extends JoinstrFormController implements IThreadExecutor {
 
@@ -88,7 +94,7 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
         joinstrMenuBox.visibleProperty().bind(getJoinstrForm().lockedProperty().not());
 
         // Set theme CSS
-        String darkCss = getClass().getResource("../darktheme.css").toExternalForm();
+        String darkCss = AppServices.class.getResource("darktheme.css").toExternalForm();
         if(Config.get().getTheme() == Theme.DARK) {
             if(!stage.getScene().getStylesheets().contains(darkCss)) {
                 stage.getScene().getStylesheets().add(darkCss);
@@ -195,6 +201,13 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
      * property is set and the rest of Sparrow's traffic is unaffected.
      */
     private void awaitTor() {
+        if(AppServices.isTorRunning()) {
+            log.info("[Joinstr] Tor is already running, joinstr requests will use it");
+            return;
+        }
+
+        Stage progress = showTorProgress();
+
         Thread t = new Thread(() -> {
             try {
                 int waited = 0;
@@ -204,18 +217,52 @@ public class JoinstrController extends JoinstrFormController implements IThreadE
                 }
                 if (AppServices.isTorRunning()) {
                     log.info("[Joinstr] Tor is running, joinstr requests will use it");
+                    javafx.application.Platform.runLater(progress::close);
                 } else {
                     log.warn("[Joinstr] Tor not ready after 90s, joinstr requests will be refused");
-                    javafx.application.Platform.runLater(() -> AppServices.showErrorDialog(
-                            "Tor Not Running", JoinstrTransport.NOT_READY));
+                    javafx.application.Platform.runLater(() -> {
+                        progress.close();
+                        AppServices.showErrorDialog("Tor Not Running", JoinstrTransport.NOT_READY);
+                    });
                 }
             } catch (InterruptedException e) {
+                javafx.application.Platform.runLater(progress::close);
                 Thread.currentThread().interrupt();
             }
         });
         t.setDaemon(true);
         t.setName("TorReadinessWatcher");
         t.start();
+    }
+
+    /**
+     * Tor can take a while on first start, and joinstr cannot send anything until it is up.
+     * Show that rather than leaving the window looking stuck.
+     */
+    private Stage showTorProgress() {
+        Label message = new Label("Starting Tor, this can take a minute on first run.");
+        ProgressBar progressBar = new ProgressBar();
+        progressBar.setProgress(ProgressBar.INDETERMINATE_PROGRESS);
+        progressBar.setMaxWidth(Double.MAX_VALUE);
+
+        VBox content = new VBox(12, message, progressBar);
+        content.setPadding(new Insets(20));
+        content.setPrefWidth(360);
+
+        Scene scene = new Scene(content);
+        if(Config.get().getTheme() == Theme.DARK) {
+            scene.getStylesheets().add(AppServices.class.getResource("darktheme.css").toExternalForm());
+        }
+
+        Stage progress = new Stage(StageStyle.UTILITY);
+        progress.setTitle("Coinjoin");
+        progress.initOwner(stage);
+        progress.initModality(Modality.NONE);
+        progress.setResizable(false);
+        progress.setScene(scene);
+        progress.show();
+
+        return progress;
     }
 
     @Override

--- a/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
+++ b/src/main/java/com/sparrowwallet/sparrow/joinstr/control/JoinstrInfoPane.java
@@ -1,5 +1,6 @@
 package com.sparrowwallet.sparrow.joinstr.control;
 
+import com.sparrowwallet.sparrow.AppServices;
 import com.sparrowwallet.sparrow.Theme;
 import com.sparrowwallet.sparrow.io.Config;
 import com.sparrowwallet.sparrow.joinstr.JoinstrPool;
@@ -23,7 +24,7 @@ public class JoinstrInfoPane extends VBox {
 
     public JoinstrInfoPane() {
         if(Config.get().getTheme() == Theme.DARK) {
-            getStylesheets().add(getClass().getResource("../../darktheme.css").toExternalForm());
+            getStylesheets().add(AppServices.class.getResource("darktheme.css").toExternalForm());
         }
         getStyleClass().add("joinstr-infopane");
         setSpacing(10);

--- a/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
+++ b/src/main/resources/com/sparrowwallet/sparrow/joinstr/new_pool.fxml
@@ -28,7 +28,7 @@
             </ImageView>
             <Label styleClass="title" text="Create a new pool"/>
             <Form style="-fx-max-width: 400px;">
-                <Fieldset inputGrow="ALWAYS">
+                <Fieldset inputGrow="ALWAYS" styleClass="wideLabelFieldSet">
                     <Field text="Denomination:" style="-fx-text-fill: #aaaaaa;">
                         <TextField fx:id="denominationField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
                             <tooltip>
@@ -53,7 +53,9 @@
                             </tooltip>
                         </TextField>
                     </Field>
-                    <Field text="Keyset (optional):" style="-fx-text-fill: #aaaaaa;">
+                </Fieldset>
+                <Fieldset inputGrow="ALWAYS" styleClass="wideLabelFieldSet" text="Sybil resistance (optional)">
+                    <Field text="aut-ct Keyset:" style="-fx-text-fill: #aaaaaa;">
                         <TextField fx:id="autctKeysetField" styleClass="textfield-dark" style="-fx-max-width: 200px;">
                             <tooltip>
                                 <Tooltip text="aut-ct keyset, e.g. autct-830000-100000-1-2-1024.aks. Leave blank for no sybil resistance"/>
@@ -67,6 +69,8 @@
                             </tooltip>
                         </PasswordField>
                     </Field>
+                </Fieldset>
+                <Fieldset inputGrow="ALWAYS" styleClass="wideLabelFieldSet">
                     <Field>
                         <VBox alignment="CENTER">
                             <ToggleButton fx:id="createButton" text="Create" onAction="#handleCreateButton"


### PR DESCRIPTION
Brings the #101 commits into master. They merged into `fix-config-serialisation` just after #100 had already taken that branch, so they are not in master.

Without this, master still has okhttp declared without `requires('java.logging')`, which breaks every nostr call in the release binaries.

No new work, same commits already reviewed in #101.